### PR TITLE
[AI-6222] Remove autoSend option from SDK trigger API

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -553,17 +553,15 @@ describe('AngieMcpSdk', () => {
       expect(params.get('angie-prompt')).toBe('Hello world');
     });
 
-    it('should parse prompt with newChat and autoSend', () => {
-      const params = (sdk as any).parseHashParams('#angie-prompt=Fix%20error&angie-newChat=true&angie-autoSend=true');
+    it('should parse prompt with newChat', () => {
+      const params = (sdk as any).parseHashParams('#angie-prompt=Fix%20error&angie-newChat=true');
       expect(params.get('angie-prompt')).toBe('Fix error');
       expect(params.get('angie-newChat')).toBe('true');
-      expect(params.get('angie-autoSend')).toBe('true');
     });
 
     it('should return null for missing params', () => {
       const params = (sdk as any).parseHashParams('#angie-prompt=Hello');
       expect(params.get('angie-newChat')).toBeNull();
-      expect(params.get('angie-autoSend')).toBeNull();
     });
 
     it('should handle hash without # prefix', () => {
@@ -617,8 +615,8 @@ describe('AngieMcpSdk', () => {
       expect(postMessageSpy).not.toHaveBeenCalled();
     });
 
-    it('should trigger with newChat=true and autoSend=true when params are set', async () => {
-      window.location.hash = '#angie-prompt=Fix%20error&angie-newChat=true&angie-autoSend=true';
+    it('should trigger with newChat=true when param is set', async () => {
+      window.location.hash = '#angie-prompt=Fix%20error&angie-newChat=true';
 
       await (sdk as any).handlePromptHash();
 
@@ -629,7 +627,6 @@ describe('AngieMcpSdk', () => {
             prompt: 'Fix error',
             options: expect.objectContaining({
               newChat: true,
-              autoSend: true,
             }),
           }),
         }),
@@ -637,7 +634,7 @@ describe('AngieMcpSdk', () => {
       );
     });
 
-    it('should default newChat and autoSend to false when not in hash', async () => {
+    it('should default newChat to false when not in hash', async () => {
       window.location.hash = '#angie-prompt=Just%20a%20prompt';
 
       await (sdk as any).handlePromptHash();
@@ -649,27 +646,6 @@ describe('AngieMcpSdk', () => {
             prompt: 'Just a prompt',
             options: expect.objectContaining({
               newChat: false,
-              autoSend: false,
-            }),
-          }),
-        }),
-        expect.anything()
-      );
-    });
-
-    it('should support newChat=true without autoSend', async () => {
-      window.location.hash = '#angie-prompt=Hello&angie-newChat=true';
-
-      await (sdk as any).handlePromptHash();
-
-      expect(postMessageSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: 'sdk-trigger-angie',
-          payload: expect.objectContaining({
-            prompt: 'Hello',
-            options: expect.objectContaining({
-              newChat: true,
-              autoSend: false,
             }),
           }),
         }),
@@ -678,7 +654,7 @@ describe('AngieMcpSdk', () => {
     });
 
     it('should clear hash after successful trigger', async () => {
-      window.location.hash = '#angie-prompt=Test&angie-newChat=true&angie-autoSend=true';
+      window.location.hash = '#angie-prompt=Test&angie-newChat=true';
 
       await (sdk as any).handlePromptHash();
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -14,7 +14,6 @@ export { DEFAULT_CONTAINER_ID } from './config';
 
 const HASH_PARAM_PROMPT = 'angie-prompt';
 const HASH_PARAM_NEW_CHAT = 'angie-newChat';
-const HASH_PARAM_AUTO_SEND = 'angie-autoSend';
 const HASH_SOURCE = 'hash-parameter';
 
 type FeatureToggle = { enabled: boolean };
@@ -409,9 +408,8 @@ export class AngieMcpSdk {
       }
 
       const newChat = params.get(HASH_PARAM_NEW_CHAT) === 'true';
-      const autoSend = params.get(HASH_PARAM_AUTO_SEND) === 'true';
 
-      this.logger.log('Detected prompt in hash:', { prompt, newChat, autoSend });
+      this.logger.log('Detected prompt in hash:', { prompt, newChat });
 
       await this.waitForReady();
 
@@ -424,7 +422,6 @@ export class AngieMcpSdk {
         },
         options: {
           newChat,
-          autoSend,
         },
       });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,6 @@ export interface AngieTriggerRequest {
   options?: {
     timeout?: number;
     newChat?: boolean;
-    autoSend?: boolean;
   };
 }
 


### PR DESCRIPTION
## Summary
- Remove `autoSend` from `AngieTriggerRequest.options` — when `newChat` is `true`, the prompt is always auto-sent after the new chat loads
- Remove `HASH_PARAM_AUTO_SEND` constant and hash parameter parsing for `angie-autoSend`
- Simplifies the API surface by removing a flag that was always coupled with `newChat`

## Test plan
- [x] All 139 SDK tests pass
- [ ] Verify `#angie-prompt=Fix%20error&angie-newChat=true` triggers new chat + auto-send
- [ ] Verify `#angie-prompt=Hello` just sets input text (no new chat)


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Removing unused `autoSend` option from the SDK's trigger API (Jira: AI-6222). The feature was exposed through URL hash parameters and the TypeScript interface but apparently never used or needed. Simplifies the API surface and reduces cognitive load.

## 2. What Changed (Where)

- `src/types.ts`: Removed `autoSend` property from `AngieTriggerRequest.options` interface
- `src/angie-mcp-sdk.ts`: Removed `HASH_PARAM_AUTO_SEND` constant and its parsing/usage in `handlePromptHash()`
- `src/angie-mcp-sdk.test.ts`: Updated tests to remove `autoSend` assertions and consolidated test cases

## 3. How It Works

Hash parameter parsing now only extracts `angie-prompt` and `angie-newChat` from URL. The `triggerAngie()` method continues working identically but no longer accepts or forwards the `autoSend` option to the MCP server. Tests verify both single-parameter and multi-parameter cases still work correctly.

## 4. Risks

None. This is pure removal of an option. If downstream consumers were using `autoSend`, they'll get TypeScript errors immediately. Runtime behavior unchanged for existing valid uses of `newChat` and prompt triggers.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
