### PR TITLE
[AI-6222] Use kebab-case for hash parameter: angie-new-chat

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -553,15 +553,15 @@ describe('AngieMcpSdk', () => {
       expect(params.get('angie-prompt')).toBe('Hello world');
     });
 
-    it('should parse prompt with newChat', () => {
-      const params = (sdk as any).parseHashParams('#angie-prompt=Fix%20error&angie-newChat=true');
+    it('should parse prompt with new-chat', () => {
+      const params = (sdk as any).parseHashParams('#angie-prompt=Fix%20error&angie-new-chat=true');
       expect(params.get('angie-prompt')).toBe('Fix error');
-      expect(params.get('angie-newChat')).toBe('true');
+      expect(params.get('angie-new-chat')).toBe('true');
     });
 
     it('should return null for missing params', () => {
       const params = (sdk as any).parseHashParams('#angie-prompt=Hello');
-      expect(params.get('angie-newChat')).toBeNull();
+      expect(params.get('angie-new-chat')).toBeNull();
     });
 
     it('should handle hash without # prefix', () => {
@@ -616,7 +616,7 @@ describe('AngieMcpSdk', () => {
     });
 
     it('should trigger with newChat=true when param is set', async () => {
-      window.location.hash = '#angie-prompt=Fix%20error&angie-newChat=true';
+      window.location.hash = '#angie-prompt=Fix%20error&angie-new-chat=true';
 
       await (sdk as any).handlePromptHash();
 
@@ -654,7 +654,7 @@ describe('AngieMcpSdk', () => {
     });
 
     it('should clear hash after successful trigger', async () => {
-      window.location.hash = '#angie-prompt=Test&angie-newChat=true';
+      window.location.hash = '#angie-prompt=Test&angie-new-chat=true';
 
       await (sdk as any).handlePromptHash();
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -13,7 +13,7 @@ import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerCon
 export { DEFAULT_CONTAINER_ID } from './config';
 
 const HASH_PARAM_PROMPT = 'angie-prompt';
-const HASH_PARAM_NEW_CHAT = 'angie-newChat';
+const HASH_PARAM_NEW_CHAT = 'angie-new-chat';
 const HASH_SOURCE = 'hash-parameter';
 
 type FeatureToggle = { enabled: boolean };


### PR DESCRIPTION
## Summary
- Rename `angie-newChat` hash parameter to `angie-new-chat` for consistency with the existing `angie-prompt` naming convention
- Update constant, hash parsing, and all related tests

## Test plan
- [x] All 139 SDK tests pass
- [ ] Verify `#angie-prompt=Fix%20error&angie-new-chat=true` triggers new chat


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

URL hash parameters need consistent naming conventions. `angie-newChat` mixed camelCase with kebab-case prefix, breaking convention. Standardized to `angie-new-chat` for consistency across the SDK's hash parameter API. [AI-6222]

## 2. What Changed (Where)

- **src/angie-mcp-sdk.ts**: Updated constant from `angie-newChat` to `angie-new-chat`
- **src/angie-mcp-sdk.test.ts**: Updated test assertions and mock hash strings to use kebab-case parameter

## 3. How It Works

Direct string constant swap. Hash parsing logic remains unchanged — just consuming the new parameter name. All test cases updated to validate the new format (`angie-new-chat=true` instead of `angie-newChat=true`).

## 4. Risks

Breaking change for any existing URLs in bookmarks, docs, or external integrations using `angie-newChat`. Coordination needed if parameter is documented or in production use.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[AI-6222]: https://elementor.atlassian.net/browse/AI-6222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ