### PR TITLE
v1.0.10: Migrate OAuth to OIDC auth flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/iframe.test.ts
+++ b/src/iframe.test.ts
@@ -11,6 +11,12 @@ jest.mock( './logger', () => ( {
 	} ) ),
 } ) );
 
+jest.mock( './oidc-auth-inline', () => ( {
+	isOidcFlowInUrl: jest.fn( () => false ),
+	setupOidcAuthParentListener: jest.fn(),
+	forwardOidcLoginFlowToWindow: jest.fn(),
+} ) );
+
 describe( 'disableNavigationPrevention', () => {
 	let mockContentWindow: { postMessage: jest.Mock };
 	let mockIframe: HTMLIFrameElement;

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,7 +1,7 @@
 import { addLocalStorageListener } from './localStorage';
 import { appState } from './config';
 import { createChildLogger } from './logger';
-import { listenToOAuthFromIframe } from './oauth';
+import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
 import { listenToSDK } from './sdk';
 import { loadWidth } from './sidebar';
 import { HostEventType, MessageEventType } from './types';
@@ -157,6 +157,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 	listenToSDK( appState );
 
 	listenToOAuthFromIframe();
+	setupOidcLoginFlowHandler();
 
 	window.addEventListener( 'message', async ( event ) => {
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,8 +1,10 @@
-import { appState } from "./config";
-import { createChildLogger } from "./logger";
-import { sendErrorMessage, sendSuccessMessage } from "./utils";
-
-const oauthLogger = createChildLogger( 'oauth' );
+import {
+	forwardOidcLoginFlowToWindow,
+	setupOidcAuthParentListener,
+	type OidcAuthAppWindow,
+} from './oidc-auth-inline';
+import { appState } from './config';
+import { createChildLogger } from './logger';
 
 declare global {
 	interface Window {
@@ -10,138 +12,33 @@ declare global {
 	}
 }
 
-// OAuth message types for iframe communication
-export const OAUTH_MESSAGE_TYPES = {
-	OAUTH_GET_CODE_AND_STATE: 'OAUTH_GET_CODE_AND_STATE',
-	OAUTH_GET_TOP_URL: 'OAUTH_GET_TOP_URL',
-	OAUTH_REDIRECT_TOP_WINDOW: 'OAUTH_REDIRECT_TOP_WINDOW',
-	OAUTH_UPDATE_URL: 'OAUTH_UPDATE_URL',
-	ANGIE_REDIRECT_TO_WP_ADMIN_WITH_OAUTH: 'ANGIE_REDIRECT_TO_WP_ADMIN_WITH_OAUTH',
-	ANGIE_REDIRECT_TO_AUTH_ORIGIN_LOGOUT: 'ANGIE_REDIRECT_TO_AUTH_ORIGIN_LOGOUT',
-} as const;
-
-function checkOAuthParameterCleanup( oldUrl: string, newUrl: string ): boolean {
-	const newUrlObject = new URL( newUrl );
-	const oldUrlObject = new URL( oldUrl );
-	const newUrlParams = newUrlObject.searchParams;
-	const oldUrlParams = oldUrlObject.searchParams;
-	const oauthParams = [ 'oauth_code', 'oauth_state', 'start-oauth' ];
-	return oauthParams.some( param => oldUrlParams?.has( param ) ) &&
-		! oauthParams.some( param => newUrlParams?.has( param ) );
-}
+const logger = createChildLogger( 'oauth' );
 
 function openSidebarAfterAuthentication(): void {
-	oauthLogger.log( 'OAuth parameters cleaned, opening sidebar' );
 	try {
 		localStorage.setItem( 'angie_sidebar_state', 'open' );
 	} catch ( e ) {
-		oauthLogger.warn( 'localStorage not available' );
+		logger.warn( 'localStorage not available' );
 	}
 	setTimeout( () => {
 		window.toggleAngieSidebar( true );
 	}, 500 );
 }
 
-function handleUrlUpdate( newUrl: string, port: MessagePort ): void {
-	if ( ! history?.replaceState ) {
-		oauthLogger.warn( 'history.replaceState not supported in this browser' );
-		sendErrorMessage( port, { message: 'URL update not supported in this browser' } );
-		return;
-	}
-
-	try {
-		const oldUrl = window.location.href;
-		history.replaceState( {}, '', newUrl );
-
-		if ( checkOAuthParameterCleanup( oldUrl, newUrl ) ) {
-			openSidebarAfterAuthentication();
-		}
-
-		sendSuccessMessage( port, {
-			message: 'URL updated successfully',
-		} );
-	} catch ( error ) {
-		oauthLogger.warn( 'Failed to update URL via history.replaceState:', error );
-		sendErrorMessage( port, { message: 'URL update failed: ' + ( error instanceof Error ? error.message : 'Unknown error' ) } );
-	}
-}
-
-function redirectToWpAdminWithOAuth(): void {
-	const currentUrl = new URL( window.location.href );
-	currentUrl.searchParams.set( 'start-oauth', '1' );
-	oauthLogger.log( 'Redirecting to wp-admin with OAuth:', currentUrl.toString() );
-	window.location.href = currentUrl.toString();
-}
-
-export const getOAuthCodeAndState = ( port: MessagePort ): void => {
-	const urlParams = new URLSearchParams( window.location.search );
-	const oauthCode = urlParams.get( 'oauth_code' );
-	const oauthState = urlParams.get( 'oauth_state' );
-
-	if ( oauthCode && oauthState ) {
-		sendSuccessMessage( port, {
-			code: oauthCode,
-			state: oauthState,
-		} );
-	} else {
-		const oauthError = urlParams.get( 'oauth_error' );
-		if ( oauthError ) {
-			sendErrorMessage( port, {
-				message: oauthError,
-				code: oauthCode || null,
-				state: oauthState || null,
-			} );
-			const cleanUrl = new URL( window.location.href );
-			cleanUrl.searchParams.delete( 'oauth_error' );
-			history.replaceState( {}, '', cleanUrl.toString() );
-		} else {
-			sendSuccessMessage( port, {
-				message: 'No OAuth error found',
-			} );
-		}
-	}
+export const listenToOAuthFromIframe = (): void => {
+	setupOidcAuthParentListener( {
+		trustedOrigin: appState.iframeUrlObject?.origin ?? '',
+		onOAuthParamsCleared: openSidebarAfterAuthentication,
+	} );
 };
 
-export const listenToOAuthFromIframe = (): void => {
-	window.addEventListener( 'message', ( event ) => {
-		if ( event.origin !== appState.iframeUrlObject?.origin ) {
-			return;
-		}
+export const setupOidcLoginFlowHandler = (): void => {
+	const targets: OidcAuthAppWindow = { window: appState.iframe, windowURL: appState.iframeUrlObject };
 
-		switch ( event.data.type ) {
-			case OAUTH_MESSAGE_TYPES.OAUTH_GET_CODE_AND_STATE:
-				getOAuthCodeAndState( event.ports[ 0 ] );
-				break;
-
-			case OAUTH_MESSAGE_TYPES.OAUTH_GET_TOP_URL:
-				oauthLogger.log( 'Iframe requested top window URL via MessageChannel' );
-				sendSuccessMessage( event.ports[ 0 ], {
-					topUrl: window.location.href,
-				} );
-				break;
-
-			case OAUTH_MESSAGE_TYPES.OAUTH_REDIRECT_TOP_WINDOW:
-				oauthLogger.log( 'Iframe requested top window redirect to:', event.data.payload.url );
-				window.location.href = event.data.payload.url;
-				break;
-
-			case OAUTH_MESSAGE_TYPES.OAUTH_UPDATE_URL:
-				oauthLogger.log( 'Iframe requested URL update to:', event.data.payload.url );
-				handleUrlUpdate( event.data.payload.url, event.ports[ 0 ] );
-				break;
-
-			case OAUTH_MESSAGE_TYPES.ANGIE_REDIRECT_TO_WP_ADMIN_WITH_OAUTH:
-				redirectToWpAdminWithOAuth();
-				break;
-
-			case OAUTH_MESSAGE_TYPES.ANGIE_REDIRECT_TO_AUTH_ORIGIN_LOGOUT:
-				try {
-					redirectToWpAdminWithOAuth();
-				} catch ( error ) {
-					oauthLogger.error( 'Auth origin logout fallback failed:', error );
-					window.location.reload();
-				}
-				break;
-		}
+	window.addEventListener( 'load', () => {
+		logger.log( 'OIDC: Window load event fired, forwarding OIDC state if present' );
+		forwardOidcLoginFlowToWindow( { targets, onSuccess: openSidebarAfterAuthentication } );
 	} );
+
+	forwardOidcLoginFlowToWindow( { targets, onSuccess: openSidebarAfterAuthentication } );
 };

--- a/src/oidc-auth-inline.ts
+++ b/src/oidc-auth-inline.ts
@@ -1,0 +1,183 @@
+import { createChildLogger } from './logger';
+
+const logger = createChildLogger( 'oidc-auth' );
+
+const OIDC_AUTH_URL_PARAMS = {
+	LOGIN_SUCCESS: 'oauth2_login_success',
+	STATE: 'oauth2_state',
+	TOP_ORIGIN: 'oauth2_top_origin',
+} as const;
+
+const OIDC_AUTH_MESSAGE_TYPES = {
+	LOGIN_FLOW_COMPLETE: 'OAUTH2_LOGIN_FLOW_COMPLETE_EVENT',
+	GET_TOP_URL: 'OAUTH_GET_TOP_URL',
+	REDIRECT_TOP_WINDOW: 'OAUTH_REDIRECT_TOP_WINDOW',
+	UPDATE_URL: 'OAUTH_UPDATE_URL',
+	CHECK_PENDING: 'OAUTH2_CHECK_PENDING',
+} as const;
+
+export type OidcAuthAppWindow = {
+	window: HTMLIFrameElement | null;
+	windowURL: URL | null;
+};
+
+export function isOidcFlowInUrl(): boolean {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+	const urlParams = new URLSearchParams( window.location.search );
+	return urlParams.has( OIDC_AUTH_URL_PARAMS.LOGIN_SUCCESS ) ||
+		urlParams.has( OIDC_AUTH_URL_PARAMS.STATE ) ||
+		urlParams.has( OIDC_AUTH_URL_PARAMS.TOP_ORIGIN );
+}
+
+function sendPortSuccess( port: MessagePort, payload?: unknown ): void {
+	port.postMessage( { status: 'success', payload } );
+}
+
+function sendPortError( port: MessagePort, error: unknown ): void {
+	port.postMessage( { status: 'error', payload: error } );
+}
+
+function checkOAuthParamsCleared( oldUrl: string, newUrl: string ): boolean {
+	const oldParams = new URL( oldUrl ).searchParams;
+	const newParams = new URL( newUrl ).searchParams;
+	const oidcParams = [ OIDC_AUTH_URL_PARAMS.LOGIN_SUCCESS, OIDC_AUTH_URL_PARAMS.STATE, OIDC_AUTH_URL_PARAMS.TOP_ORIGIN ];
+	return oidcParams.some( param => oldParams.has( param ) ) &&
+		! oidcParams.some( param => newParams.has( param ) );
+}
+
+type SetupOidcAuthParentListenerArgs = {
+	trustedOrigin: string;
+	onOAuthParamsCleared?: () => void;
+};
+
+export function setupOidcAuthParentListener( { trustedOrigin, onOAuthParamsCleared }: SetupOidcAuthParentListenerArgs ): void {
+	window.addEventListener( 'message', ( event ) => {
+		if ( event.origin !== trustedOrigin ) {
+			return;
+		}
+
+		const port = event.ports?.[ 0 ];
+
+		switch ( event.data.type ) {
+			case OIDC_AUTH_MESSAGE_TYPES.GET_TOP_URL:
+				if ( ! port ) {
+					return;
+				}
+				sendPortSuccess( port, { topUrl: window.location.href } );
+				break;
+
+			case OIDC_AUTH_MESSAGE_TYPES.REDIRECT_TOP_WINDOW:
+				window.location.href = event.data.payload.url;
+				break;
+
+			case OIDC_AUTH_MESSAGE_TYPES.UPDATE_URL: {
+				if ( ! port ) {
+					return;
+				}
+				const newUrl = event.data.payload.url;
+				if ( ! history?.replaceState ) {
+					sendPortError( port, { message: 'URL update not supported in this browser' } );
+					return;
+				}
+				try {
+					const oldUrl = window.location.href;
+					history.replaceState( {}, '', newUrl );
+
+					if ( checkOAuthParamsCleared( oldUrl, newUrl ) ) {
+						onOAuthParamsCleared?.();
+					}
+
+					sendPortSuccess( port, { message: 'URL updated successfully' } );
+				} catch ( error ) {
+					sendPortError( port, {
+						message: 'URL update failed: ' + ( error instanceof Error ? error.message : 'Unknown error' ),
+					} );
+				}
+				break;
+			}
+
+			case OIDC_AUTH_MESSAGE_TYPES.CHECK_PENDING: {
+				if ( ! port ) {
+					return;
+				}
+				const searchParams = new URLSearchParams( window.location.search );
+				const isPending = searchParams.get( OIDC_AUTH_URL_PARAMS.LOGIN_SUCCESS ) === 'true';
+				sendPortSuccess( port, { isPending } );
+				break;
+			}
+		}
+	} );
+}
+
+function sendOidcStateToWindow( payload: Record<string, unknown>, targets: OidcAuthAppWindow ): void {
+	const targetWindow = targets.window?.contentWindow;
+	const targetOrigin = targets.windowURL?.origin;
+
+	if ( ! targetWindow || ! targetOrigin ) {
+		logger.warn( 'Cannot send OIDC state: window or origin not available' );
+		return;
+	}
+
+	targetWindow.postMessage( {
+		type: OIDC_AUTH_MESSAGE_TYPES.LOGIN_FLOW_COMPLETE,
+		payload,
+	}, targetOrigin );
+}
+
+type ForwardOidcLoginFlowToWindowArgs = {
+	targets: OidcAuthAppWindow;
+	onSuccess?: () => void;
+	attempt?: number;
+};
+
+const MAX_FORWARD_ATTEMPTS = 5;
+const FORWARD_RETRY_DELAY_MS = 500;
+
+export function forwardOidcLoginFlowToWindow( { targets, onSuccess, attempt = 1 }: ForwardOidcLoginFlowToWindowArgs ): void {
+	const searchParams = new URLSearchParams( window.location.search );
+	const loginComplete = searchParams.get( OIDC_AUTH_URL_PARAMS.LOGIN_SUCCESS );
+
+	if ( ! loginComplete ) {
+		return;
+	}
+
+	const oauthStateParam = searchParams.get( OIDC_AUTH_URL_PARAMS.STATE );
+	if ( ! oauthStateParam ) {
+		logger.warn( 'OIDC login complete but no state found in URL' );
+		return;
+	}
+
+	if ( ! targets.window?.contentWindow || ! targets.windowURL ) {
+		if ( attempt < MAX_FORWARD_ATTEMPTS ) {
+			setTimeout( () => {
+				forwardOidcLoginFlowToWindow( { targets, onSuccess, attempt: attempt + 1 } );
+			}, FORWARD_RETRY_DELAY_MS );
+		} else {
+			logger.error( 'OIDC: Failed to forward login flow after', MAX_FORWARD_ATTEMPTS, 'attempts - iframe never became available' );
+		}
+		return;
+	}
+
+	try {
+		const oauthState = JSON.parse( oauthStateParam );
+		const topOrigin = oauthState.state?.data?.[ OIDC_AUTH_URL_PARAMS.TOP_ORIGIN ];
+
+		if ( topOrigin && topOrigin !== window.location.origin ) {
+			logger.error( 'Origin mismatch in OIDC state:', topOrigin, 'vs', window.location.origin );
+			return;
+		}
+
+		sendOidcStateToWindow( { oauthState }, targets );
+
+		const cleanUrl = new URL( window.location.href );
+		cleanUrl.searchParams.delete( OIDC_AUTH_URL_PARAMS.LOGIN_SUCCESS );
+		cleanUrl.searchParams.delete( OIDC_AUTH_URL_PARAMS.STATE );
+		history.replaceState( {}, '', cleanUrl.toString() );
+
+		onSuccess?.();
+	} catch ( error ) {
+		logger.error( 'Failed to parse or forward OIDC state:', error );
+	}
+}

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -25,6 +25,10 @@ jest.mock('./utils', () => ({
   waitForDocumentReady: jest.fn().mockImplementation(() => Promise.resolve()),
 }));
 
+jest.mock('./oidc-auth-inline', () => ({
+  isOidcFlowInUrl: jest.fn(() => false),
+}));
+
 describe('sidebar', () => {
   let mockLocalStorage: { [key: string]: string };
 

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,5 +1,6 @@
 import { postMessageToAngieIframe } from "./angie-iframe-utils";
 import { createChildLogger } from "./logger";
+import { isOidcFlowInUrl } from "./oidc-auth-inline";
 import { MessageEventType } from "./types";
 import { waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
@@ -100,14 +101,6 @@ export function applyWidth( width: number ): void {
 	document.documentElement.style.setProperty( '--angie-sidebar-width', `${ width }px` );
 }
 
-export function isInOAuthFlow(): boolean {
-	const urlParams = new URLSearchParams( window.location.search );
-	return urlParams.has( 'start-oauth' ) ||
-			urlParams.has( 'oauth_code' ) ||
-			urlParams.has( 'oauth_state' ) ||
-			urlParams.has( 'oauth_error' );
-}
-
 export function forceSidebarClosedDuringOAuth(): void {
 	applyState( ANGIE_SIDEBAR_STATE_CLOSED );
 	try {
@@ -118,7 +111,7 @@ export function forceSidebarClosedDuringOAuth(): void {
 }
 
 export function loadState(): void {
-	if ( isInOAuthFlow() ) {
+	if ( isOidcFlowInUrl() ) {
 		forceSidebarClosedDuringOAuth();
 		return;
 	}


### PR DESCRIPTION
## Summary

- Replace legacy OAuth message-based authentication with OIDC (OpenID Connect) flow
- Inline `setupOidcAuthParentListener`, `forwardOidcLoginFlowToWindow`, and `isOidcFlowInUrl` from the `@elementor/oidc-auth` package into a new `oidc-auth-inline.ts` module to keep the SDK self-contained
- Update `oauth.ts` to use the OIDC parent listener and login flow forwarding instead of manual message handling
- Update `sidebar.ts` to use `isOidcFlowInUrl()` for detecting authentication flows (checks `oauth2_login_success`, `oauth2_state`, `oauth2_top_origin` params)
- Add `setupOidcLoginFlowHandler()` call in `iframe.ts` to forward OIDC state to the iframe on page load
- Bump version to 1.0.10

## Why inlined?

The `@elementor/oidc-auth` package is a private monorepo dependency. To keep the SDK publishable on npm without a private peer dependency, the 3 functions the SDK needs are inlined. They are self-contained and don't depend on `oidc-client-ts`, `OidcAuthConfig`, or any other heavy parts of the auth package.

## Test plan

- [x] All 91 existing tests pass
- [x] TypeScript compilation succeeds
- [x] Both ESM and CJS bundles build successfully
- [x] Mocks added for `oidc-auth-inline` in `iframe.test.ts` and `sidebar.test.ts`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Migrate OAuth authentication flow from custom OAuth implementation to standardized OIDC (OpenID Connect) protocol to improve security and maintainability of authentication system.

Main changes:
- Replaced custom OAuth message handlers with OIDC-compliant authentication flow using new oidc-auth-inline module
- Refactored URL parameter names from oauth_code/oauth_state to oauth2_login_success/oauth2_state for OIDC standard compliance
- Added retry mechanism with 5 attempts for forwarding OIDC login state to iframe when window not immediately available

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
