### PR TITLE
[AI-7207] Fix: Can't run SDK locally

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,10 @@ const baseConfig = {
   mode: 'production',
   optimization: {
     minimize: true,
+    // Single output file: inlined CSS via raw-loader; split chunks would leave
+    // ./sidebar.js importing ./sidebar.css (breaks Next and other consumers).
+    splitChunks: false,
+    runtimeChunk: false,
   },
 };
 


### PR DESCRIPTION
Update webpack configuration to disable splitChunks and runtimeChunk for single output file handling, ensuring compatibility with local Next.js and other consumers.

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Local SDK builds were broken because webpack's default chunk splitting creates separate CSS files that Next.js and other bundler-based consumers can't resolve. The `sidebar.js` would try to import `sidebar.css` at runtime, causing module resolution failures in downstream projects.

## 2. What Changed (Where)

- `webpack.config.js`: Disabled `splitChunks` and `runtimeChunk` optimizations to force single-file output

## 3. How It Works

Webpack now inlines all CSS via raw-loader into a single output bundle instead of code-splitting. Consumers get one self-contained file without external CSS dependencies that would fail module resolution in their own build pipelines.

## 4. Risks

None. This trades marginal bundle size optimization for compatibility — acceptable for an SDK distribution where integration reliability trumps a few KB.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
