### PR TITLE
[AI-6222] Document newChat option and angie-new-chat hash parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ await sdk.triggerAngie({
 
 **Options:**
 - `timeout`: How long to wait for Angie response (milliseconds)  
-- `priority`: Request priority level
+- `newChat`: When `true`, clears the current conversation and opens a fresh chat with the prompt pre-filled in the input
 - `context`: Additional data to help Angie understand the request
 
 ### Hash Parameter Method
@@ -221,8 +221,15 @@ await sdk.triggerAngie({
 // Trigger via URL hash - perfect for deep linking
 window.location.hash = 'angie-prompt=' + encodeURIComponent('Help me create a contact page');
 
-// Or visit URLs like: https://yoursite.com/wp-admin/edit.php#angie-prompt=Help%20me%20optimize%20SEO
+// Open a new chat via hash parameter
+window.location.hash = 'angie-prompt=' + encodeURIComponent('Fix this error') + '&angie-new-chat=true';
+
+// Example URL: https://yoursite.com/wp-admin/edit.php#angie-prompt=Help%20me%20optimize%20SEO&angie-new-chat=true
 ```
+
+**Hash Parameters:**
+- `angie-prompt`: The prompt text to populate in the input field
+- `angie-new-chat`: When set to `true`, clears the current conversation and opens a fresh chat with the prompt pre-filled in the input
 
 **Note:** Always call `await sdk.waitForReady()` before triggering Angie.
 

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ await sdk.triggerAngie({
 
 **Options:**
 - `timeout`: How long to wait for Angie response (milliseconds)  
-- `newChat`: When `true`, clears the current conversation and opens a fresh chat with the prompt pre-filled in the input
+- `angie-new-chat`: When `true`, clears the current conversation and opens a fresh chat with the prompt pre-filled in the input
 - `context`: Additional data to help Angie understand the request
 
 ### Hash Parameter Method


### PR DESCRIPTION
## Summary
- Document `newChat` option in `triggerAngie` API examples
- Add `&angie-new-chat=true` hash parameter usage to docs
- Fix stale `priority` option reference in README

## Test plan
- [ ] Verify README renders correctly on GitHub

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Developers couldn't discover the `angie-new-chat` parameter for clearing conversation context when triggering Angie. Documentation lacked examples for deep-linking with fresh chat sessions. This closes **AI-6222**.

## 2. What Changed (Where)

- **README.md**: Added `angie-new-chat` option to both SDK method and hash parameter sections, replaced stale `priority` option documentation with actual functionality.

## 3. How It Works

The `angie-new-chat=true` parameter (SDK or URL hash) clears conversation history before populating the prompt input. Works alongside existing `angie-prompt` parameter for deep-linking scenarios where context isolation is needed.

## 4. Risks

None — pure documentation change with no code modifications.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->


[AI-6222]: https://elementor.atlassian.net/browse/AI-6222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ