### PR TITLE
[AI-7839] Improve: Replace isEmbeddedMode with skipLoadingServers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.6",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -38,7 +38,7 @@ export type WidgetConfig = {
   betaBanner?: FeatureToggle;
   aiContextGuidance?: FeatureToggle;
   userProfileMenu?: FeatureToggle;
-  isEmbeddedMode?: boolean;
+  skipLoadingServers?: boolean;
 };
 
 export type AngieMcpSdkOptions = {


### PR DESCRIPTION
## Problem
Hosts embedding Angie in my.elementor need to disable MCP server loading, but the `isEmbeddedMode` flag did not clearly express that behavior.

## Solution
Rename the widget config option to `skipLoadingServers` and release SDK v1.4.8.

Jira: https://elementor.atlassian.net/browse/AI-7839

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Replacing `isEmbeddedMode` with `skipLoadingServers` provides clearer intent—the config now explicitly controls server loading behavior rather than implying a broader "embedded" mode context.

## 2. What Changed (Where)

- `src/angie-mcp-sdk.ts`: Swapped `isEmbeddedMode` for `skipLoadingServers` in `WidgetConfig` type
- `package.json`: Version bump to 1.4.8

## 3. How It Works

`skipLoadingServers` is a boolean flag in `WidgetConfig` that consumers pass during SDK initialization to control whether the widget loads available MCP servers. This is a direct semantic replacement with no behavioral changes—just renamed for clarity.

## 4. Risks

**Backward compatibility**: Existing consumers using `isEmbeddedMode` will break. Mitigation: Ship as minor version bump (1.4.8) and document migration path.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
