### PR TITLE
[AI-5004] add local publish registry

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,10 @@
     "dev": "tsc --watch",
     "test": "jest",
     "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "publish:local": "npm version prerelease --preid dev --no-git-tag-version && npm run build && npm publish --registry http://localhost:4873/ --userconfig ~/.config/verdaccio/npmrc.local",
+    "publish:local:complete": "npm version patch --no-git-tag-version",
+    "install:local": "npm install --userconfig ~/.config/verdaccio/npmrc.local"
   },
   "keywords": [
     "mcp",


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add local package registry workflow using Verdaccio to enable testing and development of npm packages before public release.

Main changes:
- Added publish:local script to version, build, and publish packages to local Verdaccio registry at localhost:4873
- Created publish:local:complete and install:local scripts for local package version management and installation workflow
- Added lint:fix script for automated ESLint error correction during development

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
