### PR TITLE
v1.0.7: Navigation safety controls + MessageEventType consolidation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/client-manager.ts
+++ b/src/client-manager.ts
@@ -8,6 +8,7 @@ export class ClientManager {
     const request: ClientCreationRequest = {
       serverId: registration.id,
       serverName: config.name,
+      serverTitle: config.title,
       serverVersion: config.version,
       description: config.description,
       transport: config.transport || AngieLocalServerTransport.POST_MESSAGE,

--- a/src/iframe.test.ts
+++ b/src/iframe.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+import { disableNavigationPrevention } from './iframe';
+import { appState } from './config';
+import { MessageEventType } from './types';
+
+jest.mock( './logger', () => ( {
+	createChildLogger: jest.fn( () => ( {
+		log: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	} ) ),
+} ) );
+
+describe( 'disableNavigationPrevention', () => {
+	let mockContentWindow: { postMessage: jest.Mock };
+	let mockIframe: HTMLIFrameElement;
+	let mockOrigin: URL;
+	let originalSetTimeout: typeof setTimeout;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		
+		originalSetTimeout = global.setTimeout;
+		
+		global.setTimeout = jest.fn( ( callback: () => void ) => {
+			callback();
+			return 0 as unknown as NodeJS.Timeout;
+		} ) as unknown as typeof setTimeout;
+
+		mockContentWindow = {
+			postMessage: jest.fn(),
+		};
+
+		mockIframe = {
+			contentWindow: mockContentWindow as unknown as Window,
+		} as HTMLIFrameElement;
+
+		mockOrigin = new URL( 'https://angie.elementor.com' );
+
+		appState.iframe = mockIframe;
+		appState.iframeUrlObject = mockOrigin;
+	} );
+
+	afterEach( () => {
+		global.setTimeout = originalSetTimeout;
+		
+		appState.iframe = null;
+		appState.iframeUrlObject = null;
+	} );
+
+	it( 'should successfully post message when iframe and origin are available', async () => {
+		// Act
+		await disableNavigationPrevention();
+
+		// Assert
+		expect( mockContentWindow.postMessage ).toHaveBeenCalledWith(
+			{ type: MessageEventType.ANGIE_DISABLE_NAVIGATION_PREVENTION },
+			mockOrigin.origin
+		);
+		expect( mockContentWindow.postMessage ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not post message when iframe is null', async () => {
+		// Arrange
+		appState.iframe = null;
+
+		// Act
+		await disableNavigationPrevention();
+
+		// Assert
+		expect( mockContentWindow.postMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should throw error when postMessage fails', async () => {
+		// Arrange
+		const mockError = new Error( 'postMessage failed' );
+		mockContentWindow.postMessage.mockImplementation( () => {
+			throw mockError;
+		} );
+
+		// Act & Assert
+		await expect( disableNavigationPrevention() ).rejects.toThrow( 'postMessage failed' );
+	} );
+} );

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,5 +17,6 @@ export {
 export { waitForDocumentReady, toggleAngieSidebar } from './utils';
 export { navigateAngieIframe } from './navigation-utils';
 export { getAngieIframe } from './angie-iframe-utils';
+export { disableNavigationPrevention } from './iframe';
 export * from './types';
 export { BrowserContextTransport } from './browser-context-transport';

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,7 +1,7 @@
 import { createChildLogger } from './logger';
 import { sendSuccessMessage } from './utils';
 import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
-import { MessageEventType } from './iframe';
+import { MessageEventType } from './types';
 import { AppState } from './config';
 
 const sdkLogger = createChildLogger( 'sdk' );

--- a/src/sidebar.css
+++ b/src/sidebar.css
@@ -37,15 +37,15 @@ body.angie-sidebar-transitioning #angie-sidebar-container {
 
     body.angie-sidebar-active #angie-body-top-padding {
         width: 100%;
-        height: 8px;
+        height: 0;
     }
 
     /* Push WordPress Admin Bar - LTR */
     body.angie-sidebar-active #wpadminbar {
         inset-inline-start: var(--angie-sidebar-width) !important;
-        inset-inline-end: 8px !important;
-        width: calc(100% - 8px - var(--angie-sidebar-width)) !important;
-        margin-top: 8px;
+        inset-inline-end: 0 !important;
+        width: calc(100% - var(--angie-sidebar-width)) !important;
+        margin-top: 0;
     }
 
     /* Sidebar container - LTR */

--- a/src/sidebar.css
+++ b/src/sidebar.css
@@ -29,26 +29,12 @@ body.angie-sidebar-transitioning #angie-sidebar-container {
     transition: var(--angie-sidebar-transition) !important;
 }
 
-/* LTR Layout (default) - Push content to the right */
+/* Layout (default) - Push content */
 @media (min-width: 768px) {
     body.angie-sidebar-active {
         padding-inline-start: var(--angie-sidebar-width) !important;
     }
 
-    body.angie-sidebar-active #angie-body-top-padding {
-        width: 100%;
-        height: 0;
-    }
-
-    /* Push WordPress Admin Bar - LTR */
-    body.angie-sidebar-active #wpadminbar {
-        inset-inline-start: var(--angie-sidebar-width) !important;
-        inset-inline-end: 0 !important;
-        width: calc(100% - var(--angie-sidebar-width)) !important;
-        margin-top: 0;
-    }
-
-    /* Sidebar container - LTR */
     #angie-sidebar-container {
         position: fixed;
         top: 0;

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,6 +1,6 @@
-import { createChildLogger } from "./logger";
 import { postMessageToAngieIframe } from "./angie-iframe-utils";
-import { MessageEventType } from "./iframe";
+import { createChildLogger } from "./logger";
+import { MessageEventType } from "./types";
 import { waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export enum AngieServerType {
 
 export type AngieBaseServerConfig = {
   name: string;
+  title?: string;
   version: string;
   description: string;
   capabilities?: ServerCapabilities;
@@ -67,6 +68,7 @@ export interface AngieMessage<T = unknown> {
 export interface ClientCreationRequest {
   serverId: string;
   serverName: string;
+  serverTitle?: string;
   description: string;
   serverVersion: string;
   transport?: AngieLocalServerTransport | AngieRemoteServerTransport;
@@ -105,10 +107,20 @@ export interface AngieTriggerResponse {
 export enum MessageEventType {
   SDK_ANGIE_READY_PING = 'sdk-angie-ready-ping',
   SDK_ANGIE_REFRESH_PING = 'sdk-angie-refresh-ping',
+  SDK_ANGIE_ALL_SERVERS_REGISTERED = 'sdk-angie-all-servers-registered',
   SDK_REQUEST_CLIENT_CREATION = 'sdk-request-client-creation',
   SDK_REQUEST_INIT_SERVER = 'sdk-request-init-server',
   SDK_TRIGGER_ANGIE = 'sdk-trigger-angie',
   SDK_TRIGGER_ANGIE_RESPONSE = 'sdk-trigger-angie-response',
+
+  ANGIE_SIDEBAR_RESIZED = 'angie-sidebar-resized',
+  ANGIE_SIDEBAR_TOGGLED = 'angie-sidebar-toggled',
+  ANGIE_CHAT_TOGGLE = 'angie-chat-toggle',
+  ANGIE_STUDIO_TOGGLE = 'angie-studio-toggle',
+  ANGIE_NAVIGATE_TO_URL = 'angie/navigate-to-url',
+  ANGIE_PAGE_RELOAD = 'angie/page-reload',
+  ANGIE_DISABLE_NAVIGATION_PREVENTION = 'angie/disable-navigation-prevention',
+  ANGIE_NAVIGATE_AFTER_RESPONSE = 'angie/navigate-after-response',
 }
 
 


### PR DESCRIPTION
## Summary
- Add `disableNavigationPrevention` for safe page navigation/reload — sends `ANGIE_DISABLE_NAVIGATION_PREVENTION` to iframe before navigating
- Require `confirmed: true` in payload for `ANGIE_NAVIGATE_TO_URL` and `ANGIE_PAGE_RELOAD` events
- Consolidate `MessageEventType` enum into `types.ts` (remove duplicate from `iframe.ts`)
- Add new `MessageEventType` values: `ANGIE_DISABLE_NAVIGATION_PREVENTION`, `ANGIE_NAVIGATE_AFTER_RESPONSE`, `SDK_ANGIE_ALL_SERVERS_REGISTERED`, sidebar/chat/studio toggles
- Add `title` field to `AngieBaseServerConfig` and `ClientCreationRequest`
- Fix sidebar CSS padding/margin values (remove 8px gaps)
- Export `disableNavigationPrevention` from index

## Version
`1.0.6` → `1.0.7` (patch — no breaking changes, additive enum values + internal navigation safety)

## Test plan
- [x] All 82 tests pass (3 new for `disableNavigationPrevention`)
- [ ] Verify navigation/reload still works in Angie with confirmed payloads
- [ ] Verify sidebar layout after CSS changes


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add user-confirmed navigation safety controls and consolidate MessageEventType enum across SDK modules to improve security and maintainability.

Main changes:
- Implemented disableNavigationPrevention() function with confirmation flow for ANGIE_NAVIGATE_TO_URL and ANGIE_PAGE_RELOAD events
- Consolidated MessageEventType enum from iframe.ts into types.ts central location, adding navigation control events
- Added serverTitle optional field to ClientCreationRequest and AngieBaseServerConfig interfaces for enhanced server metadata

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
