### PR TITLE
ci: add beta publish workflow

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -9,6 +9,9 @@ on:
         default: 'beta'
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   publish-beta:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -1,0 +1,42 @@
+name: Publish Beta to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      preid:
+        description: 'Pre-release identifier (e.g. beta, alpha, rc)'
+        required: false
+        default: 'beta'
+        type: string
+
+jobs:
+  publish-beta:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build package
+        run: npm run build
+
+      - name: Set beta version
+        run: |
+          BASE_VERSION=$(node -p "require('./package.json').version")
+          BETA_VERSION="${BASE_VERSION}-${{ github.event.inputs.preid }}.${{ github.run_number }}"
+          npm version "$BETA_VERSION" --no-git-tag-version
+          echo "Publishing version: $BETA_VERSION"
+
+      - name: Publish beta to npm
+        run: npm publish --tag ${{ github.event.inputs.preid }} --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds a `workflow_dispatch` workflow to publish beta versions to npm from any branch
- Version is auto-generated as `{current_version}-{preid}.{run_number}` (e.g. `1.2.0-beta.1`)
- Publishes with `--tag beta` (or custom preid) so `latest` is never affected

## Usage
Actions → Publish Beta to NPM → Run workflow → select branch → set preid (default: `beta`)

Install beta:
```bash
npm install @elementor/angie-sdk@beta
```

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add automated GitHub Actions workflow to publish beta versions of the NPM package with configurable pre-release identifiers and version management.

Main changes:
- Created workflow_dispatch workflow with configurable preid input for beta, alpha, or rc releases
- Implemented automated beta versioning using base version, preid, and GitHub run number
- Configured NPM publishing with custom tags and public access using NPM_TOKEN secret

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
