### PR TITLE
Replace legacy OAuth with OIDC auth integration

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -20,6 +20,7 @@ const config = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
     '\\.(css)\\?raw$': '<rootDir>/src/__mocks__/cssRawMock.js',
+    '^@elementor/oidc-auth$': '<rootDir>/src/__mocks__/oidc-auth.js',
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.0.6",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@elementor/angie-logger": "^0.3.1"
+        "@elementor/angie-logger": "^0.3.1",
+        "@elementor/oidc-auth": "^0.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^8.0.0",
@@ -29,6 +30,9 @@
         "typescript": "^5.3.3",
         "webpack": "^5.89.0",
         "webpack-cli": "^5.1.4"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": ">=1.17.4"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -738,6 +742,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@elementor/oidc-auth": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@elementor/oidc-auth/-/oidc-auth-0.1.0.tgz",
+      "integrity": "sha512-fUtdq4JE6UPMiRvuBZiUoUmabO2LDMLL/cs4rRbbH8rOVws3B7MUlGxYbVt04p68ig0AfKF2M9DQHQJu53lKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@elementor/angie-logger": "^0.3.1",
+        "oidc-client-ts": "^3.4.1"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -5718,6 +5732,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6096,6 +6119,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/oidc-client-ts": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/oidc-client-ts/-/oidc-client-ts-3.4.1.tgz",
+      "integrity": "sha512-jNdst/U28Iasukx/L5MP6b274Vr7ftQs6qAhPBCvz6Wt5rPCA+Q/tUmCzfCHHWweWw5szeMy2Gfrm1rITwUKrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jwt-decode": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/on-finished": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",
@@ -34,7 +34,8 @@
   "author": "Elementor",
   "license": "MIT",
   "dependencies": {
-    "@elementor/angie-logger": "^0.3.1"
+    "@elementor/angie-logger": "^0.3.1",
+    "@elementor/oidc-auth": "^0.1.0"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": ">=1.17.4"

--- a/src/__mocks__/oidc-auth.js
+++ b/src/__mocks__/oidc-auth.js
@@ -1,0 +1,5 @@
+module.exports = {
+  isOidcFlowInUrl: jest.fn(() => false),
+  setupOidcAuthParentListener: jest.fn(),
+  forwardOidcLoginFlowToWindow: jest.fn(),
+};

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,7 +1,7 @@
 import { addLocalStorageListener } from './localStorage';
 import { appState } from './config';
 import { createChildLogger } from './logger';
-import { listenToOAuthFromIframe } from './oauth';
+import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
 import { listenToSDK } from './sdk';
 import { loadWidth } from './sidebar';
 import { HostEventType, MessageEventType } from './types';
@@ -157,6 +157,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 	listenToSDK( appState );
 
 	listenToOAuthFromIframe();
+	setupOidcLoginFlowHandler();
 
 	window.addEventListener( 'message', async ( event ) => {
 

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -1,8 +1,10 @@
+import {
+	forwardOidcLoginFlowToWindow,
+	setupOidcAuthParentListener,
+	type OidcAuthAppWindow,
+} from "@elementor/oidc-auth";
 import { appState } from "./config";
 import { createChildLogger } from "./logger";
-import { sendErrorMessage, sendSuccessMessage } from "./utils";
-
-const oauthLogger = createChildLogger( 'oauth' );
 
 declare global {
 	interface Window {
@@ -10,138 +12,33 @@ declare global {
 	}
 }
 
-// OAuth message types for iframe communication
-export const OAUTH_MESSAGE_TYPES = {
-	OAUTH_GET_CODE_AND_STATE: 'OAUTH_GET_CODE_AND_STATE',
-	OAUTH_GET_TOP_URL: 'OAUTH_GET_TOP_URL',
-	OAUTH_REDIRECT_TOP_WINDOW: 'OAUTH_REDIRECT_TOP_WINDOW',
-	OAUTH_UPDATE_URL: 'OAUTH_UPDATE_URL',
-	ANGIE_REDIRECT_TO_WP_ADMIN_WITH_OAUTH: 'ANGIE_REDIRECT_TO_WP_ADMIN_WITH_OAUTH',
-	ANGIE_REDIRECT_TO_AUTH_ORIGIN_LOGOUT: 'ANGIE_REDIRECT_TO_AUTH_ORIGIN_LOGOUT',
-} as const;
-
-function checkOAuthParameterCleanup( oldUrl: string, newUrl: string ): boolean {
-	const newUrlObject = new URL( newUrl );
-	const oldUrlObject = new URL( oldUrl );
-	const newUrlParams = newUrlObject.searchParams;
-	const oldUrlParams = oldUrlObject.searchParams;
-	const oauthParams = [ 'oauth_code', 'oauth_state', 'start-oauth' ];
-	return oauthParams.some( param => oldUrlParams?.has( param ) ) &&
-		! oauthParams.some( param => newUrlParams?.has( param ) );
-}
+const logger = createChildLogger( 'oauth' );
 
 function openSidebarAfterAuthentication(): void {
-	oauthLogger.log( 'OAuth parameters cleaned, opening sidebar' );
 	try {
 		localStorage.setItem( 'angie_sidebar_state', 'open' );
 	} catch ( e ) {
-		oauthLogger.warn( 'localStorage not available' );
+		logger.warn( 'localStorage not available' );
 	}
 	setTimeout( () => {
 		window.toggleAngieSidebar( true );
 	}, 500 );
 }
 
-function handleUrlUpdate( newUrl: string, port: MessagePort ): void {
-	if ( ! history?.replaceState ) {
-		oauthLogger.warn( 'history.replaceState not supported in this browser' );
-		sendErrorMessage( port, { message: 'URL update not supported in this browser' } );
-		return;
-	}
-
-	try {
-		const oldUrl = window.location.href;
-		history.replaceState( {}, '', newUrl );
-
-		if ( checkOAuthParameterCleanup( oldUrl, newUrl ) ) {
-			openSidebarAfterAuthentication();
-		}
-
-		sendSuccessMessage( port, {
-			message: 'URL updated successfully',
-		} );
-	} catch ( error ) {
-		oauthLogger.warn( 'Failed to update URL via history.replaceState:', error );
-		sendErrorMessage( port, { message: 'URL update failed: ' + ( error instanceof Error ? error.message : 'Unknown error' ) } );
-	}
-}
-
-function redirectToWpAdminWithOAuth(): void {
-	const currentUrl = new URL( window.location.href );
-	currentUrl.searchParams.set( 'start-oauth', '1' );
-	oauthLogger.log( 'Redirecting to wp-admin with OAuth:', currentUrl.toString() );
-	window.location.href = currentUrl.toString();
-}
-
-export const getOAuthCodeAndState = ( port: MessagePort ): void => {
-	const urlParams = new URLSearchParams( window.location.search );
-	const oauthCode = urlParams.get( 'oauth_code' );
-	const oauthState = urlParams.get( 'oauth_state' );
-
-	if ( oauthCode && oauthState ) {
-		sendSuccessMessage( port, {
-			code: oauthCode,
-			state: oauthState,
-		} );
-	} else {
-		const oauthError = urlParams.get( 'oauth_error' );
-		if ( oauthError ) {
-			sendErrorMessage( port, {
-				message: oauthError,
-				code: oauthCode || null,
-				state: oauthState || null,
-			} );
-			const cleanUrl = new URL( window.location.href );
-			cleanUrl.searchParams.delete( 'oauth_error' );
-			history.replaceState( {}, '', cleanUrl.toString() );
-		} else {
-			sendSuccessMessage( port, {
-				message: 'No OAuth error found',
-			} );
-		}
-	}
+export const listenToOAuthFromIframe = (): void => {
+	setupOidcAuthParentListener( {
+		trustedOrigin: appState.iframeUrlObject?.origin ?? '',
+		onOAuthParamsCleared: openSidebarAfterAuthentication,
+	} );
 };
 
-export const listenToOAuthFromIframe = (): void => {
-	window.addEventListener( 'message', ( event ) => {
-		if ( event.origin !== appState.iframeUrlObject?.origin ) {
-			return;
-		}
+export const setupOidcLoginFlowHandler = (): void => {
+	const targets: OidcAuthAppWindow = { window: appState.iframe, windowURL: appState.iframeUrlObject };
 
-		switch ( event.data.type ) {
-			case OAUTH_MESSAGE_TYPES.OAUTH_GET_CODE_AND_STATE:
-				getOAuthCodeAndState( event.ports[ 0 ] );
-				break;
-
-			case OAUTH_MESSAGE_TYPES.OAUTH_GET_TOP_URL:
-				oauthLogger.log( 'Iframe requested top window URL via MessageChannel' );
-				sendSuccessMessage( event.ports[ 0 ], {
-					topUrl: window.location.href,
-				} );
-				break;
-
-			case OAUTH_MESSAGE_TYPES.OAUTH_REDIRECT_TOP_WINDOW:
-				oauthLogger.log( 'Iframe requested top window redirect to:', event.data.payload.url );
-				window.location.href = event.data.payload.url;
-				break;
-
-			case OAUTH_MESSAGE_TYPES.OAUTH_UPDATE_URL:
-				oauthLogger.log( 'Iframe requested URL update to:', event.data.payload.url );
-				handleUrlUpdate( event.data.payload.url, event.ports[ 0 ] );
-				break;
-
-			case OAUTH_MESSAGE_TYPES.ANGIE_REDIRECT_TO_WP_ADMIN_WITH_OAUTH:
-				redirectToWpAdminWithOAuth();
-				break;
-
-			case OAUTH_MESSAGE_TYPES.ANGIE_REDIRECT_TO_AUTH_ORIGIN_LOGOUT:
-				try {
-					redirectToWpAdminWithOAuth();
-				} catch ( error ) {
-					oauthLogger.error( 'Auth origin logout fallback failed:', error );
-					window.location.reload();
-				}
-				break;
-		}
+	window.addEventListener( 'load', () => {
+		logger.log( 'OIDC: Window load event fired, forwarding OIDC state if present' );
+		forwardOidcLoginFlowToWindow( { targets, onSuccess: openSidebarAfterAuthentication } );
 	} );
+
+	forwardOidcLoginFlowToWindow( { targets, onSuccess: openSidebarAfterAuthentication } );
 };

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,6 +1,7 @@
 import { postMessageToAngieIframe } from "./angie-iframe-utils";
-import { createChildLogger } from "./logger";
 import { MessageEventType } from "./types";
+import { createChildLogger } from "./logger";
+import { isOidcFlowInUrl } from "@elementor/oidc-auth";
 import { waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
 
@@ -100,14 +101,6 @@ export function applyWidth( width: number ): void {
 	document.documentElement.style.setProperty( '--angie-sidebar-width', `${ width }px` );
 }
 
-export function isInOAuthFlow(): boolean {
-	const urlParams = new URLSearchParams( window.location.search );
-	return urlParams.has( 'start-oauth' ) ||
-			urlParams.has( 'oauth_code' ) ||
-			urlParams.has( 'oauth_state' ) ||
-			urlParams.has( 'oauth_error' );
-}
-
 export function forceSidebarClosedDuringOAuth(): void {
 	applyState( ANGIE_SIDEBAR_STATE_CLOSED );
 	try {
@@ -118,7 +111,7 @@ export function forceSidebarClosedDuringOAuth(): void {
 }
 
 export function loadState(): void {
-	if ( isInOAuthFlow() ) {
+	if ( isOidcFlowInUrl() ) {
 		forceSidebarClosedDuringOAuth();
 		return;
 	}


### PR DESCRIPTION
## Summary

Replace the custom OAuth message handling implementation with the standardized `@elementor/oidc-auth` package (v0.1.0).

### Changes
- **oauth.ts**: Replace 148 lines of manual OAuth message handling with 44 lines using `@elementor/oidc-auth`:
  - `setupOidcAuthParentListener` — handles OIDC messages from iframe
  - `forwardOidcLoginFlowToWindow` — forwards OIDC state to iframe on page load
- **sidebar.ts**: Replace local `isInOAuthFlow()` with `isOidcFlowInUrl()` from oidc-auth package
- **iframe.ts**: Add `setupOidcLoginFlowHandler()` call after iframe initialization
- **package.json**: Add `@elementor/oidc-auth: ^0.1.0` dependency, bump to v1.1.0

### Benefits
- Consistent auth flow with iframe-app (both use same oidc-auth package)
- Simpler, more maintainable code
- Standardized OIDC protocol instead of custom OAuth message types

### Breaking Change
OAuth message types removed (`OAUTH_GET_CODE_AND_STATE`, `OAUTH_GET_TOP_URL`, etc). Consumers must use OIDC flow.

## Test plan
- [x] Build passes
- [x] All 91 tests pass
- [ ] Test auth flow in WordPress integration
- [ ] Verify sidebar state management during OAuth redirect


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Replace legacy OAuth implementation with standardized OIDC authentication library to improve security and reduce maintenance overhead across authentication flows.

Main changes:
- Integrated @elementor/oidc-auth package replacing 147 lines of custom OAuth message handling and URL parameter management
- Added setupOidcLoginFlowHandler function with window load event listener to handle OIDC login flow forwarding
- Replaced custom isInOAuthFlow URL parameter detection with isOidcFlowInUrl from OIDC library

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
