### PR TITLE
feat: add newChat as URL param and top-level trigger param

### DIFF
--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -237,7 +237,7 @@ export class AngieMcpSdk {
         payload: {
           requestId,
           prompt: request.prompt,
-          options: request.options,
+          newChat: request.newChat,
           context: {
             pageUrl: window.location.href,
             pageTitle: document.title,
@@ -349,7 +349,11 @@ export class AngieMcpSdk {
     }
 
     try {
-      const promptEncoded = hash.replace('#angie-prompt=', '');
+      let promptEncoded = hash.replace('#angie-prompt=', '');
+      const newChat = promptEncoded.includes('&angie-new-chat=1') ? true : false;
+      if( newChat ){
+        promptEncoded = promptEncoded.split('&angie-new-chat=1')[0] || '';
+      }
       const prompt = decodeURIComponent(promptEncoded);
 
       if (!prompt) {
@@ -368,6 +372,7 @@ export class AngieMcpSdk {
           pageUrl: window.location.href,
           timestamp: new Date().toISOString(),
         },
+        newChat,
       });
 
       this.logger.log('Triggered successfully from hash:', response);

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -81,7 +81,7 @@ export const listenToSDK = ( appState: AppState ) => {
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 
 				try {
-					const { requestId, prompt, context } = event.data.payload;
+				const { requestId, prompt, context, newChat } = event.data.payload;
 
 					if ( appState.iframe ) {
 						appState.iframe.contentWindow?.postMessage( {
@@ -90,6 +90,7 @@ export const listenToSDK = ( appState: AppState ) => {
 								requestId,
 								prompt,
 								context,
+								newChat,
 							},
 						}, appState.iframeUrlObject?.origin || '' );
 					} else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,7 @@ export interface AngieTriggerRequest {
   context:{
     source?: string;
   }& Record<string, any>;
+  newChat?: boolean;
   options?: {
     timeout?: number;
   };


### PR DESCRIPTION
## Summary
- **URL param:** `#angie-prompt=...&angie-new-chat=1` — when present, opens in new chat.
- **API:** `newChat` is now a top-level field on `AngieTriggerRequest` (no longer under `options`).
- **Flow:** `handlePromptHash` parses `angie-new-chat=1` from the hash and passes `newChat` into `triggerAngie`; `sdk.ts` forwards `newChat` in the payload to the iframe.

## Changes
- `src/types.ts`: `newChat?: boolean` on `AngieTriggerRequest`; `options` only has `timeout`.
- `src/angie-mcp-sdk.ts`: Parse `angie-new-chat=1` in hash, pass `newChat` to `triggerAngie` and in postMessage payload.
- `src/sdk.ts`: Destructure and forward `newChat` (not `options`) to iframe.

## Testing
- `npm test` / `npx jest` — all 12 suites, 113 tests pass.
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add newChat parameter to SDK trigger API and URL hash parsing to enable control over chat session creation from external integrations.

Main changes:
- Added newChat boolean parameter to AngieTriggerRequest interface and SDK message payload forwarding chain
- Implemented URL hash parameter parsing for &angie-new-chat=1 flag in hash-based trigger initialization
- Removed unused options field from SDK_TRIGGER_ANGIE message payload in favor of top-level newChat parameter

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
