### PR TITLE
Add referrer redirect support to OIDC auth completion (v1.3.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+
+const mockSetupOidcAuthParentListener = jest.fn();
+const mockForwardOidcLoginFlowToWindow = jest.fn();
+
+jest.mock( '@elementor/oidc-auth', () => ( {
+	setupOidcAuthParentListener: mockSetupOidcAuthParentListener,
+	forwardOidcLoginFlowToWindow: mockForwardOidcLoginFlowToWindow,
+} ) );
+
+const mockGetReferrerRedirect = jest.fn();
+const mockClearReferrerRedirect = jest.fn();
+
+jest.mock( './referrer-redirect', () => ( {
+	getReferrerRedirect: mockGetReferrerRedirect,
+	clearReferrerRedirect: mockClearReferrerRedirect,
+} ) );
+
+jest.mock( './config', () => ( {
+	appState: {
+		iframeUrlObject: { origin: 'https://angie.test.com' },
+		iframe: document.createElement( 'iframe' ),
+	},
+} ) );
+
+jest.mock( './logger', () => ( {
+	createChildLogger: () => ( {
+		log: jest.fn(),
+		warn: jest.fn(),
+		error: jest.fn(),
+	} ),
+} ) );
+
+import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
+
+describe( 'oauth', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockGetReferrerRedirect.mockReturnValue( null );
+
+		Object.defineProperty( window, 'toggleAngieSidebar', {
+			value: jest.fn(),
+			writable: true,
+			configurable: true,
+		} );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	function getOidcParentCallback(): () => void {
+		listenToOAuthFromIframe();
+		return ( mockSetupOidcAuthParentListener.mock.calls[ 0 ][ 0 ] as any ).onOAuthParamsCleared;
+	}
+
+	function getOidcLoginFlowCallback(): () => void {
+		setupOidcLoginFlowHandler();
+		const lastIdx = mockForwardOidcLoginFlowToWindow.mock.calls.length - 1;
+		return ( mockForwardOidcLoginFlowToWindow.mock.calls[ lastIdx ][ 0 ] as any ).onSuccess;
+	}
+
+	describe( 'listenToOAuthFromIframe', () => {
+		it( 'should setup OIDC auth parent listener', () => {
+			// Act
+			listenToOAuthFromIframe();
+
+			// Assert
+			expect( mockSetupOidcAuthParentListener ).toHaveBeenCalledWith( {
+				trustedOrigin: 'https://angie.test.com',
+				onOAuthParamsCleared: expect.any( Function ),
+			} );
+		} );
+
+		it( 'should open sidebar when auth completes and no referrer redirect', () => {
+			// Arrange
+			jest.useFakeTimers();
+			const callback = getOidcParentCallback();
+
+			// Act
+			callback();
+			jest.advanceTimersByTime( 500 );
+
+			// Assert
+			expect( window.toggleAngieSidebar ).toHaveBeenCalledWith( true );
+
+			jest.useRealTimers();
+		} );
+
+		it( 'should redirect with prompt when referrer redirect with prompt exists', () => {
+			// Arrange
+			const returnUrl = 'http://localhost/wp-admin/post.php?post=123';
+			const prompt = 'Help me create a contact page';
+			mockGetReferrerRedirect.mockReturnValue( { url: returnUrl, prompt } );
+			const callback = getOidcParentCallback();
+
+			// Act
+			callback();
+
+			// Assert
+			expect( mockClearReferrerRedirect ).toHaveBeenCalled();
+			expect( window.toggleAngieSidebar ).not.toHaveBeenCalled();
+		} );
+
+		it( 'should redirect without prompt hash when referrer redirect exists without prompt', () => {
+			// Arrange
+			const returnUrl = 'http://localhost/wp-admin/post.php?post=123';
+			mockGetReferrerRedirect.mockReturnValue( { url: returnUrl } );
+			const callback = getOidcParentCallback();
+
+			// Act
+			callback();
+
+			// Assert
+			expect( mockClearReferrerRedirect ).toHaveBeenCalled();
+			expect( window.toggleAngieSidebar ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'setupOidcLoginFlowHandler', () => {
+		it( 'should forward OIDC login flow with redirect callback', () => {
+			// Act
+			setupOidcLoginFlowHandler();
+
+			// Assert
+			expect( mockForwardOidcLoginFlowToWindow ).toHaveBeenCalledWith( {
+				targets: expect.any( Object ),
+				onSuccess: expect.any( Function ),
+			} );
+		} );
+
+		it( 'should redirect when OIDC login succeeds and referrer redirect exists', () => {
+			// Arrange
+			const returnUrl = 'http://localhost/wp-admin/post.php?post=456';
+			const prompt = 'Help me optimize SEO';
+			mockGetReferrerRedirect.mockReturnValue( { url: returnUrl, prompt } );
+			const callback = getOidcLoginFlowCallback();
+
+			// Act
+			callback();
+
+			// Assert
+			expect( mockClearReferrerRedirect ).toHaveBeenCalled();
+		} );
+	} );
+} );

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -5,6 +5,7 @@ import {
 } from "@elementor/oidc-auth";
 import { appState } from "./config";
 import { createChildLogger } from "./logger";
+import { clearReferrerRedirect, getReferrerRedirect } from "./referrer-redirect";
 
 declare global {
 	interface Window {
@@ -14,7 +15,22 @@ declare global {
 
 const logger = createChildLogger( 'oauth' );
 
-function openSidebarAfterAuthentication(): void {
+function buildRedirectUrl( url: string, prompt?: string ): string {
+	if ( ! prompt ) {
+		return url;
+	}
+	return `${ url }#angie-prompt=${ encodeURIComponent( prompt ) }`;
+}
+
+function onAuthenticationComplete(): void {
+	const redirectData = getReferrerRedirect();
+
+	if ( redirectData ) {
+		clearReferrerRedirect();
+		window.location.href = buildRedirectUrl( redirectData.url, redirectData.prompt );
+		return;
+	}
+
 	try {
 		localStorage.setItem( 'angie_sidebar_state', 'open' );
 	} catch ( e ) {
@@ -28,7 +44,7 @@ function openSidebarAfterAuthentication(): void {
 export const listenToOAuthFromIframe = (): void => {
 	setupOidcAuthParentListener( {
 		trustedOrigin: appState.iframeUrlObject?.origin ?? '',
-		onOAuthParamsCleared: openSidebarAfterAuthentication,
+		onOAuthParamsCleared: onAuthenticationComplete,
 	} );
 };
 
@@ -37,8 +53,8 @@ export const setupOidcLoginFlowHandler = (): void => {
 
 	window.addEventListener( 'load', () => {
 		logger.log( 'OIDC: Window load event fired, forwarding OIDC state if present' );
-		forwardOidcLoginFlowToWindow( { targets, onSuccess: openSidebarAfterAuthentication } );
+		forwardOidcLoginFlowToWindow( { targets, onSuccess: onAuthenticationComplete } );
 	} );
 
-	forwardOidcLoginFlowToWindow( { targets, onSuccess: openSidebarAfterAuthentication } );
+	forwardOidcLoginFlowToWindow( { targets, onSuccess: onAuthenticationComplete } );
 };


### PR DESCRIPTION
## Summary
- After OIDC authentication completes, the SDK now checks for a stored referrer redirect (`getReferrerRedirect()`)
- If redirect data exists, navigates to the stored URL with optional `#angie-prompt=` hash parameter, then clears the redirect
- If no redirect data exists, opens the sidebar as before (no behavior change for existing flows)
- Bumps version to 1.3.0

## Context
This is part of AI-6561 (Add support for prompt when setting redirect referrer). The previous PR (#13) added prompt support to the `setReferrerRedirect`/`getReferrerRedirect` utilities. This PR wires that into the actual auth completion callback so redirects happen after OIDC login.

The `ai-remote-integration` package in `elementor-ai` had a `post-activation-redirect.ts` that was supposed to handle this, but it relied on a `ANGIE_USER_ALREADY_AUTHENTICATED` postMessage that is no longer sent in the OIDC flow — making it dead code. Moving the redirect logic into the SDK's `onAuthenticationComplete` callback is the correct integration point.

## Test plan
- [ ] 6 unit tests added covering: listener setup, sidebar open (no redirect), redirect with prompt, redirect without prompt, login flow forwarding, login flow redirect
- [ ] All 103 existing tests pass
- [ ] After merge + publish, bump version in `elementor-ai` and remove dead `post-activation-redirect.ts`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add referrer redirect functionality to OIDC authentication flow to enable post-authentication navigation with optional prompt parameters.

Main changes:
- Implemented onAuthenticationComplete handler to check for referrer redirect data and navigate to stored URL with encoded prompt
- Replaced openSidebarAfterAuthentication with unified completion handler that prioritizes redirect over sidebar toggle behavior
- Added comprehensive test suite covering referrer redirect scenarios and OIDC authentication callback flows

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
