### PR TITLE
[AI-6561] Add prompt support to referrer redirect utilities

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,4 +20,4 @@ export { getAngieIframe } from './angie-iframe-utils';
 export { disableNavigationPrevention } from './iframe';
 export * from './types';
 export { BrowserContextTransport } from './browser-context-transport';
-export { setReferrerRedirect, getReferrerRedirect, clearReferrerRedirect } from './referrer-redirect';
+export { setReferrerRedirect, getReferrerRedirect, clearReferrerRedirect, type ReferrerRedirectData } from './referrer-redirect';

--- a/src/referrer-redirect.test.ts
+++ b/src/referrer-redirect.test.ts
@@ -36,7 +36,7 @@ describe( 'referrer-redirect', () => {
 	} );
 
 	describe( 'setReferrerRedirect', () => {
-		it( 'should store valid same-origin URL', () => {
+		it( 'should store valid same-origin URL as JSON', () => {
 			// Arrange
 			const validUrl = 'http://localhost/some-page?id=123';
 
@@ -45,7 +45,26 @@ describe( 'referrer-redirect', () => {
 
 			// Assert
 			expect( result ).toBe( true );
-			expect( localStorage.setItem ).toHaveBeenCalledWith( 'angie_return_url', validUrl );
+			expect( localStorage.setItem ).toHaveBeenCalledWith(
+				'angie_return_url',
+				JSON.stringify( { url: validUrl } )
+			);
+		} );
+
+		it( 'should store URL with prompt as JSON', () => {
+			// Arrange
+			const validUrl = 'http://localhost/some-page?id=123';
+			const prompt = 'Help me create a contact page';
+
+			// Act
+			const result = setReferrerRedirect( validUrl, prompt );
+
+			// Assert
+			expect( result ).toBe( true );
+			expect( localStorage.setItem ).toHaveBeenCalledWith(
+				'angie_return_url',
+				JSON.stringify( { url: validUrl, prompt } )
+			);
 		} );
 
 		it( 'should reject external domain URL', () => {
@@ -54,6 +73,18 @@ describe( 'referrer-redirect', () => {
 
 			// Act
 			const result = setReferrerRedirect( externalUrl );
+
+			// Assert
+			expect( result ).toBe( false );
+			expect( localStorage.setItem ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should reject external domain URL even with prompt', () => {
+			// Arrange
+			const externalUrl = 'https://evil.com/phishing';
+
+			// Act
+			const result = setReferrerRedirect( externalUrl, 'some prompt' );
 
 			// Assert
 			expect( result ).toBe( false );
@@ -87,19 +118,47 @@ describe( 'referrer-redirect', () => {
 				expect( result ).toBe( true );
 			}
 		} );
+
+		it( 'should not store prompt when it is an empty string', () => {
+			// Arrange
+			const validUrl = 'http://localhost/some-page';
+
+			// Act
+			const result = setReferrerRedirect( validUrl, '' );
+
+			// Assert
+			expect( result ).toBe( true );
+			expect( localStorage.setItem ).toHaveBeenCalledWith(
+				'angie_return_url',
+				JSON.stringify( { url: validUrl } )
+			);
+		} );
 	} );
 
 	describe( 'getReferrerRedirect', () => {
-		it( 'should return stored valid same-origin URL', () => {
+		it( 'should return stored valid same-origin URL as object', () => {
 			// Arrange
 			const validUrl = 'http://localhost/dashboard?post=123';
-			mockLocalStorage[ 'angie_return_url' ] = validUrl;
+			mockLocalStorage[ 'angie_return_url' ] = JSON.stringify( { url: validUrl } );
 
 			// Act
 			const result = getReferrerRedirect();
 
 			// Assert
-			expect( result ).toBe( validUrl );
+			expect( result ).toEqual( { url: validUrl } );
+		} );
+
+		it( 'should return stored URL with prompt as object', () => {
+			// Arrange
+			const validUrl = 'http://localhost/dashboard?post=123';
+			const prompt = 'Help me with SEO';
+			mockLocalStorage[ 'angie_return_url' ] = JSON.stringify( { url: validUrl, prompt } );
+
+			// Act
+			const result = getReferrerRedirect();
+
+			// Assert
+			expect( result ).toEqual( { url: validUrl, prompt } );
 		} );
 
 		it( 'should return null when no URL is stored', () => {
@@ -112,7 +171,29 @@ describe( 'referrer-redirect', () => {
 
 		it( 'should return null for invalid stored URL (external domain)', () => {
 			// Arrange
-			mockLocalStorage[ 'angie_return_url' ] = 'https://evil.com/page';
+			mockLocalStorage[ 'angie_return_url' ] = JSON.stringify( { url: 'https://evil.com/page' } );
+
+			// Act
+			const result = getReferrerRedirect();
+
+			// Assert
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should return null for malformed JSON', () => {
+			// Arrange
+			mockLocalStorage[ 'angie_return_url' ] = 'not-json';
+
+			// Act
+			const result = getReferrerRedirect();
+
+			// Assert
+			expect( result ).toBeNull();
+		} );
+
+		it( 'should return null for JSON without url field', () => {
+			// Arrange
+			mockLocalStorage[ 'angie_return_url' ] = JSON.stringify( { prompt: 'orphan prompt' } );
 
 			// Act
 			const result = getReferrerRedirect();
@@ -125,7 +206,7 @@ describe( 'referrer-redirect', () => {
 	describe( 'clearReferrerRedirect', () => {
 		it( 'should remove stored URL', () => {
 			// Arrange
-			mockLocalStorage[ 'angie_return_url' ] = 'http://localhost/dashboard';
+			mockLocalStorage[ 'angie_return_url' ] = JSON.stringify( { url: 'http://localhost/dashboard' } );
 
 			// Act
 			clearReferrerRedirect();

--- a/src/referrer-redirect.ts
+++ b/src/referrer-redirect.ts
@@ -4,6 +4,11 @@ const REFERRER_REDIRECT_KEY = 'angie_return_url';
 
 const referrerLogger = createChildLogger( 'referrer-redirect' );
 
+export type ReferrerRedirectData = {
+	url: string;
+	prompt?: string;
+};
+
 function isValidRedirectUrl( url: string ): boolean {
 	try {
 		const parsed = new URL( url, window.location.origin );
@@ -13,14 +18,20 @@ function isValidRedirectUrl( url: string ): boolean {
 	}
 }
 
-export function setReferrerRedirect( url: string ): boolean {
+export function setReferrerRedirect( url: string, prompt?: string ): boolean {
 	if ( ! isValidRedirectUrl( url ) ) {
 		referrerLogger.warn( 'Invalid redirect URL rejected:', url );
 		return false;
 	}
 
 	try {
-		localStorage.setItem( REFERRER_REDIRECT_KEY, url );
+		const data: ReferrerRedirectData = { url };
+
+		if ( prompt ) {
+			data.prompt = prompt;
+		}
+
+		localStorage.setItem( REFERRER_REDIRECT_KEY, JSON.stringify( data ) );
 		return true;
 	} catch ( e ) {
 		referrerLogger.warn( 'localStorage not available' );
@@ -28,16 +39,32 @@ export function setReferrerRedirect( url: string ): boolean {
 	}
 }
 
-export function getReferrerRedirect(): string | null {
+export function getReferrerRedirect(): ReferrerRedirectData | null {
 	try {
-		const url = localStorage.getItem( REFERRER_REDIRECT_KEY );
-		if ( url && isValidRedirectUrl( url ) ) {
-			return url;
+		const raw = localStorage.getItem( REFERRER_REDIRECT_KEY );
+		if ( ! raw ) {
+			return null;
 		}
-		if ( url ) {
-			referrerLogger.warn( 'Stored redirect URL is invalid, returning null:', url );
+
+		let data: ReferrerRedirectData;
+		try {
+			data = JSON.parse( raw );
+		} catch {
+			referrerLogger.warn( 'Stored redirect data is not valid JSON, returning null' );
+			return null;
 		}
-		return null;
+
+		if ( ! data.url || typeof data.url !== 'string' ) {
+			referrerLogger.warn( 'Stored redirect data missing url field, returning null' );
+			return null;
+		}
+
+		if ( ! isValidRedirectUrl( data.url ) ) {
+			referrerLogger.warn( 'Stored redirect URL is invalid, returning null:', data.url );
+			return null;
+		}
+
+		return data;
 	} catch ( e ) {
 		referrerLogger.warn( 'localStorage not available' );
 		return null;


### PR DESCRIPTION
## Summary

- **`setReferrerRedirect(url, prompt?)`** now accepts an optional `prompt` parameter
- **`getReferrerRedirect()`** returns `ReferrerRedirectData | null` (object with `url` and optional `prompt`) instead of `string | null`
- Storage format changes from a plain URL string to a JSON object `{ url, prompt? }`
- Exports new `ReferrerRedirectData` type

## Intent

When a user triggers an action that requires authentication (OAuth redirect), we currently save only the return URL. After the redirect round-trip, the user lands back on the original page but loses the context of what they were trying to do.

This change allows callers to persist a prompt alongside the redirect URL. After the user returns from OAuth, the consumer can read the prompt and auto-trigger Angie with it (e.g., by appending `#angie-prompt=<encoded>` to the redirect URL).

## Follow-up required

After this PR is merged and a new SDK version is published, a follow-up PR is needed in the **elementor-ai** repo to:
1. Bump the `@elementor/angie-sdk` dependency
2. Update `post-activation-redirect.ts` to parse the new JSON format and use the prompt (append `#angie-prompt=` to the redirect URL when a prompt is present)
3. Update callers of `setReferrerRedirect` to pass prompts where applicable

## Test plan

- [x] All 15 referrer-redirect tests pass (including 6 new tests for prompt support)
- [x] Full test suite passes (97/97)
- [x] No new lint errors

[AI-6561](https://elementor.atlassian.net/browse/AI-6561)

Made with [Cursor](https://cursor.com)

[AI-6561]: https://elementor.atlassian.net/browse/AI-6561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Extend referrer redirect utilities to store optional prompt messages alongside redirect URLs, enabling context-aware navigation flows.

Main changes:
- Modified storage format from plain string to JSON object containing url and optional prompt field
- Added ReferrerRedirectData type export and enhanced validation for malformed JSON and missing url fields
- Updated setReferrerRedirect to accept optional prompt parameter and getReferrerRedirect to return structured object

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
