### PR TITLE
[AI-6222] Add newChat and autoSend options to SDK trigger API

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -546,4 +546,143 @@ describe('AngieMcpSdk', () => {
       expect(mockPostMessageToAngieIframe).not.toHaveBeenCalled();
     });
   });
+
+  describe('parseHashParams', () => {
+    it('should parse prompt from hash', () => {
+      const params = (sdk as any).parseHashParams('#angie-prompt=Hello%20world');
+      expect(params.get('angie-prompt')).toBe('Hello world');
+    });
+
+    it('should parse prompt with newChat and autoSend', () => {
+      const params = (sdk as any).parseHashParams('#angie-prompt=Fix%20error&angie-newChat=true&angie-autoSend=true');
+      expect(params.get('angie-prompt')).toBe('Fix error');
+      expect(params.get('angie-newChat')).toBe('true');
+      expect(params.get('angie-autoSend')).toBe('true');
+    });
+
+    it('should return null for missing params', () => {
+      const params = (sdk as any).parseHashParams('#angie-prompt=Hello');
+      expect(params.get('angie-newChat')).toBeNull();
+      expect(params.get('angie-autoSend')).toBeNull();
+    });
+
+    it('should handle hash without # prefix', () => {
+      const params = (sdk as any).parseHashParams('angie-prompt=Test');
+      expect(params.get('angie-prompt')).toBe('Test');
+    });
+  });
+
+  describe('handlePromptHash', () => {
+    let postMessageSpy: ReturnType<typeof jest.spyOn>;
+
+    beforeEach(() => {
+      postMessageSpy = jest.spyOn(window, 'postMessage').mockImplementation((message: any) => {
+        if (message?.type === 'sdk-trigger-angie') {
+          const responseEvent = new MessageEvent('message', {
+            data: {
+              type: 'sdk-trigger-angie-response',
+              payload: {
+                success: true,
+                requestId: message.payload.requestId,
+                response: 'Triggered',
+              },
+            },
+          });
+          window.dispatchEvent(responseEvent);
+        }
+      });
+      mockAngieDetector.isReady.mockReturnValue(true);
+      mockAngieDetector.waitForReady.mockResolvedValue({ isReady: true });
+      (sdk as any).isInitialized = true;
+    });
+
+    afterEach(() => {
+      window.location.hash = '';
+      postMessageSpy.mockRestore();
+    });
+
+    it('should do nothing when hash has no angie-prompt', async () => {
+      window.location.hash = '#other-param=value';
+
+      await (sdk as any).handlePromptHash();
+
+      expect(postMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should do nothing for empty prompt', async () => {
+      window.location.hash = '#angie-prompt=';
+
+      await (sdk as any).handlePromptHash();
+
+      expect(postMessageSpy).not.toHaveBeenCalled();
+    });
+
+    it('should trigger with newChat=true and autoSend=true when params are set', async () => {
+      window.location.hash = '#angie-prompt=Fix%20error&angie-newChat=true&angie-autoSend=true';
+
+      await (sdk as any).handlePromptHash();
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'sdk-trigger-angie',
+          payload: expect.objectContaining({
+            prompt: 'Fix error',
+            options: expect.objectContaining({
+              newChat: true,
+              autoSend: true,
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should default newChat and autoSend to false when not in hash', async () => {
+      window.location.hash = '#angie-prompt=Just%20a%20prompt';
+
+      await (sdk as any).handlePromptHash();
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'sdk-trigger-angie',
+          payload: expect.objectContaining({
+            prompt: 'Just a prompt',
+            options: expect.objectContaining({
+              newChat: false,
+              autoSend: false,
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should support newChat=true without autoSend', async () => {
+      window.location.hash = '#angie-prompt=Hello&angie-newChat=true';
+
+      await (sdk as any).handlePromptHash();
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'sdk-trigger-angie',
+          payload: expect.objectContaining({
+            prompt: 'Hello',
+            options: expect.objectContaining({
+              newChat: true,
+              autoSend: false,
+            }),
+          }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should clear hash after successful trigger', async () => {
+      window.location.hash = '#angie-prompt=Test&angie-newChat=true&angie-autoSend=true';
+
+      await (sdk as any).handlePromptHash();
+
+      expect(window.location.hash).toBe('');
+    });
+  });
 }); 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -12,6 +12,11 @@ import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerCon
 
 export { DEFAULT_CONTAINER_ID } from './config';
 
+const HASH_PARAM_PROMPT = 'angie-prompt';
+const HASH_PARAM_NEW_CHAT = 'angie-newChat';
+const HASH_PARAM_AUTO_SEND = 'angie-autoSend';
+const HASH_SOURCE = 'hash-parameter';
+
 type FeatureToggle = { enabled: boolean };
 
 type PromptSuggestion = { label: string; value: string };
@@ -382,32 +387,44 @@ export class AngieMcpSdk {
     return `${this.instanceId}-${Date.now()}-${Math.random().toString(36).substring(2, 8)}`;
   }
 
+  private parseHashParams(hash: string): URLSearchParams {
+    const paramString = hash.startsWith('#') ? hash.substring(1) : hash;
+    return new URLSearchParams(paramString);
+  }
+
   private async handlePromptHash(): Promise<void> {
     const hash = window.location.hash;
 
-    if (!hash.startsWith('#angie-prompt=')) {
+    if (!hash.includes(`${HASH_PARAM_PROMPT}=`)) {
       return;
     }
 
     try {
-      const promptEncoded = hash.replace('#angie-prompt=', '');
-      const prompt = decodeURIComponent(promptEncoded);
+      const params = this.parseHashParams(hash);
+      const prompt = params.get(HASH_PARAM_PROMPT) || '';
 
       if (!prompt) {
         this.logger.warn('Empty prompt detected in hash');
         return;
       }
 
-      this.logger.log('Detected prompt in hash:', prompt);
+      const newChat = params.get(HASH_PARAM_NEW_CHAT) === 'true';
+      const autoSend = params.get(HASH_PARAM_AUTO_SEND) === 'true';
+
+      this.logger.log('Detected prompt in hash:', { prompt, newChat, autoSend });
 
       await this.waitForReady();
 
       const response = await this.triggerAngie({
         prompt,
         context: {
-          source: 'hash-parameter',
+          source: HASH_SOURCE,
           pageUrl: window.location.href,
           timestamp: new Date().toISOString(),
+        },
+        options: {
+          newChat,
+          autoSend,
         },
       });
 

--- a/src/iframe.test.ts
+++ b/src/iframe.test.ts
@@ -24,7 +24,7 @@ describe( 'disableNavigationPrevention', () => {
 		
 		global.setTimeout = jest.fn( ( callback: () => void ) => {
 			callback();
-			return 0 as unknown as NodeJS.Timeout;
+			return 0 as unknown as ReturnType<typeof setTimeout>;
 		} ) as unknown as typeof setTimeout;
 
 		mockContentWindow = {

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -81,7 +81,7 @@ export const listenToSDK = ( appState: AppState ) => {
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 
 				try {
-					const { requestId, prompt, context } = event.data.payload;
+					const { requestId, prompt, context, options } = event.data.payload;
 
 					if ( appState.iframe ) {
 						appState.iframe.contentWindow?.postMessage( {
@@ -90,6 +90,7 @@ export const listenToSDK = ( appState: AppState ) => {
 								requestId,
 								prompt,
 								context,
+								options,
 							},
 						}, appState.iframeUrlObject?.origin || '' );
 					} else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,8 @@ export interface AngieTriggerRequest {
   }& Record<string, any>;
   options?: {
     timeout?: number;
+    newChat?: boolean;
+    autoSend?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary
- Parse `angie-newChat=true` and `angie-autoSend=true` hash params in `handlePromptHash` using proper `URLSearchParams` parsing
- Add `newChat` and `autoSend` to `AngieTriggerRequest.options` and forward through the postMessage bridge to the iframe
- Backward-compatible: defaults to `false` when params are absent

## Changes
- `src/types.ts`: Add `newChat?: boolean` and `autoSend?: boolean` to `options`
- `src/angie-mcp-sdk.ts`: Refactor hash parsing with `parseHashParams()`, pass `options.newChat`/`options.autoSend` to `triggerAngie`
- `src/sdk.ts`: Forward `options` in `SDK_TRIGGER_ANGIE` payload to iframe
- `src/angie-mcp-sdk.test.ts`: Tests for hash parsing and trigger with newChat/autoSend

## Test plan
- [x] `npx jest` — all 140 tests pass
- [ ] Manual: navigate to `wp-admin#angie-prompt=Fix%20error&angie-newChat=true&angie-autoSend=true` — verify new chat opens and prompt auto-sends

## Notes
Supersedes #24 — this approach keeps `newChat`/`autoSend` under `options` (alongside `timeout`) rather than top-level, and adds `autoSend` support.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

**Jira**: AI-6222

Extends the SDK trigger API to support starting new chat sessions and auto-sending prompts. Previously, hash-based triggers could only populate the input field; now they can optionally clear context (newChat) and immediately submit (autoSend). This enables deep-linking workflows where external systems can fully automate Angie interactions, not just pre-fill prompts.

## 2. What Changed (Where)

- **`angie-mcp-sdk.ts`**: Added `newChat` and `autoSend` hash parameter parsing; refactored `handlePromptHash()` to use `URLSearchParams` instead of string replacement
- **`types.ts`**: Extended `AngieTriggerRequest.options` interface with `newChat` and `autoSend` boolean fields
- **`sdk.ts`**: Updated message relay to forward `options` object to iframe
- **`angie-mcp-sdk.test.ts`**: Added comprehensive test coverage for new hash parsing logic and parameter combinations
- **`iframe.test.ts`**: Fixed `setTimeout` return type for Node compatibility (unrelated cleanup)

## 3. How It Works

Hash parameters (`#angie-prompt=X&angie-newChat=true&angie-autoSend=true`) are parsed via `URLSearchParams`. The `handlePromptHash()` method extracts prompt + flags, then passes them through the existing `triggerAngie()` flow. The `options` object propagates from SDK → parent window → iframe message payload. Defaults to `false` for both flags when omitted, preserving backward compatibility with existing `#angie-prompt=X` URLs.

## 4. Risks

None. Additive change with defensive defaults. Existing integrations unaffected since new parameters are optional and default to `false`. Test coverage validates all combinations (both flags, one flag, no flags, empty prompt).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
