### PR TITLE
Bump version to 1.4.6 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.4.5",
+      "version": "1.4.6",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.5",
+  "version": "1.4.6",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,10 @@ const baseConfig = {
   mode: 'production',
   optimization: {
     minimize: true,
+    // Single output file: inlined CSS via raw-loader; split chunks would leave
+    // ./sidebar.js importing ./sidebar.css (breaks Next and other consumers).
+    splitChunks: false,
+    runtimeChunk: false,
   },
 };
 


### PR DESCRIPTION
### Changelog

#### Fixes
- Fix: Can't run SDK locally ([#35](https://github.com/elementor/angie-sdk/pull/35))

#### Improvements
- Use kebab-case for hash parameter: `angie-new-chat` ([#33](https://github.com/elementor/angie-sdk/pull/33))

#### Changes
- Remove `autoSend` option from SDK trigger API ([#32](https://github.com/elementor/angie-sdk/pull/32))

#### Features
- Add `newChat` and `autoSend` options to SDK trigger API ([#31](https://github.com/elementor/angie-sdk/pull/31))
- Document `newChat` option and `angie-new-chat` hash parameter ([#34](https://github.com/elementor/angie-sdk/pull/34))