### PR TITLE
Improve: localServers object for WidgetConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.7",
+  "version": "1.4.8",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -25,6 +25,10 @@ export type ModeSwitcherConfig = {
   default?: 'agent' | 'plan' | 'ask';
 };
 
+export type LocalServersConfig = {
+  skipLoading?: boolean;
+};
+
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -38,7 +42,7 @@ export type WidgetConfig = {
   betaBanner?: FeatureToggle;
   aiContextGuidance?: FeatureToggle;
   userProfileMenu?: FeatureToggle;
-  skipLoadingServers?: boolean;
+  localServers?: LocalServersConfig;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -39,6 +39,8 @@ export type WidgetConfig = {
   featuredMcpServer?: string;
   modeSwitcher?: ModeSwitcherConfig;
   closeButton?: 'collapse' | 'close';
+  commands?: FeatureToggle;
+  testMode?: FeatureToggle;
   betaBanner?: FeatureToggle;
   aiContextGuidance?: FeatureToggle;
   userProfileMenu?: FeatureToggle;


### PR DESCRIPTION
## Problem
Hosts embedding Angie need a clear way to skip loading MCP servers, but a flat `skipLoadingServers` flag is awkward to extend.

## Solution
Replace it with `localServers.skipLoading` on widget config and release SDK v1.4.8.