### PR TITLE
[AI-6812] Feature: Export McpAppDisplayMode for third-party MCP tools

### DIFF
--- a/docs/tool-annotations.md
+++ b/docs/tool-annotations.md
@@ -196,25 +196,18 @@ interface AngieToolUiMeta {
 import { McpAppDisplayMode, AngieToolMeta } from '@elementor/angie-sdk';
 
 server.registerTool(
-  'ask-user-questions',
+  'apply-to-site',
   {
-    description: 'Displays a questionnaire to collect user input',
+    description: 'Applies generated code to the site',
     inputSchema: { /* ... */ },
     _meta: {
       ui: {
-        displayMode: McpAppDisplayMode.Inline
+        resourceUri: 'ui://apply-to-site/preview.html',
+        displayMode: McpAppDisplayMode.EndOfTurn
       }
     } as AngieToolMeta,
   },
-  async (args) => {
-    return {
-      content: [{
-        type: 'html',
-        content: '<form>...</form>',
-        title: 'User Questions'
-      }]
-    };
-  }
+  async (args) => { /* handler */ }
 );
 ```
 

--- a/docs/tool-annotations.md
+++ b/docs/tool-annotations.md
@@ -26,6 +26,7 @@ The MCP protocol distinguishes between two types of tool metadata:
 | `ANGIE_REQUIRED_RESOURCES` | `'angie/requiredResources'` | Declare resources the tool needs |
 | `ANGIE_MODEL_PREFERENCES` | `'angie/modelPreferences'` | Request a specific AI model |
 | `ANGIE_EXTENDED_TIMEOUT` | `'angie/extendedTimeout'` | Request a longer execution timeout |
+| `ui` | `AngieToolUiMeta` | Configure UI display behavior for MCP apps |
 
 ---
 
@@ -161,6 +162,59 @@ server.registerTool(
     } as AngieToolMeta,
   },
   async (args) => { /* handler */ }
+);
+```
+
+---
+
+## `ui` (MCP App Display Configuration)
+
+Configure how MCP app UI content is displayed in the Angie chat interface.
+
+```typescript
+enum McpAppDisplayMode {
+  Inline = 'inline',        // Show immediately, agentic loop continues in parallel
+  EndOfTurn = 'end-of-turn' // Queue and show after agentic loop completes
+}
+
+interface AngieToolUiMeta {
+  resourceUri?: string;          // URI to load UI content from
+  displayMode?: McpAppDisplayMode; // When to display the UI (default: Inline)
+}
+```
+
+### Display Modes
+
+| Mode | Behavior |
+|---|---|
+| `Inline` (default) | UI appears immediately when the tool returns. The agentic loop continues in parallel. |
+| `EndOfTurn` | UI is queued and displayed after the entire agentic turn completes. |
+
+**Example:**
+
+```typescript
+import { McpAppDisplayMode, AngieToolMeta } from '@elementor/angie-sdk';
+
+server.registerTool(
+  'ask-user-questions',
+  {
+    description: 'Displays a questionnaire to collect user input',
+    inputSchema: { /* ... */ },
+    _meta: {
+      ui: {
+        displayMode: McpAppDisplayMode.Inline
+      }
+    } as AngieToolMeta,
+  },
+  async (args) => {
+    return {
+      content: [{
+        type: 'html',
+        content: '<form>...</form>',
+        title: 'User Questions'
+      }]
+    };
+  }
 );
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.4.2",
+      "version": "1.4.3",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-annotations.ts
+++ b/src/angie-annotations.ts
@@ -3,6 +3,11 @@ export const ANGIE_MODEL_PREFERENCES = 'angie/modelPreferences' as const;
 export const ANGIE_EXTENDED_TIMEOUT = 'angie/extendedTimeout' as const;
 export const MCP_READONLY = 'readOnlyHint' as const;
 
+export enum McpAppDisplayMode {
+	Inline = 'inline',
+	EndOfTurn = 'end-of-turn',
+}
+
 export interface AngieRequiredResource {
 	uri: string;
 	whenToUse: string;
@@ -20,6 +25,11 @@ export interface AngieExtendedTimeout {
 	timeoutMs: number;
 }
 
+export interface AngieToolUiMeta {
+	resourceUri?: string;
+	displayMode?: McpAppDisplayMode;
+}
+
 /**
  * Custom Angie metadata to be placed in the `_meta` field of a tool.
  * These are vendor-specific extensions and should NOT be placed in `annotations`.
@@ -32,6 +42,7 @@ export interface AngieExtendedTimeout {
  *   _meta: {
  *     [ANGIE_REQUIRED_RESOURCES]: [{ uri: 'resource://...', whenToUse: '...' }],
  *     [ANGIE_MODEL_PREFERENCES]: { intelligencePriority: 0.8 },
+ *     ui: { displayMode: McpAppDisplayMode.Inline },
  *   }
  * }, handler);
  */
@@ -39,6 +50,7 @@ export interface AngieToolMeta {
 	[ANGIE_REQUIRED_RESOURCES]?: AngieRequiredResource[];
 	[ANGIE_MODEL_PREFERENCES]?: AngieModelPreferences;
 	[ANGIE_EXTENDED_TIMEOUT]?: AngieExtendedTimeout;
+	ui?: AngieToolUiMeta;
 }
 
 /**

--- a/src/angie-annotations.ts
+++ b/src/angie-annotations.ts
@@ -42,7 +42,7 @@ export interface AngieToolUiMeta {
  *   _meta: {
  *     [ANGIE_REQUIRED_RESOURCES]: [{ uri: 'resource://...', whenToUse: '...' }],
  *     [ANGIE_MODEL_PREFERENCES]: { intelligencePriority: 0.8 },
- *     ui: { displayMode: McpAppDisplayMode.Inline },
+ *     ui: { resourceUri: 'ui://...', displayMode: McpAppDisplayMode.Inline },
  *   }
  * }, handler);
  */


### PR DESCRIPTION
## Problem
Third-party MCP tool developers cannot control when their UI content is displayed in the Angie chat interface. The `McpAppDisplayMode` enum was only available internally.

## Solution
Export `McpAppDisplayMode` enum and `AngieToolUiMeta` interface from `@elementor/angie-sdk` so third-party developers can:
- Set `displayMode: McpAppDisplayMode.Inline` to show UI immediately
- Set `displayMode: McpAppDisplayMode.EndOfTurn` to queue UI until agentic loop completes

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Export McpAppDisplayMode enum and AngieToolUiMeta interface to enable third-party MCP tools to configure UI display behavior in Angie chat interface.

Main changes:
- Added McpAppDisplayMode enum with Inline and EndOfTurn options to control when UI content appears
- Extended AngieToolMeta interface with ui field for configuring resourceUri and displayMode settings
- Updated documentation with usage examples and display mode behavior specifications for MCP app integration

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
