### PR TITLE
[AI-7839] Feature: Disable tools when loaded in my.elementor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.6",
+  "version": "1.4.7",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -35,6 +35,10 @@ export type WidgetConfig = {
   featuredMcpServer?: string;
   modeSwitcher?: ModeSwitcherConfig;
   closeButton?: 'collapse' | 'close';
+  betaBanner?: FeatureToggle;
+  aiContextGuidance?: FeatureToggle;
+  userProfileMenu?: FeatureToggle;
+  isEmbeddedMode?: boolean;
 };
 
 export type AngieMcpSdkOptions = {


### PR DESCRIPTION
## Problem
When Angie loads inside my.elementor, users still see tools and UI elements meant for the full admin experience.

## Solution
Expose widget config options (embedded mode, beta banner, AI context guidance, user profile menu) so hosts can disable them via the SDK.

Jira: https://elementor.atlassian.net/browse/AI-7839

Made with [Cursor](https://cursor.com)