### PR TITLE
[AI-8148] chore: refuse install of npm packages younger than 7 days

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,14 @@
+# Supply-chain hardening: disable lifecycle scripts during install.
+# Mitigates Shai-Hulud / TanStack-style worms (GHSA-g7cv-rxg3-hmpx, 2026-05-11)
+# that propagate via `postinstall`. If a dep legitimately needs scripts:
+#   npm rebuild <pkg> --foreground-scripts
+ignore-scripts=true
+
+# Refuse to install package versions younger than 7 days (npm >= 11.10.0).
+# Mitigates fresh-malicious-publish supply-chain attacks. Emergency bypass:
+#   npm install <pkg> --min-release-age=0
+# Older npm versions silently ignore this flag.
+min-release-age=7
+
+audit-level=moderate
+fund=false


### PR DESCRIPTION
## Summary

Add `min-release-age=7` and `ignore-scripts=true` to `.npmrc` to harden the repo against fresh-publish npm supply-chain attacks (Shai-Hulud / TanStack-class worms — e.g. [GHSA-g7cv-rxg3-hmpx](https://github.com/TanStack/router/security/advisories/GHSA-g7cv-rxg3-hmpx)).

## What changed (where)

- `.npmrc` (new file):
  - `min-release-age=7` — refuses to install any package version (transitive included) published <7 days ago. Native npm flag since v11.10.0 (Feb 2026); silently ignored on older npm.
  - `ignore-scripts=true` — neutralizes the postinstall RCE vector most worms rely on. If a dep legitimately needs scripts: `npm rebuild <pkg> --foreground-scripts`.
  - Minor: `audit-level=moderate`, `fund=false`.

## How it works

`min-release-age` is sugar for `--before=<today-N-days>`, applied at manifest-fetch time. Lockfile entries pass through unchanged, so `npm ci` in CI is unaffected. Only fresh resolutions (`npm install <pkg>@new`, `npm install` after editing `package.json`) are gated.

Emergency bypass: `npm install <pkg> --min-release-age=0`.

## Risks

- Devs on npm <11.10.0 get no enforcement (silent no-op). Effective gate kicks in once they upgrade.
- `ignore-scripts=true` could break deps that need native binary install (sharp, puppeteer, etc.). Verified clean on this repo's 618-package install.

## Test plan

- [x] `npm ci` succeeds with new `.npmrc` on a copy of this repo (618 packages, exit 0)
- [x] Empirically verified gate: `vite@8.0.12` (1d old) rejected; `lodash@4.17.21` accepted
- [ ] CI matrix (Node 16/18/20) passes — relies on `npm ci` lockfile path, gate doesn't fire

Made with [Cursor](https://cursor.com)