### PR TITLE
v1.0.8: Referrer redirect utilities + model preferences docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,9 @@ The SDK covers three main abilities:
 **Not Available:**
 - Roots, STDIO transport (browser environment limitations)
 
-📖 **For detailed feature documentation and best practices, see [MCP SDK Supported Features](./docs/angie-sdk-supported-features.md)**
+📖 **Documentation:**
+- [MCP SDK Supported Features](./docs/angie-sdk-supported-features.md)
+- [Tool Model Preferences](./docs/model-preferences.md) - Configure preferred AI models for your tools
 
 ---
 

--- a/docs/model-preferences.md
+++ b/docs/model-preferences.md
@@ -1,0 +1,66 @@
+# Tool Model Preferences
+
+Angie allows MCP tools to specify their preferred AI models using the `angie/modelPreferences` annotation. This ensures tools can request specific models optimized for their functionality (e.g., code generation tools preferring Claude Sonnet).
+
+## How It Works
+
+When a tool is selected, Angie uses its preferred model for both planning and execution, overriding user preferences when specified.
+
+## Annotation Schema
+
+```typescript
+export const ANGIE_MODEL_PREFERENCES = 'angie/modelPreferences' as const;
+
+export interface AngieModelPreferences {
+  hints?: Array<{ name: string }>;
+  costPriority?: number;           // 0-1 (future use)
+  speedPriority?: number;          // 0-1 (future use)
+  intelligencePriority?: number;   // 0-1 (future use)
+}
+```
+
+## Usage Example
+
+```typescript
+
+server.tool(
+  'generate-custom-css',
+  'Generates CSS code based on design requirements',
+  { /* input schema */ },
+  {
+    [ANGIE_MODEL_PREFERENCES]: {
+      hints: [
+        { name: 'claude-sonnet' },  // First choice
+        { name: 'gpt-4.1' }         // Fallback
+      ],
+      intelligencePriority: 0.9     // Optional: for future use
+    }
+  },
+  async (args) => {
+    // Tool handler implementation
+  }
+);
+```
+
+## Model Selection Priority
+
+Angie resolves the model to use in this order:
+
+1. **User preference (Internal users only)** - `executionModel` if provided and different from the system default
+2. **Tool annotation** - `angie/modelPreferences.hints[0]` if user preference is default or not provided
+3. **System defaults** - Falls back to default model if neither is available
+
+## Best Practices
+
+- **Use for specialized tasks**: Apply model preferences when your tool requires specific model capabilities (e.g., code generation, creative writing)
+- **Provide fallbacks**: List multiple model hints in order of preference
+- **Test with different models**: Verify your tool works with fallback models
+- **Document requirements**: Explain in your tool description why specific models are preferred
+
+## Notes
+
+- Based on [MCP Sampling specification](https://modelcontextprotocol.io/specification/2025-06-18/client/sampling)
+- First hint is the most preferred, subsequent hints are fallbacks
+- Fully typed with TypeScript - no `any` types used
+- Backward compatible with existing model selection behavior
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,3 +20,4 @@ export { getAngieIframe } from './angie-iframe-utils';
 export { disableNavigationPrevention } from './iframe';
 export * from './types';
 export { BrowserContextTransport } from './browser-context-transport';
+export { setReferrerRedirect, getReferrerRedirect, clearReferrerRedirect } from './referrer-redirect';

--- a/src/referrer-redirect.test.ts
+++ b/src/referrer-redirect.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+import {
+	setReferrerRedirect,
+	getReferrerRedirect,
+	clearReferrerRedirect,
+} from './referrer-redirect';
+
+describe( 'referrer-redirect', () => {
+	let mockLocalStorage: { [ key: string ]: string };
+	const originalLocation = window.location;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		mockLocalStorage = {};
+		Object.defineProperty( global, 'localStorage', {
+			value: {
+				getItem: jest.fn( ( key: string ) => mockLocalStorage[ key ] || null ),
+				setItem: jest.fn( ( key: string, value: string ) => {
+					mockLocalStorage[ key ] = value;
+				} ),
+				removeItem: jest.fn( ( key: string ) => {
+					delete mockLocalStorage[ key ];
+				} ),
+			},
+			writable: true,
+		} );
+
+		delete ( window as any ).location;
+		( window as any ).location = { origin: 'http://localhost' };
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+		( window as any ).location = originalLocation;
+	} );
+
+	describe( 'setReferrerRedirect', () => {
+		it( 'should store valid same-origin URL', () => {
+			// Arrange
+			const validUrl = 'http://localhost/some-page?id=123';
+
+			// Act
+			const result = setReferrerRedirect( validUrl );
+
+			// Assert
+			expect( result ).toBe( true );
+			expect( localStorage.setItem ).toHaveBeenCalledWith( 'angie_return_url', validUrl );
+		} );
+
+		it( 'should reject external domain URL', () => {
+			// Arrange
+			const externalUrl = 'https://evil.com/phishing';
+
+			// Act
+			const result = setReferrerRedirect( externalUrl );
+
+			// Assert
+			expect( result ).toBe( false );
+			expect( localStorage.setItem ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should accept relative paths as same-origin', () => {
+			// Arrange
+			const relativePath = 'not-a-valid-url';
+
+			// Act
+			const result = setReferrerRedirect( relativePath );
+
+			// Assert — relative paths resolve to same origin
+			expect( result ).toBe( true );
+		} );
+
+		it( 'should accept various same-origin paths', () => {
+			// Arrange
+			const validUrls = [
+				'http://localhost/admin/post.php?post=123',
+				'http://localhost/dashboard',
+				'http://localhost/settings?page=general',
+				'http://localhost/',
+			];
+
+			// Act & Assert
+			for ( const url of validUrls ) {
+				mockLocalStorage = {};
+				const result = setReferrerRedirect( url );
+				expect( result ).toBe( true );
+			}
+		} );
+	} );
+
+	describe( 'getReferrerRedirect', () => {
+		it( 'should return stored valid same-origin URL', () => {
+			// Arrange
+			const validUrl = 'http://localhost/dashboard?post=123';
+			mockLocalStorage[ 'angie_return_url' ] = validUrl;
+
+			// Act
+			const result = getReferrerRedirect();
+
+			// Assert
+			expect( result ).toBe( validUrl );
+		} );
+
+		it( 'should return null when no URL is stored', () => {
+			// Act
+			const result = getReferrerRedirect();
+
+			// Assert
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should return null for invalid stored URL (external domain)', () => {
+			// Arrange
+			mockLocalStorage[ 'angie_return_url' ] = 'https://evil.com/page';
+
+			// Act
+			const result = getReferrerRedirect();
+
+			// Assert
+			expect( result ).toBeNull();
+		} );
+	} );
+
+	describe( 'clearReferrerRedirect', () => {
+		it( 'should remove stored URL', () => {
+			// Arrange
+			mockLocalStorage[ 'angie_return_url' ] = 'http://localhost/dashboard';
+
+			// Act
+			clearReferrerRedirect();
+
+			// Assert
+			expect( localStorage.removeItem ).toHaveBeenCalledWith( 'angie_return_url' );
+		} );
+
+		it( 'should not throw when no URL is stored', () => {
+			// Act & Assert
+			expect( () => clearReferrerRedirect() ).not.toThrow();
+		} );
+	} );
+} );

--- a/src/referrer-redirect.ts
+++ b/src/referrer-redirect.ts
@@ -1,0 +1,53 @@
+import { createChildLogger } from './logger';
+
+const REFERRER_REDIRECT_KEY = 'angie_return_url';
+
+const referrerLogger = createChildLogger( 'referrer-redirect' );
+
+function isValidRedirectUrl( url: string ): boolean {
+	try {
+		const parsed = new URL( url, window.location.origin );
+		return parsed.origin === window.location.origin;
+	} catch {
+		return false;
+	}
+}
+
+export function setReferrerRedirect( url: string ): boolean {
+	if ( ! isValidRedirectUrl( url ) ) {
+		referrerLogger.warn( 'Invalid redirect URL rejected:', url );
+		return false;
+	}
+
+	try {
+		localStorage.setItem( REFERRER_REDIRECT_KEY, url );
+		return true;
+	} catch ( e ) {
+		referrerLogger.warn( 'localStorage not available' );
+		return false;
+	}
+}
+
+export function getReferrerRedirect(): string | null {
+	try {
+		const url = localStorage.getItem( REFERRER_REDIRECT_KEY );
+		if ( url && isValidRedirectUrl( url ) ) {
+			return url;
+		}
+		if ( url ) {
+			referrerLogger.warn( 'Stored redirect URL is invalid, returning null:', url );
+		}
+		return null;
+	} catch ( e ) {
+		referrerLogger.warn( 'localStorage not available' );
+		return null;
+	}
+}
+
+export function clearReferrerRedirect(): void {
+	try {
+		localStorage.removeItem( REFERRER_REDIRECT_KEY );
+	} catch ( e ) {
+		referrerLogger.warn( 'localStorage not available' );
+	}
+}


### PR DESCRIPTION
## Summary
- Added `setReferrerRedirect`, `getReferrerRedirect`, `clearReferrerRedirect` — utilities for storing/retrieving a return URL in localStorage with **same-origin validation** to prevent open redirect attacks
- Added `docs/model-preferences.md` — documentation for the `angie/modelPreferences` tool annotation (internal paths stripped for public repo)
- Updated README with documentation links
- Version bump to 1.0.8

## Security
The referrer redirect validation enforces **same-origin only** — redirects to external domains are rejected. This is the SDK's security boundary; host applications can add additional path restrictions on their side.

## Changes vs private repo
- `referrer-redirect.ts`: Removed `wp-admin/` path prefix check (WP-specific). Same-origin check is sufficient for security
- `model-preferences.md`: Removed internal file paths (`elementor-ai-api/...`, `elementor-ai-common/...`)

## Test Plan
- [x] 91 tests pass
- [x] Build succeeds
- [ ] Verify same-origin URLs are accepted
- [ ] Verify cross-origin URLs are rejected

Made with [Cursor](https://cursor.com)