### PR TITLE
[AI-6829] Feature: Add configurable container, CSS, and widget UI options to SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.4.3",
+      "version": "1.4.4",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.3",
+  "version": "1.4.4",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -8,6 +8,9 @@ jest.mock('./angie-detector');
 jest.mock('./registration-queue');
 jest.mock('./client-manager');
 jest.mock('./browser-context-transport');
+jest.mock('./angie-iframe-utils', () => ({
+  postMessageToAngieIframe: jest.fn(),
+}));
 jest.mock('./sidebar', () => ({
   initAngieSidebar: jest.fn(),
 }));
@@ -27,6 +30,7 @@ describe('AngieMcpSdk', () => {
   let mockBrowserContextTransport: any;
   let mockInitAngieSidebar: any;
   let mockOpenIframe: any;
+  let mockPostMessageToAngieIframe: any;
   let addEventListenerSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
@@ -55,10 +59,11 @@ describe('AngieMcpSdk', () => {
 
     mockBrowserContextTransport = jest.fn().mockImplementation(() => ({}));
 
-    // Mock sidebar and iframe functions
+    // Mock sidebar, iframe, and postMessage functions
     mockInitAngieSidebar = require('./sidebar').initAngieSidebar as jest.MockedFunction<any>;
     mockOpenIframe = require('./iframe').openIframe as jest.MockedFunction<any>;
     mockOpenIframe.mockResolvedValue(undefined);
+    mockPostMessageToAngieIframe = require('./angie-iframe-utils').postMessageToAngieIframe as jest.MockedFunction<any>;
 
     // Mock the constructors
     (require('./angie-detector') as any).AngieDetector.mockImplementation(() => mockAngieDetector);
@@ -450,11 +455,16 @@ describe('AngieMcpSdk', () => {
 
       // Assert
       expect(mockInitAngieSidebar).toHaveBeenCalledTimes(1);
+      expect(mockInitAngieSidebar).toHaveBeenCalledWith({
+        skipDefaultCss: false,
+      });
       expect(mockOpenIframe).toHaveBeenCalledTimes(1);
       expect(mockOpenIframe).toHaveBeenCalledWith({
         origin: 'https://angie.elementor.com',
         uiTheme: 'light',
         isRTL: false,
+        containerId: 'angie-sidebar-container',
+        skipDefaultCss: false,
       });
     });
 
@@ -464,6 +474,8 @@ describe('AngieMcpSdk', () => {
         origin: 'https://custom-origin.example.com',
         uiTheme: 'dark',
         isRTL: true,
+        containerId: 'my-custom-container',
+        skipDefaultCss: true,
       };
 
       // Act
@@ -471,12 +483,47 @@ describe('AngieMcpSdk', () => {
 
       // Assert
       expect(mockInitAngieSidebar).toHaveBeenCalledTimes(1);
+      expect(mockInitAngieSidebar).toHaveBeenCalledWith({
+        skipDefaultCss: true,
+      });
       expect(mockOpenIframe).toHaveBeenCalledTimes(1);
       expect(mockOpenIframe).toHaveBeenCalledWith({
         origin: 'https://custom-origin.example.com',
         uiTheme: 'dark',
         isRTL: true,
+        containerId: 'my-custom-container',
+        skipDefaultCss: true,
       });
+    });
+
+    it('should send widget config via postMessage when provided', async () => {
+      // Arrange
+      const widgetConfig = {
+        title: 'Custom Title',
+        subtitle: 'Custom Subtitle',
+        promptLibrary: { enabled: false },
+        fileUpload: { enabled: false },
+        feedback: { enabled: false },
+        featuredMcpServer: 'wp-search',
+        suggestions: { items: [{ label: 'Search', value: 'search for' }] },
+      };
+
+      // Act
+      await sdk.loadSidebar({ widgetConfig });
+
+      // Assert
+      expect(mockPostMessageToAngieIframe).toHaveBeenCalledWith({
+        type: 'sdk-widget-config',
+        payload: widgetConfig,
+      });
+    });
+
+    it('should not send widget config when not provided', async () => {
+      // Act
+      await sdk.loadSidebar();
+
+      // Assert
+      expect(mockPostMessageToAngieIframe).not.toHaveBeenCalled();
     });
   });
 }); 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -1,17 +1,46 @@
 import type { Logger } from '@elementor/angie-logger';
+import { postMessageToAngieIframe } from './angie-iframe-utils';
 import { AngieDetector } from './angie-detector';
 import { BrowserContextTransport } from './browser-context-transport';
 import { ClientManager } from './client-manager';
+import { appState, DEFAULT_CONTAINER_ID } from './config';
 import { createChildLogger } from './logger';
 import { openIframe } from './iframe';
 import { initAngieSidebar } from './sidebar';
 import { RegistrationQueue } from './registration-queue';
 import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerConfig, AngieServerConfig, AngieServerType, MessageEventType, ServerRegistration, AngieTriggerRequest, AngieTriggerResponse } from './types';
 
+export { DEFAULT_CONTAINER_ID } from './config';
+
+type FeatureToggle = { enabled: boolean };
+
+type PromptSuggestion = { label: string; value: string };
+
+export type WidgetConfig = {
+  title?: string;
+  subtitle?: string;
+  suggestions?: { items: PromptSuggestion[] };
+  promptLibrary?: FeatureToggle;
+  fileUpload?: FeatureToggle;
+  feedback?: FeatureToggle;
+  featuredMcpServer?: string;
+};
+
 export type AngieMcpSdkOptions = {
   origin?: string;
   uiTheme?: string;
   isRTL?: boolean;
+  containerId?: string;
+  skipDefaultCss?: boolean;
+  widgetConfig?: WidgetConfig;
+};
+
+const DEFAULT_OPTIONS: Required<Omit<AngieMcpSdkOptions, 'widgetConfig'>> = {
+  origin: 'https://angie.elementor.com',
+  uiTheme: 'light',
+  isRTL: false,
+  containerId: DEFAULT_CONTAINER_ID,
+  skipDefaultCss: false,
 };
 
 export class AngieMcpSdk {
@@ -37,13 +66,16 @@ export class AngieMcpSdk {
   }
 
   public async loadSidebar( options?: AngieMcpSdkOptions ): Promise<void> {
-    initAngieSidebar();
-    await openIframe({
-      origin: options?.origin || 'https://angie.elementor.com',
-      uiTheme: options?.uiTheme || 'light',
-      isRTL: options?.isRTL || false,
-      ...options,
-    });
+    const { widgetConfig, ...rest } = options || {};
+    const config = { ...DEFAULT_OPTIONS, ...rest };
+    appState.containerId = config.containerId;
+    initAngieSidebar( { skipDefaultCss: config.skipDefaultCss } );
+    await openIframe( config );
+
+    if ( widgetConfig ) {
+      postMessageToAngieIframe( { type: 'sdk-widget-config', payload: widgetConfig } );
+    }
+
     this.setupPromptHashDetection();
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,11 +1,15 @@
+export const DEFAULT_CONTAINER_ID = 'angie-sidebar-container';
+
 export type AppState = {
 	open: boolean;
 	iframe: HTMLIFrameElement | null;
 	iframeUrlObject: URL | null;
+	containerId: string;
 };
 
 export const appState: AppState = {
 	open: false,
 	iframe: null as HTMLIFrameElement | null,
 	iframeUrlObject: null as URL | null,
+	containerId: DEFAULT_CONTAINER_ID,
 };

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -43,7 +43,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 	}
 
 	// Check if sidebar container exists
-	let sidebarContainer = document.getElementById( 'angie-sidebar-container' );
+	let sidebarContainer = document.getElementById( appState.containerId );
 
 	if ( ! sidebarContainer ) {
 		// Use MutationObserver for more efficient DOM watching
@@ -54,7 +54,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 			// First try with shorter polling interval for immediate cases
 			let attempts = 0;
 			const quickCheck = setInterval( () => {
-				sidebarContainer = document.getElementById( 'angie-sidebar-container' );
+				sidebarContainer = document.getElementById( appState.containerId );
 				attempts++;
 				if ( sidebarContainer || attempts > 20 ) { // Check for 2 seconds max with 100ms intervals
 					clearInterval( quickCheck );
@@ -75,7 +75,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 				}
 
 				const observer = new MutationObserver( () => {
-					sidebarContainer = document.getElementById( 'angie-sidebar-container' );
+					sidebarContainer = document.getElementById( appState.containerId );
 					if ( sidebarContainer ) {
 						observer.disconnect();
 						resolve();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type WidgetConfig } from './angie-mcp-sdk';
 export { AngieDetector } from './angie-detector';
 export { RegistrationQueue } from './registration-queue';
 export { ClientManager } from './client-manager';

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -137,7 +137,7 @@ describe('sidebar', () => {
 
     it('should call custom onToggle callback when provided', () => {
       const mockOnToggle = jest.fn();
-      initAngieSidebar(mockOnToggle);
+      initAngieSidebar({ onToggle: mockOnToggle });
       
       const toggleFunction = (global.window as any).toggleAngieSidebar;
       expect(toggleFunction).toBeDefined();

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,4 +1,5 @@
 import { postMessageToAngieIframe } from "./angie-iframe-utils";
+import { appState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
 import { isOidcFlowInUrl } from "@elementor/oidc-auth";
@@ -126,7 +127,7 @@ export function applyState( state: AngieSidebarState ): void {
 }
 
 export function initializeResize(): void {
-	const sidebar = document.getElementById( 'angie-sidebar-container' );
+	const sidebar = document.getElementById( appState.containerId );
 	if ( ! sidebar ) {
 		return;
 	}
@@ -204,7 +205,7 @@ export function initializeResize(): void {
 export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void ): ( force?: boolean, skipTransition?: boolean ) => void {
 	return function( force?: boolean, skipTransition?: boolean ): void {
 		const body = document.body;
-		const sidebar = document.getElementById( 'angie-sidebar-container' );
+		const sidebar = document.getElementById( appState.containerId );
 
 		if ( ! sidebar ) {
 			sidebarLogger.warn( 'Required elements not found!' );
@@ -259,11 +260,18 @@ export function setupMessageListener(): void {
 	} );
 }
 
-export function initAngieSidebar( onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void ): void {
-	injectCSS();
+type InitAngieSidebarOptions = {
+	onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void;
+	skipDefaultCss?: boolean;
+};
+
+export function initAngieSidebar( options?: InitAngieSidebarOptions ): void {
+	if ( ! options?.skipDefaultCss ) {
+		injectCSS();
+	}
 
 	if ( typeof window !== 'undefined' ) {
-		window.toggleAngieSidebar = createToggleSidebarFunction( onToggle );
+		window.toggleAngieSidebar = createToggleSidebarFunction( options?.onToggle );
 		setupMessageListener();
 	}
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,7 @@
+import { appState } from './config';
+
 export const toggleAngieSidebar = ( iframe: HTMLIFrameElement, isOpen: boolean ) => {
-	const sidebarContainer = document.getElementById( 'angie-sidebar-container' );
+	const sidebarContainer = document.getElementById( appState.containerId );
 	if ( sidebarContainer ) {
 		sidebarContainer.setAttribute( 'aria-hidden', isOpen ? 'false' : 'true' );
 	}


### PR DESCRIPTION
## Problem
SDK consumers are locked into a hardcoded container ID, always get default CSS injected, and have no way to customize widget UI features (title, subtitle, suggestions, feature toggles).

## Solution
Add `containerId`, `skipDefaultCss`, and `widgetConfig` options to `loadSidebar()`. Widget config is sent via postMessage to the iframe, allowing consumers to tailor the Angie widget to their integration needs.

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add configurable container ID, CSS injection control, and widget customization options to Angie SDK for enhanced UI flexibility and integration control.

Main changes:
- Introduced configurable container ID support replacing hardcoded 'angie-sidebar-container' throughout codebase with dynamic appState-based lookup
- Added skipDefaultCss option to initAngieSidebar allowing custom CSS injection and widgetConfig parameter for runtime UI customization
- Exported DEFAULT_CONTAINER_ID, WidgetConfig type, and enhanced AngieMcpSdkOptions with new configuration properties for external consumers

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
