### PR TITLE
[AI-8410] Feature: Host apps can load Angie sidebar with v2 config

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -21,6 +21,9 @@ jest.mock('./iframe', () => ({
     SDK_ANGIE_REFRESH_PING: 'sdk-angie-refresh-ping',
   },
 }));
+jest.mock('./load-sidebar-v2/boot-sidebar', () => ({
+  bootSidebar: jest.fn( () => Promise.resolve() ),
+}));
 
 describe('AngieMcpSdk', () => {
   let sdk: AngieMcpSdk;
@@ -544,6 +547,22 @@ describe('AngieMcpSdk', () => {
 
       // Assert
       expect(mockPostMessageToAngieIframe).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loadSidebarV2', () => {
+    it('should delegate to bootSidebar', async () => {
+      const mockBootSidebar = require('./load-sidebar-v2/boot-sidebar').bootSidebar as jest.MockedFunction<any>;
+      const options = {
+        host: {
+          appId: 'editor-lite',
+        },
+      };
+
+      await sdk.loadSidebarV2( options );
+
+      expect( mockBootSidebar ).toHaveBeenCalledTimes( 1 );
+      expect( mockBootSidebar ).toHaveBeenCalledWith( options );
     });
   });
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -8,6 +8,8 @@ import { createChildLogger } from './logger';
 import { openIframe } from './iframe';
 import { initAngieSidebar } from './sidebar';
 import { RegistrationQueue } from './registration-queue';
+import { bootSidebar } from './load-sidebar-v2/boot-sidebar';
+import type { LoadSidebarV2Options } from './load-sidebar-v2/config';
 import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerConfig, AngieServerConfig, AngieServerType, MessageEventType, ServerRegistration, AngieTriggerRequest, AngieTriggerResponse } from './types';
 
 export { DEFAULT_CONTAINER_ID } from './config';
@@ -100,6 +102,10 @@ export class AngieMcpSdk {
     }
 
     this.setupPromptHashDetection();
+  }
+
+  public async loadSidebarV2( options: LoadSidebarV2Options ): Promise<void> {
+    await bootSidebar( options );
   }
 
   // listen to MessageEventType.SDK_ANGIE_READY_PING

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -8,12 +8,15 @@ import { HostEventType, MessageEventType } from './types';
 import { isMobile, isSafeUrl, sendSuccessMessage, toggleAngieSidebar } from './utils';
 import { ANGIE_SDK_VERSION } from './version';
 import { openSaaSPage } from './openSaaSPage';
+import { setAngieIframeRef } from './angie-iframe-utils';
+import type { HostEmbeddedConfigPayload } from './load-sidebar-v2/config';
 
 type OpenIframeProps = {
 	origin?: string;
 	uiTheme: string;
 	isRTL: boolean;
 	path?: string;
+	hostReadyEmbedded?: HostEmbeddedConfigPayload;
 }
 
 const iframeLogger = createChildLogger( 'iframe' );
@@ -138,13 +141,6 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 
 		// Insert iframe into sidebar
 		sidebarContainer?.appendChild( iframeElement );
-
-		toggleAngieSidebar( iframeElement, true );
-
-		// Focus management after iframe loads
-		iframeElement.addEventListener( 'load', () => {
-			iframeElement.focus();
-		} );
 	};
 
 	// Determine CSS styling based on mode
@@ -160,6 +156,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 		origin: props.origin || 'https://angie.elementor.com',
 		path: props.path && isValidPath( props.path ) ? props.path : DEFAULT_PATH,
 		insertCallback,
+		hostReadyEmbedded: props.hostReadyEmbedded,
 		css: iframeCss,
 		uiTheme: props.uiTheme,
 		isRTL: props.isRTL,
@@ -168,6 +165,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 
 	appState.iframe = iframe;
 	appState.iframeUrlObject = iframeUrlObject;
+	setAngieIframeRef( iframe );
 
 	addLocalStorageListener();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,13 @@
 export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
-export { type LoadSidebarV2Options, type ResolvedConfigV2 } from './load-sidebar-v2/config';
+export {
+	type ChatToggleButtonConfig,
+	type LoadSidebarV2ContainerStyleTheme,
+	type LoadSidebarV2Layout,
+	type LoadSidebarV2Options,
+	type ResolvedConfigV2,
+} from './load-sidebar-v2/config';
+export { FLOATING_CHAT_LAYOUT, FLOATING_CHAT_PRESET_DEFAULTS } from './load-sidebar-v2/presets/floating-chat';
+export { SIDEBAR_LAYOUT, SIDEBAR_PRESET_DEFAULTS } from './load-sidebar-v2/presets/sidebar';
 export { AngieDetector } from './angie-detector';
 export { RegistrationQueue } from './registration-queue';
 export { ClientManager } from './client-manager';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { type LoadSidebarV2Options, type ResolvedConfigV2 } from './load-sidebar-v2/config';
 export { AngieDetector } from './angie-detector';
 export { RegistrationQueue } from './registration-queue';
 export { ClientManager } from './client-manager';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	type ChatToggleButtonConfig,
+	type ExternalHeadersCallback,
 	type LoadSidebarV2ContainerStyleTheme,
 	type LoadSidebarV2Layout,
 	type LoadSidebarV2Options,

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -2,6 +2,10 @@ import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals
 import { bootSidebar } from './boot-sidebar';
 
 jest.mock( '../sidebar', () => ( {
+	ANGIE_SIDEBAR_STATE_CLOSED: 'closed',
+	ANGIE_SIDEBAR_STATE_OPEN: 'open',
+	applyState: jest.fn(),
+	getAngieSidebarSavedState: jest.fn( () => null ),
 	initAngieSidebar: jest.fn(),
 	initializeResize: jest.fn(),
 	loadState: jest.fn(),
@@ -11,18 +15,25 @@ jest.mock( '../iframe', () => ( {
 	openIframe: jest.fn( () => Promise.resolve() ),
 } ) );
 
+jest.mock( './open-embedded-iframe', () => ( {
+	openEmbeddedIframe: jest.fn( () => Promise.resolve() ),
+} ) );
+
 jest.mock( './embedded-handshake', () => ( {
 	buildEmbeddedPayload: jest.fn(),
 	sendEmbeddedConfig: jest.fn(),
+	sendWidgetConfig: jest.fn(),
 } ) );
 
 describe( 'load-sidebar-v2/boot-sidebar', () => {
+	let mockApplyState: jest.Mock;
 	let mockInitAngieSidebar: jest.Mock;
 	let mockLoadState: jest.Mock;
 	let mockInitializeResize: jest.Mock;
-	let mockOpenIframe: jest.Mock;
+	let mockOpenEmbeddedIframe: jest.Mock;
 	let mockBuildEmbeddedPayload: jest.Mock;
 	let mockSendEmbeddedConfig: jest.Mock;
+	let mockSendWidgetConfig: jest.Mock;
 
 	beforeAll( () => {
 		Object.defineProperty( window, 'matchMedia', {
@@ -42,12 +53,16 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 
 	beforeEach( () => {
 		jest.clearAllMocks();
+		document.body.innerHTML = '';
+		document.getElementById( 'angie-chat-widget-styles' )?.remove();
+		mockApplyState = require( '../sidebar' ).applyState as jest.Mock;
 		mockInitAngieSidebar = require( '../sidebar' ).initAngieSidebar as jest.Mock;
 		mockLoadState = require( '../sidebar' ).loadState as jest.Mock;
 		mockInitializeResize = require( '../sidebar' ).initializeResize as jest.Mock;
-		mockOpenIframe = require( '../iframe' ).openIframe as jest.Mock;
+		mockOpenEmbeddedIframe = require( './open-embedded-iframe' ).openEmbeddedIframe as jest.Mock;
 		mockBuildEmbeddedPayload = require( './embedded-handshake' ).buildEmbeddedPayload as jest.Mock;
 		mockSendEmbeddedConfig = require( './embedded-handshake' ).sendEmbeddedConfig as jest.Mock;
+		mockSendWidgetConfig = require( './embedded-handshake' ).sendWidgetConfig as jest.Mock;
 		mockBuildEmbeddedPayload.mockReturnValue( {
 			appId: 'editor-lite',
 			configVersion: 2,
@@ -57,8 +72,8 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 	it( 'should send host config via postMessage after openIframe', async () => {
 		await bootSidebar( {
 			container: {
-				preset: 'sidebar',
-				stylePreset: 'wordpress',
+				layout: 'sidebar',
+				styleTheme: 'wordpress',
 			},
 			host: {
 				appId: 'editor-lite',
@@ -68,9 +83,11 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockBuildEmbeddedPayload ).toHaveBeenCalledWith(
 			expect.objectContaining( { appId: 'editor-lite' } ),
 		);
-		expect( mockOpenIframe ).toHaveBeenCalledWith(
+		expect( mockOpenEmbeddedIframe ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				path: 'angie/embedded',
+				iframe: expect.objectContaining( {
+					path: 'angie/embedded',
+				} ),
 			} ),
 		);
 		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
@@ -82,15 +99,12 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockInitAngieSidebar ).toHaveBeenCalledWith(
 			expect.objectContaining( { skipDefaultCss: false } ),
 		);
-		expect( mockLoadState ).toHaveBeenCalledTimes( 1 );
+		expect( mockLoadState ).toHaveBeenCalledWith( 'open' );
 		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'should send host config for any iframe path', async () => {
 		await bootSidebar( {
-			container: {
-				preset: 'none',
-			},
 			host: {
 				appId: 'editor-lite',
 			},
@@ -99,9 +113,11 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 			},
 		} );
 
-		expect( mockOpenIframe ).toHaveBeenCalledWith(
+		expect( mockOpenEmbeddedIframe ).toHaveBeenCalledWith(
 			expect.objectContaining( {
-				path: 'angie/wp-admin',
+				iframe: expect.objectContaining( {
+					path: 'angie/wp-admin',
+				} ),
 			} ),
 		);
 		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
@@ -113,25 +129,188 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockInitAngieSidebar ).not.toHaveBeenCalled();
 	} );
 
-	it( 'should skip default css when stylePreset is chat', async () => {
+	it( 'should init floating-chat layout without injecting toggle when disabled', async () => {
 		await bootSidebar( {
 			container: {
-				stylePreset: 'chat',
+				chatToggleButton: { enabled: false },
+				layout: 'floating-chat',
 			},
 			host: {
 				appId: 'editor-lite',
 			},
 		} );
 
+		expect( document.getElementById( 'angie-chat-widget-styles' ) ).not.toBeNull();
+		expect( document.getElementById( 'angie-widget-toggle' ) ).toBeNull();
+		expect( mockInitAngieSidebar ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should apply closed state before iframe load when toggle is enabled', async () => {
+		let applyStateCalledBeforeIframe = false;
+
+		mockApplyState.mockImplementation( () => {
+			if ( ! mockOpenEmbeddedIframe.mock.invocationCallOrder.length ) {
+				applyStateCalledBeforeIframe = true;
+			}
+		} );
+
+		await bootSidebar( {
+			container: {
+				chatToggleButton: {
+					enabled: true,
+					id: 'angie-lite-toggle',
+				},
+				layout: 'sidebar',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( mockApplyState ).toHaveBeenCalledWith( 'closed' );
+		expect( applyStateCalledBeforeIframe ).toBe( true );
+		expect( mockOpenEmbeddedIframe ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should init sidebar shell and inject toggle when host button is missing', async () => {
+		jest.useFakeTimers();
+		document.body.innerHTML = '';
+
+		const bootPromise = bootSidebar( {
+			container: {
+				chatToggleButton: {
+					enabled: true,
+					id: 'angie-lite-toggle',
+				},
+				layout: 'sidebar',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		await jest.runAllTimersAsync();
+		await bootPromise;
+		jest.useRealTimers();
+
+		expect( document.getElementById( 'angie-chat-widget-styles' ) ).toBeNull();
+		expect( document.getElementById( 'angie-lite-toggle' ) ).not.toBeNull();
 		expect( mockInitAngieSidebar ).toHaveBeenCalledWith(
 			expect.objectContaining( { skipDefaultCss: true } ),
 		);
+		expect( mockApplyState ).toHaveBeenCalledWith( 'closed' );
+		expect( mockLoadState ).toHaveBeenCalledWith( 'closed' );
+		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
 	} );
 
-	it( 'should create sidebar container when preset is sidebar', async () => {
+	it( 'should init sidebar shell when host toggle is present', async () => {
+		document.body.innerHTML = '';
+
+		const toggle = document.createElement( 'button' );
+		toggle.id = 'angie-lite-toggle';
+		document.body.appendChild( toggle );
+
+		await bootSidebar( {
+			container: {
+				chatToggleButton: {
+					enabled: true,
+					id: 'angie-lite-toggle',
+				},
+				layout: 'sidebar',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( document.getElementById( 'angie-chat-widget-styles' ) ).toBeNull();
+		expect( mockInitAngieSidebar ).toHaveBeenCalledWith(
+			expect.objectContaining( { skipDefaultCss: true } ),
+		);
+		expect( mockApplyState ).toHaveBeenCalledWith( 'closed' );
+		expect( mockLoadState ).toHaveBeenCalledWith( 'closed' );
+		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
+
+		toggle.click();
+		expect( mockInitAngieSidebar ).toHaveBeenCalled();
+	} );
+
+	it( 'should init chat shell when chatToggleButton is enabled', async () => {
 		document.body.innerHTML = '';
 
 		await bootSidebar( {
+			container: {
+				chatToggleButton: { enabled: true },
+				layout: 'floating-chat',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( document.getElementById( 'angie-widget-toggle' ) ).not.toBeNull();
+		expect( document.getElementById( 'angie-chat-widget-styles' ) ).not.toBeNull();
+		expect( mockInitAngieSidebar ).not.toHaveBeenCalled();
+		expect( mockOpenEmbeddedIframe ).toHaveBeenCalled();
+	} );
+
+	it( 'should init chat shell with a custom toggle button id', async () => {
+		document.body.innerHTML = '';
+
+		await bootSidebar( {
+			container: {
+				chatToggleButton: {
+					enabled: true,
+					id: 'angie-lite-toggle',
+				},
+				layout: 'floating-chat',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( document.getElementById( 'angie-lite-toggle' ) ).not.toBeNull();
+		expect( document.getElementById( 'angie-widget-toggle' ) ).toBeNull();
+		expect( mockInitAngieSidebar ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should send close widget config for floating-chat layout by default', async () => {
+		await bootSidebar( {
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( mockSendWidgetConfig ).toHaveBeenCalledWith( {
+			closeButton: 'close',
+		} );
+	} );
+
+	it( 'should send collapse widget config for sidebar layout by default', async () => {
+		await bootSidebar( {
+			container: {
+				layout: 'sidebar',
+				styleTheme: 'wordpress',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( mockSendWidgetConfig ).toHaveBeenCalledWith( {
+			closeButton: 'collapse',
+		} );
+	} );
+
+	it( 'should always create sidebar container', async () => {
+		document.body.innerHTML = '';
+
+		await bootSidebar( {
+			container: {
+				layout: 'sidebar',
+				styleTheme: 'wordpress',
+			},
 			host: {
 				appId: 'editor-lite',
 			},

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -1,0 +1,143 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { bootSidebar } from './boot-sidebar';
+
+jest.mock( '../sidebar', () => ( {
+	initAngieSidebar: jest.fn(),
+	initializeResize: jest.fn(),
+	loadState: jest.fn(),
+} ) );
+
+jest.mock( '../iframe', () => ( {
+	openIframe: jest.fn( () => Promise.resolve() ),
+} ) );
+
+jest.mock( './embedded-handshake', () => ( {
+	buildEmbeddedPayload: jest.fn(),
+	sendEmbeddedConfig: jest.fn(),
+} ) );
+
+describe( 'load-sidebar-v2/boot-sidebar', () => {
+	let mockInitAngieSidebar: jest.Mock;
+	let mockLoadState: jest.Mock;
+	let mockInitializeResize: jest.Mock;
+	let mockOpenIframe: jest.Mock;
+	let mockBuildEmbeddedPayload: jest.Mock;
+	let mockSendEmbeddedConfig: jest.Mock;
+
+	beforeAll( () => {
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query: unknown ) => ( {
+				matches: false,
+				media: String( query ),
+				onchange: null,
+				addListener: jest.fn(),
+				removeListener: jest.fn(),
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+				dispatchEvent: jest.fn(),
+			} ) ),
+		} );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockInitAngieSidebar = require( '../sidebar' ).initAngieSidebar as jest.Mock;
+		mockLoadState = require( '../sidebar' ).loadState as jest.Mock;
+		mockInitializeResize = require( '../sidebar' ).initializeResize as jest.Mock;
+		mockOpenIframe = require( '../iframe' ).openIframe as jest.Mock;
+		mockBuildEmbeddedPayload = require( './embedded-handshake' ).buildEmbeddedPayload as jest.Mock;
+		mockSendEmbeddedConfig = require( './embedded-handshake' ).sendEmbeddedConfig as jest.Mock;
+		mockBuildEmbeddedPayload.mockReturnValue( {
+			appId: 'editor-lite',
+			configVersion: 2,
+		} );
+	} );
+
+	it( 'should send host config via postMessage after openIframe', async () => {
+		await bootSidebar( {
+			container: {
+				preset: 'sidebar',
+				stylePreset: 'wordpress',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( mockBuildEmbeddedPayload ).toHaveBeenCalledWith(
+			expect.objectContaining( { appId: 'editor-lite' } ),
+		);
+		expect( mockOpenIframe ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: 'angie/embedded',
+			} ),
+		);
+		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				appId: 'editor-lite',
+				configVersion: 2,
+			} ),
+		);
+		expect( mockInitAngieSidebar ).toHaveBeenCalledWith(
+			expect.objectContaining( { skipDefaultCss: false } ),
+		);
+		expect( mockLoadState ).toHaveBeenCalledTimes( 1 );
+		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should send host config for any iframe path', async () => {
+		await bootSidebar( {
+			container: {
+				preset: 'none',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+			iframe: {
+				path: 'angie/wp-admin',
+			},
+		} );
+
+		expect( mockOpenIframe ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: 'angie/wp-admin',
+			} ),
+		);
+		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				appId: 'editor-lite',
+				configVersion: 2,
+			} ),
+		);
+		expect( mockInitAngieSidebar ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should skip default css when stylePreset is chat', async () => {
+		await bootSidebar( {
+			container: {
+				stylePreset: 'chat',
+			},
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( mockInitAngieSidebar ).toHaveBeenCalledWith(
+			expect.objectContaining( { skipDefaultCss: true } ),
+		);
+	} );
+
+	it( 'should create sidebar container when preset is sidebar', async () => {
+		document.body.innerHTML = '';
+
+		await bootSidebar( {
+			host: {
+				appId: 'editor-lite',
+			},
+		} );
+
+		expect( document.getElementById( 'angie-sidebar-container' ) ).not.toBeNull();
+		expect( document.getElementById( 'angie-sidebar-loading' ) ).not.toBeNull();
+	} );
+} );

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -158,7 +158,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 			container: {
 				chatToggleButton: {
 					enabled: true,
-					id: 'angie-lite-toggle',
+					selector: '#angie-lite-toggle',
 				},
 				layout: 'sidebar',
 			},
@@ -180,7 +180,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 			container: {
 				chatToggleButton: {
 					enabled: true,
-					id: 'angie-lite-toggle',
+					selector: '#angie-lite-toggle',
 				},
 				layout: 'sidebar',
 			},
@@ -214,7 +214,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 			container: {
 				chatToggleButton: {
 					enabled: true,
-					id: 'angie-lite-toggle',
+					selector: '#angie-lite-toggle',
 				},
 				layout: 'sidebar',
 			},
@@ -261,7 +261,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 			container: {
 				chatToggleButton: {
 					enabled: true,
-					id: 'angie-lite-toggle',
+					selector: '#angie-lite-toggle',
 				},
 				layout: 'floating-chat',
 			},

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -6,6 +6,7 @@ import { buildEmbeddedPayload, sendEmbeddedConfig, sendWidgetConfig } from './em
 import { readEnv } from './env';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { resolveConfig, shouldBoot } from './resolve-config';
+import { initHostApiBridge } from './host-api-bridge';
 import { applyInitialSidebarShellState, finalizeSidebarShellState, initSidebarShell } from './shell';
 
 export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
@@ -15,6 +16,11 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 	if ( ! shouldBoot( config, env ) ) {
 		return;
 	}
+
+	initHostApiBridge( {
+		iframeOrigin: config.iframe.origin,
+		getExternalHeaders: config.callbacks.getExternalHeaders,
+	} );
 
 	appState.containerId = config.container.id;
 

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -1,11 +1,12 @@
 import { appState } from '../config';
-import { openIframe } from '../iframe';
+import { initFloatingChatLayout } from './chat-toggle/init-floating-chat-layout';
 import { ensureSidebarContainer } from './container';
 import type { LoadSidebarV2Options } from './config';
-import { buildEmbeddedPayload, sendEmbeddedConfig } from './embedded-handshake';
+import { buildEmbeddedPayload, sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
 import { readEnv } from './env';
+import { openEmbeddedIframe } from './open-embedded-iframe';
 import { resolveConfig, shouldBoot } from './resolve-config';
-import { initSidebarShell } from './shell';
+import { applyInitialSidebarShellState, finalizeSidebarShellState, initSidebarShell } from './shell';
 
 export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
 	const env = readEnv();
@@ -17,19 +18,38 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 
 	appState.containerId = config.container.id;
 
-	if ( config.container.preset === 'sidebar' ) {
-		ensureSidebarContainer( config.container.id, env.isRTL );
+	ensureSidebarContainer( config.container.id, env.isRTL );
+
+	const { layout, chatToggleButton } = config.container;
+
+	if ( layout === 'floating-chat' ) {
+		initFloatingChatLayout( {
+			containerId: config.container.id,
+			iframeOrigin: config.iframe.origin,
+			onClose: config.callbacks.onClose,
+			toggleButtonId: chatToggleButton.id,
+			injectToggleButton: chatToggleButton.enabled,
+		} );
+	} else {
 		initSidebarShell( config.container, config.callbacks );
+		applyInitialSidebarShellState( config.container );
 	}
 
 	const embeddedPayload = buildEmbeddedPayload( config.host );
 
-	await openIframe( {
-		isRTL: config.iframe.isRTL,
-		origin: config.iframe.origin,
-		path: config.iframe.path,
-		uiTheme: config.iframe.uiTheme,
+	await openEmbeddedIframe( {
+		container: config.container,
+		iframe: config.iframe,
+		hostReadyEmbedded: embeddedPayload,
 	} );
 
+	if ( layout === 'sidebar' ) {
+		finalizeSidebarShellState( config.container );
+	}
+
 	sendEmbeddedConfig( embeddedPayload );
+
+	if ( config.widgetConfig ) {
+		sendWidgetConfig( config.widgetConfig );
+	}
 };

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -27,7 +27,7 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 			containerId: config.container.id,
 			iframeOrigin: config.iframe.origin,
 			onClose: config.callbacks.onClose,
-			toggleButtonId: chatToggleButton.id,
+			toggleButtonSelector: chatToggleButton.selector,
 			injectToggleButton: chatToggleButton.enabled,
 		} );
 	} else {

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -1,0 +1,35 @@
+import { appState } from '../config';
+import { openIframe } from '../iframe';
+import { ensureSidebarContainer } from './container';
+import type { LoadSidebarV2Options } from './config';
+import { buildEmbeddedPayload, sendEmbeddedConfig } from './embedded-handshake';
+import { readEnv } from './env';
+import { resolveConfig, shouldBoot } from './resolve-config';
+import { initSidebarShell } from './shell';
+
+export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
+	const env = readEnv();
+	const config = resolveConfig( options, env );
+
+	if ( ! shouldBoot( config, env ) ) {
+		return;
+	}
+
+	appState.containerId = config.container.id;
+
+	if ( config.container.preset === 'sidebar' ) {
+		ensureSidebarContainer( config.container.id, env.isRTL );
+		initSidebarShell( config.container, config.callbacks );
+	}
+
+	const embeddedPayload = buildEmbeddedPayload( config.host );
+
+	await openIframe( {
+		isRTL: config.iframe.isRTL,
+		origin: config.iframe.origin,
+		path: config.iframe.path,
+		uiTheme: config.iframe.uiTheme,
+	} );
+
+	sendEmbeddedConfig( embeddedPayload );
+};

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
@@ -1,12 +1,15 @@
 import { beforeEach, describe, expect, it } from '@jest/globals';
 import { MessageEventType } from '../../types';
-import { CHAT_WIDGET_HIDDEN_CLASS, DEFAULT_CHAT_TOGGLE_BUTTON_ID } from './constants';
+import {
+	CHAT_WIDGET_HIDDEN_CLASS,
+	DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR,
+} from './constants';
 import { initChatShell, setChatWidgetOpen } from './chat-shell';
 import { injectChatToggleButton, prepareChatWidgetContainer } from './widget-ui';
 
 const CONTAINER_ID = 'angie-sidebar-container';
 const IFRAME_ORIGIN = 'https://angie.elementor.com';
-const CUSTOM_TOGGLE_ID = 'angie-lite-toggle';
+const CUSTOM_TOGGLE_SELECTOR = '#angie-lite-toggle';
 
 describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 	beforeEach( () => {
@@ -18,16 +21,16 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 		document.body.appendChild( container );
 
 		prepareChatWidgetContainer( CONTAINER_ID );
-		injectChatToggleButton( DEFAULT_CHAT_TOGGLE_BUTTON_ID );
+		injectChatToggleButton( DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR );
 		initChatShell( {
 			containerId: CONTAINER_ID,
 			iframeOrigin: IFRAME_ORIGIN,
-			toggleButtonId: DEFAULT_CHAT_TOGGLE_BUTTON_ID,
+			toggleButtonSelector: DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR,
 		} );
 	} );
 
 	it( 'should toggle widget open/close on button click', () => {
-		const toggleButton = document.getElementById( DEFAULT_CHAT_TOGGLE_BUTTON_ID )!;
+		const toggleButton = document.querySelector<HTMLElement>( DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR )!;
 		const container = document.getElementById( CONTAINER_ID )!;
 
 		toggleButton.click();
@@ -45,7 +48,7 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 		const container = document.getElementById( CONTAINER_ID )!;
 		setChatWidgetOpen( {
 			containerId: CONTAINER_ID,
-			toggleButtonId: DEFAULT_CHAT_TOGGLE_BUTTON_ID,
+			toggleButtonSelector: DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR,
 			isOpen: true,
 		} );
 
@@ -88,7 +91,7 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
 	} );
 
-	it( 'should support a custom toggle button id', () => {
+	it( 'should support a custom toggle button selector', () => {
 		document.body.innerHTML = '';
 
 		const container = document.createElement( 'div' );
@@ -96,14 +99,14 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 		document.body.appendChild( container );
 
 		prepareChatWidgetContainer( CONTAINER_ID );
-		injectChatToggleButton( CUSTOM_TOGGLE_ID );
+		injectChatToggleButton( CUSTOM_TOGGLE_SELECTOR );
 		initChatShell( {
 			containerId: CONTAINER_ID,
 			iframeOrigin: IFRAME_ORIGIN,
-			toggleButtonId: CUSTOM_TOGGLE_ID,
+			toggleButtonSelector: CUSTOM_TOGGLE_SELECTOR,
 		} );
 
-		const toggleButton = document.getElementById( CUSTOM_TOGGLE_ID );
+		const toggleButton = document.querySelector( CUSTOM_TOGGLE_SELECTOR );
 		expect( toggleButton ).not.toBeNull();
 		expect( toggleButton?.className ).toBe( 'angie-widget-toggle' );
 	} );

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { MessageEventType } from '../../types';
+import { CHAT_WIDGET_HIDDEN_CLASS, DEFAULT_CHAT_TOGGLE_BUTTON_ID } from './constants';
+import { initChatShell, setChatWidgetOpen } from './chat-shell';
+import { injectChatToggleButton, prepareChatWidgetContainer } from './widget-ui';
+
+const CONTAINER_ID = 'angie-sidebar-container';
+const IFRAME_ORIGIN = 'https://angie.elementor.com';
+const CUSTOM_TOGGLE_ID = 'angie-lite-toggle';
+
+describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+
+		const container = document.createElement( 'div' );
+		container.id = CONTAINER_ID;
+		document.body.appendChild( container );
+
+		prepareChatWidgetContainer( CONTAINER_ID );
+		injectChatToggleButton( DEFAULT_CHAT_TOGGLE_BUTTON_ID );
+		initChatShell( {
+			containerId: CONTAINER_ID,
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonId: DEFAULT_CHAT_TOGGLE_BUTTON_ID,
+		} );
+	} );
+
+	it( 'should toggle widget open/close on button click', () => {
+		const toggleButton = document.getElementById( DEFAULT_CHAT_TOGGLE_BUTTON_ID )!;
+		const container = document.getElementById( CONTAINER_ID )!;
+
+		toggleButton.click();
+
+		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( false );
+		expect( toggleButton.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+
+		toggleButton.click();
+
+		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
+		expect( toggleButton.getAttribute( 'aria-expanded' ) ).toBe( 'false' );
+	} );
+
+	it( 'should close widget when iframe sends toggleAngieSidebar with force false', () => {
+		const container = document.getElementById( CONTAINER_ID )!;
+		setChatWidgetOpen( {
+			containerId: CONTAINER_ID,
+			toggleButtonId: DEFAULT_CHAT_TOGGLE_BUTTON_ID,
+			isOpen: true,
+		} );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: IFRAME_ORIGIN,
+			data: {
+				type: 'toggleAngieSidebar',
+				payload: { force: false },
+			},
+		} ) );
+
+		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
+	} );
+
+	it( 'should open widget when iframe sends ANGIE_SIDEBAR_TOGGLED with force true', () => {
+		const container = document.getElementById( CONTAINER_ID )!;
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: IFRAME_ORIGIN,
+			data: {
+				type: MessageEventType.ANGIE_SIDEBAR_TOGGLED,
+				payload: { force: true },
+			},
+		} ) );
+
+		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( false );
+	} );
+
+	it( 'should ignore messages from wrong origin', () => {
+		const container = document.getElementById( CONTAINER_ID )!;
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: 'https://evil.example.com',
+			data: {
+				type: 'toggleAngieSidebar',
+				payload: { force: true },
+			},
+		} ) );
+
+		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
+	} );
+
+	it( 'should support a custom toggle button id', () => {
+		document.body.innerHTML = '';
+
+		const container = document.createElement( 'div' );
+		container.id = CONTAINER_ID;
+		document.body.appendChild( container );
+
+		prepareChatWidgetContainer( CONTAINER_ID );
+		injectChatToggleButton( CUSTOM_TOGGLE_ID );
+		initChatShell( {
+			containerId: CONTAINER_ID,
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonId: CUSTOM_TOGGLE_ID,
+		} );
+
+		const toggleButton = document.getElementById( CUSTOM_TOGGLE_ID );
+		expect( toggleButton ).not.toBeNull();
+		expect( toggleButton?.className ).toBe( 'angie-widget-toggle' );
+	} );
+} );

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.ts
@@ -4,16 +4,18 @@ import {
 	CHAT_WIDGET_HIDDEN_CLASS,
 } from './constants';
 
+import { findToggleButton } from './toggle-button-element';
+
 type InitChatShellArgs = {
 	containerId: string;
 	iframeOrigin: string;
-	toggleButtonId: string;
+	toggleButtonSelector: string;
 	onClose?: () => void;
 };
 
 type SetChatWidgetOpenArgs = {
 	containerId: string;
-	toggleButtonId: string;
+	toggleButtonSelector: string;
 	isOpen: boolean;
 };
 
@@ -25,7 +27,7 @@ const sendPortSuccess = ( port: MessagePort, payload?: unknown ) => {
 
 export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 	const container = document.getElementById( args.containerId );
-	const toggleButton = document.getElementById( args.toggleButtonId );
+	const toggleButton = findToggleButton( args.toggleButtonSelector );
 
 	if ( ! container || ! toggleButton ) {
 		return;
@@ -66,7 +68,7 @@ const handleSidebarToggleMessage = (
 	if ( force === false ) {
 		setChatWidgetOpen( {
 			containerId: args.containerId,
-			toggleButtonId: args.toggleButtonId,
+			toggleButtonSelector: args.toggleButtonSelector,
 			isOpen: false,
 		} );
 		args.onClose?.();
@@ -76,7 +78,7 @@ const handleSidebarToggleMessage = (
 	if ( force === true ) {
 		setChatWidgetOpen( {
 			containerId: args.containerId,
-			toggleButtonId: args.toggleButtonId,
+			toggleButtonSelector: args.toggleButtonSelector,
 			isOpen: true,
 		} );
 		return;
@@ -86,7 +88,7 @@ const handleSidebarToggleMessage = (
 	const isCurrentlyOpen = container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
 	setChatWidgetOpen( {
 		containerId: args.containerId,
-		toggleButtonId: args.toggleButtonId,
+		toggleButtonSelector: args.toggleButtonSelector,
 		isOpen: ! isCurrentlyOpen,
 	} );
 
@@ -96,7 +98,7 @@ const handleSidebarToggleMessage = (
 };
 
 const initToggleButton = ( args: InitChatShellArgs ): void => {
-	const toggleButton = document.getElementById( args.toggleButtonId );
+	const toggleButton = findToggleButton( args.toggleButtonSelector );
 
 	if ( ! toggleButton ) {
 		return;
@@ -106,7 +108,7 @@ const initToggleButton = ( args: InitChatShellArgs ): void => {
 		const isCurrentlyOpen = toggleButton.getAttribute( 'aria-expanded' ) === 'true';
 		setChatWidgetOpen( {
 			containerId: args.containerId,
-			toggleButtonId: args.toggleButtonId,
+			toggleButtonSelector: args.toggleButtonSelector,
 			isOpen: ! isCurrentlyOpen,
 		} );
 
@@ -141,7 +143,7 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				if ( isStudioOpen ) {
 					setChatWidgetOpen( {
 						containerId: args.containerId,
-						toggleButtonId: args.toggleButtonId,
+						toggleButtonSelector: args.toggleButtonSelector,
 						isOpen: true,
 					} );
 				}

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.ts
@@ -1,0 +1,165 @@
+import { MessageEventType } from '../../types';
+import {
+	CHAT_WIDGET_FULLSCREEN_CLASS,
+	CHAT_WIDGET_HIDDEN_CLASS,
+} from './constants';
+
+type InitChatShellArgs = {
+	containerId: string;
+	iframeOrigin: string;
+	toggleButtonId: string;
+	onClose?: () => void;
+};
+
+type SetChatWidgetOpenArgs = {
+	containerId: string;
+	toggleButtonId: string;
+	isOpen: boolean;
+};
+
+const TOGGLE_ANGIE_SIDEBAR_MESSAGE = 'toggleAngieSidebar';
+
+const sendPortSuccess = ( port: MessagePort, payload?: unknown ) => {
+	port.postMessage( { status: 'success', payload } );
+};
+
+export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
+	const container = document.getElementById( args.containerId );
+	const toggleButton = document.getElementById( args.toggleButtonId );
+
+	if ( ! container || ! toggleButton ) {
+		return;
+	}
+
+	if ( args.isOpen ) {
+		container.classList.remove( CHAT_WIDGET_HIDDEN_CLASS );
+		container.setAttribute( 'aria-hidden', 'false' );
+	} else {
+		container.classList.add( CHAT_WIDGET_HIDDEN_CLASS );
+		container.setAttribute( 'aria-hidden', 'true' );
+	}
+
+	toggleButton.setAttribute( 'aria-expanded', String( args.isOpen ) );
+	toggleButton.setAttribute( 'aria-label', args.isOpen ? 'Close Angie' : 'Open Angie' );
+};
+
+const setChatWidgetFullscreen = ( containerId: string, isFullscreen: boolean ): void => {
+	const container = document.getElementById( containerId );
+
+	if ( ! container ) {
+		return;
+	}
+
+	if ( isFullscreen ) {
+		container.classList.add( CHAT_WIDGET_FULLSCREEN_CLASS );
+	} else {
+		container.classList.remove( CHAT_WIDGET_FULLSCREEN_CLASS );
+	}
+};
+
+const handleSidebarToggleMessage = (
+	args: InitChatShellArgs,
+	payload: { force?: boolean } | undefined,
+): void => {
+	const force = payload?.force;
+
+	if ( force === false ) {
+		setChatWidgetOpen( {
+			containerId: args.containerId,
+			toggleButtonId: args.toggleButtonId,
+			isOpen: false,
+		} );
+		args.onClose?.();
+		return;
+	}
+
+	if ( force === true ) {
+		setChatWidgetOpen( {
+			containerId: args.containerId,
+			toggleButtonId: args.toggleButtonId,
+			isOpen: true,
+		} );
+		return;
+	}
+
+	const container = document.getElementById( args.containerId );
+	const isCurrentlyOpen = container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
+	setChatWidgetOpen( {
+		containerId: args.containerId,
+		toggleButtonId: args.toggleButtonId,
+		isOpen: ! isCurrentlyOpen,
+	} );
+
+	if ( isCurrentlyOpen ) {
+		args.onClose?.();
+	}
+};
+
+const initToggleButton = ( args: InitChatShellArgs ): void => {
+	const toggleButton = document.getElementById( args.toggleButtonId );
+
+	if ( ! toggleButton ) {
+		return;
+	}
+
+	toggleButton.addEventListener( 'click', () => {
+		const isCurrentlyOpen = toggleButton.getAttribute( 'aria-expanded' ) === 'true';
+		setChatWidgetOpen( {
+			containerId: args.containerId,
+			toggleButtonId: args.toggleButtonId,
+			isOpen: ! isCurrentlyOpen,
+		} );
+
+		if ( isCurrentlyOpen ) {
+			args.onClose?.();
+		}
+	} );
+};
+
+const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
+	window.addEventListener( 'message', ( event: MessageEvent ) => {
+		if ( event.origin !== args.iframeOrigin ) {
+			return;
+		}
+
+		const port = event.ports?.[ 0 ];
+		const { type, payload } = event.data || {};
+
+		switch ( type ) {
+			case MessageEventType.ANGIE_SIDEBAR_TOGGLED:
+			case TOGGLE_ANGIE_SIDEBAR_MESSAGE:
+				handleSidebarToggleMessage( args, payload );
+				if ( port ) {
+					sendPortSuccess( port );
+				}
+				break;
+
+			case MessageEventType.ANGIE_STUDIO_TOGGLE: {
+				const isStudioOpen = !! event.data.isStudioOpen;
+				setChatWidgetFullscreen( args.containerId, isStudioOpen );
+
+				if ( isStudioOpen ) {
+					setChatWidgetOpen( {
+						containerId: args.containerId,
+						toggleButtonId: args.toggleButtonId,
+						isOpen: true,
+					} );
+				}
+
+				if ( port ) {
+					sendPortSuccess( port );
+				}
+				break;
+			}
+		}
+	} );
+};
+
+export const initChatShell = ( args: InitChatShellArgs ): void => {
+	initToggleButton( args );
+	setupChatWidgetMessageListeners( args );
+
+	window.toggleAngieSidebar = ( force?: boolean ) => {
+		handleSidebarToggleMessage( args, { force } );
+	};
+};

--- a/src/load-sidebar-v2/chat-toggle/constants.ts
+++ b/src/load-sidebar-v2/chat-toggle/constants.ts
@@ -1,0 +1,7 @@
+export const CHAT_TOGGLE_BUTTON_CLASS = 'angie-widget-toggle';
+export const DEFAULT_CHAT_TOGGLE_BUTTON_ID = 'angie-widget-toggle';
+export const CHAT_WIDGET_HIDDEN_CLASS = 'angie-widget-hidden';
+export const CHAT_WIDGET_FULLSCREEN_CLASS = 'angie-widget-fullscreen';
+export const CHAT_WIDGET_CONTAINER_CLASS = 'angie-widget-container';
+export const CHAT_WIDGET_STYLES_ID = 'angie-chat-widget-styles';
+export const CHAT_TOGGLE_STYLES_ID = 'angie-chat-toggle-styles';

--- a/src/load-sidebar-v2/chat-toggle/constants.ts
+++ b/src/load-sidebar-v2/chat-toggle/constants.ts
@@ -1,5 +1,5 @@
 export const CHAT_TOGGLE_BUTTON_CLASS = 'angie-widget-toggle';
-export const DEFAULT_CHAT_TOGGLE_BUTTON_ID = 'angie-widget-toggle';
+export const DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR = '#angie-widget-toggle';
 export const CHAT_WIDGET_HIDDEN_CLASS = 'angie-widget-hidden';
 export const CHAT_WIDGET_FULLSCREEN_CLASS = 'angie-widget-fullscreen';
 export const CHAT_WIDGET_CONTAINER_CLASS = 'angie-widget-container';

--- a/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
+++ b/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
@@ -1,0 +1,30 @@
+import { initChatShell } from './chat-shell';
+import {
+	injectChatToggleButton,
+	injectChatWidgetStyles,
+	prepareChatWidgetContainer,
+} from './widget-ui';
+
+type InitFloatingChatLayoutArgs = {
+	containerId: string;
+	iframeOrigin: string;
+	toggleButtonId: string;
+	injectToggleButton: boolean;
+	onClose?: () => void;
+};
+
+export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void => {
+	injectChatWidgetStyles( args.containerId );
+	prepareChatWidgetContainer( args.containerId );
+
+	if ( args.injectToggleButton ) {
+		injectChatToggleButton( args.toggleButtonId );
+	}
+
+	initChatShell( {
+		containerId: args.containerId,
+		iframeOrigin: args.iframeOrigin,
+		onClose: args.onClose,
+		toggleButtonId: args.toggleButtonId,
+	} );
+};

--- a/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
+++ b/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
@@ -8,7 +8,7 @@ import {
 type InitFloatingChatLayoutArgs = {
 	containerId: string;
 	iframeOrigin: string;
-	toggleButtonId: string;
+	toggleButtonSelector: string;
 	injectToggleButton: boolean;
 	onClose?: () => void;
 };
@@ -18,13 +18,13 @@ export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void
 	prepareChatWidgetContainer( args.containerId );
 
 	if ( args.injectToggleButton ) {
-		injectChatToggleButton( args.toggleButtonId );
+		injectChatToggleButton( args.toggleButtonSelector );
 	}
 
 	initChatShell( {
 		containerId: args.containerId,
 		iframeOrigin: args.iframeOrigin,
 		onClose: args.onClose,
-		toggleButtonId: args.toggleButtonId,
+		toggleButtonSelector: args.toggleButtonSelector,
 	} );
 };

--- a/src/load-sidebar-v2/chat-toggle/toggle-button-element.ts
+++ b/src/load-sidebar-v2/chat-toggle/toggle-button-element.ts
@@ -1,0 +1,21 @@
+const ID_SELECTOR_PATTERN = /^#([^\s#.[:]+)$/;
+const ATTRIBUTE_SELECTOR_PATTERN = /^\[([^\]=]+)(?:="([^"]*)")?\]$/;
+
+export const findToggleButton = ( selector: string ): HTMLElement | null => {
+	return document.querySelector<HTMLElement>( selector );
+};
+
+export const applySelectorToToggleButton = ( element: HTMLElement, selector: string ): void => {
+	const idMatch = selector.match( ID_SELECTOR_PATTERN );
+
+	if ( idMatch ) {
+		element.id = idMatch[ 1 ];
+		return;
+	}
+
+	const attributeMatch = selector.match( ATTRIBUTE_SELECTOR_PATTERN );
+
+	if ( attributeMatch ) {
+		element.setAttribute( attributeMatch[ 1 ], attributeMatch[ 2 ] ?? '' );
+	}
+};

--- a/src/load-sidebar-v2/chat-toggle/widget-ui.ts
+++ b/src/load-sidebar-v2/chat-toggle/widget-ui.ts
@@ -1,0 +1,171 @@
+import {
+	CHAT_TOGGLE_BUTTON_CLASS,
+	CHAT_TOGGLE_STYLES_ID,
+	CHAT_WIDGET_CONTAINER_CLASS,
+	CHAT_WIDGET_FULLSCREEN_CLASS,
+	CHAT_WIDGET_HIDDEN_CLASS,
+	CHAT_WIDGET_STYLES_ID,
+} from './constants';
+
+const ANGIE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16" fill="none">
+	<path d="M15.0998 8.00414L14.622 8.18282C13.4991 8.60516 12.8142 9.50669 12.4001 10.6519L12.2249 11.1392L12.0497 10.6519C11.6356 9.50669 10.9109 8.60516 9.78801 8.18282L9.31018 8.00414L9.78801 7.82546C10.9109 7.40312 11.6356 6.50159 12.0497 5.3564L12.2249 4.86909L12.4001 5.3564C12.8142 6.50159 13.4991 7.40312 14.622 7.82546L15.0998 8.00414Z" fill="white"/>
+	<path d="M2 8.42721C5.5608 8.42721 8.44479 11.3685 8.44479 15" stroke="white" stroke-width="2.05092" stroke-miterlimit="10"/>
+	<path d="M2 7.57275C5.5608 7.57275 8.44479 4.6315 8.44479 0.999991" stroke="white" stroke-width="2.05092" stroke-miterlimit="10"/>
+</svg>`;
+
+const buildChatToggleButtonCss = (): string => `
+.${ CHAT_TOGGLE_BUTTON_CLASS } {
+	--angie-toggle-size: 56px;
+	--angie-widget-z-index: 99999;
+
+	position: fixed;
+	bottom: 20px;
+	inset-inline-end: 20px;
+	width: var(--angie-toggle-size);
+	height: var(--angie-toggle-size);
+	border-radius: 50%;
+	border: none;
+	background: #EB8EFB;
+	color: white;
+	cursor: pointer;
+	z-index: var(--angie-widget-z-index);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+	transition: background 0.2s ease, transform 0.15s ease;
+	padding: 0;
+}
+
+.${ CHAT_TOGGLE_BUTTON_CLASS }:hover {
+	background: #E070F5;
+	transform: scale(1.05);
+}
+
+.${ CHAT_TOGGLE_BUTTON_CLASS }:active {
+	transform: scale(0.95);
+}
+
+.${ CHAT_TOGGLE_BUTTON_CLASS }[aria-expanded="true"] {
+	display: none;
+}
+`;
+
+const buildWidgetCss = ( containerId: string ): string => `
+#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS } {
+	--angie-widget-width: 400px;
+	--angie-widget-height: 600px;
+	--angie-widget-z-index: 99999;
+
+	position: fixed !important;
+	top: auto !important;
+	bottom: 20px !important;
+	inset-inline-start: auto !important;
+	inset-inline-end: 20px !important;
+	width: var(--angie-widget-width) !important;
+	height: var(--angie-widget-height) !important;
+	max-height: calc(100vh - 40px) !important;
+	max-width: calc(100vw - 40px) !important;
+	z-index: var(--angie-widget-z-index) !important;
+	transform: none !important;
+	border-radius: 12px !important;
+	overflow: hidden !important;
+	box-shadow: 0 4px 24px rgba(0, 0, 0, 0.15) !important;
+	transition: opacity 0.2s ease, transform 0.2s ease !important;
+}
+
+#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS }.${ CHAT_WIDGET_HIDDEN_CLASS } {
+	display: none !important;
+}
+
+#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS } iframe {
+	width: 100% !important;
+	height: 100% !important;
+	border: none !important;
+	border-radius: 12px !important;
+}
+
+${ buildChatToggleButtonCss() }
+
+#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS }.${ CHAT_WIDGET_FULLSCREEN_CLASS } {
+	bottom: 0 !important;
+	inset-inline-end: 0 !important;
+	width: 100vw !important;
+	height: 100vh !important;
+	max-height: 100vh !important;
+	max-width: 100vw !important;
+	border-radius: 0 !important;
+}
+
+#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS }.${ CHAT_WIDGET_FULLSCREEN_CLASS } iframe {
+	border-radius: 0 !important;
+}
+
+@media (max-width: 480px) {
+	#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS } {
+		bottom: 0 !important;
+		inset-inline-end: 0 !important;
+		width: 100vw !important;
+		height: 100vh !important;
+		max-height: 100vh !important;
+		max-width: 100vw !important;
+		border-radius: 0 !important;
+	}
+
+	#${ containerId }.${ CHAT_WIDGET_CONTAINER_CLASS } iframe {
+		border-radius: 0 !important;
+	}
+}
+`;
+
+export const injectChatToggleButtonStyles = (): void => {
+	if ( document.getElementById( CHAT_TOGGLE_STYLES_ID ) ) {
+		return;
+	}
+
+	const style = document.createElement( 'style' );
+	style.id = CHAT_TOGGLE_STYLES_ID;
+	style.textContent = buildChatToggleButtonCss();
+	document.head.appendChild( style );
+};
+
+export const injectChatWidgetStyles = ( containerId: string ): void => {
+	if ( document.getElementById( CHAT_WIDGET_STYLES_ID ) ) {
+		return;
+	}
+
+	const style = document.createElement( 'style' );
+	style.id = CHAT_WIDGET_STYLES_ID;
+	style.textContent = buildWidgetCss( containerId );
+	document.head.appendChild( style );
+};
+
+export const prepareChatWidgetContainer = ( containerId: string ): void => {
+	const container = document.getElementById( containerId );
+
+	if ( ! container ) {
+		return;
+	}
+
+	container.classList.add( CHAT_WIDGET_CONTAINER_CLASS, CHAT_WIDGET_HIDDEN_CLASS );
+	container.setAttribute( 'role', 'complementary' );
+	container.setAttribute( 'aria-label', 'Angie' );
+	container.setAttribute( 'aria-hidden', 'true' );
+	container.setAttribute( 'tabindex', '-1' );
+};
+
+export const injectChatToggleButton = ( toggleButtonId: string ): void => {
+	if ( document.getElementById( toggleButtonId ) ) {
+		return;
+	}
+
+	const toggleButton = document.createElement( 'button' );
+	toggleButton.id = toggleButtonId;
+	toggleButton.className = CHAT_TOGGLE_BUTTON_CLASS;
+	toggleButton.setAttribute( 'aria-label', 'Open Angie' );
+	toggleButton.setAttribute( 'aria-expanded', 'false' );
+	toggleButton.type = 'button';
+	toggleButton.innerHTML = ANGIE_ICON_SVG;
+
+	document.body.appendChild( toggleButton );
+};

--- a/src/load-sidebar-v2/chat-toggle/widget-ui.ts
+++ b/src/load-sidebar-v2/chat-toggle/widget-ui.ts
@@ -6,6 +6,7 @@ import {
 	CHAT_WIDGET_HIDDEN_CLASS,
 	CHAT_WIDGET_STYLES_ID,
 } from './constants';
+import { applySelectorToToggleButton, findToggleButton } from './toggle-button-element';
 
 const ANGIE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16" fill="none">
 	<path d="M15.0998 8.00414L14.622 8.18282C13.4991 8.60516 12.8142 9.50669 12.4001 10.6519L12.2249 11.1392L12.0497 10.6519C11.6356 9.50669 10.9109 8.60516 9.78801 8.18282L9.31018 8.00414L9.78801 7.82546C10.9109 7.40312 11.6356 6.50159 12.0497 5.3564L12.2249 4.86909L12.4001 5.3564C12.8142 6.50159 13.4991 7.40312 14.622 7.82546L15.0998 8.00414Z" fill="white"/>
@@ -154,13 +155,13 @@ export const prepareChatWidgetContainer = ( containerId: string ): void => {
 	container.setAttribute( 'tabindex', '-1' );
 };
 
-export const injectChatToggleButton = ( toggleButtonId: string ): void => {
-	if ( document.getElementById( toggleButtonId ) ) {
+export const injectChatToggleButton = ( toggleButtonSelector: string ): void => {
+	if ( findToggleButton( toggleButtonSelector ) ) {
 		return;
 	}
 
 	const toggleButton = document.createElement( 'button' );
-	toggleButton.id = toggleButtonId;
+	applySelectorToToggleButton( toggleButton, toggleButtonSelector );
 	toggleButton.className = CHAT_TOGGLE_BUTTON_CLASS;
 	toggleButton.setAttribute( 'aria-label', 'Open Angie' );
 	toggleButton.setAttribute( 'aria-expanded', 'false' );

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -1,7 +1,14 @@
+import type { WidgetConfig } from '../angie-mcp-sdk';
+
 export const LOAD_SIDEBAR_V2_CONFIG_VERSION = 2 as const;
 
-export type LoadSidebarV2ContainerPreset = 'sidebar' | 'none';
-export type LoadSidebarV2ContainerStylePreset = 'wordpress' | 'chat';
+export type LoadSidebarV2Layout = 'floating-chat' | 'sidebar';
+export type LoadSidebarV2ContainerStyleTheme = 'wordpress' | '';
+
+export type ChatToggleButtonConfig = {
+	enabled?: boolean;
+	id?: string;
+};
 
 export type LoadSidebarV2Options = {
 	host: {
@@ -14,10 +21,11 @@ export type LoadSidebarV2Options = {
 	};
 	container?: {
 		id?: string;
+		layout?: LoadSidebarV2Layout;
+		styleTheme?: LoadSidebarV2ContainerStyleTheme;
 		persistOpenState?: boolean;
-		preset?: LoadSidebarV2ContainerPreset;
 		resizable?: boolean;
-		stylePreset?: LoadSidebarV2ContainerStylePreset;
+		chatToggleButton?: ChatToggleButtonConfig;
 	};
 	iframe?: {
 		isRTL?: boolean;
@@ -28,6 +36,7 @@ export type LoadSidebarV2Options = {
 	callbacks?: {
 		onClose?: () => void;
 	};
+	widgetConfig?: WidgetConfig;
 };
 
 export type ResolvedConfigV2 = {
@@ -41,10 +50,14 @@ export type ResolvedConfigV2 = {
 	};
 	container: {
 		id: string;
-		preset: LoadSidebarV2ContainerPreset;
-		stylePreset: LoadSidebarV2ContainerStylePreset;
+		layout: LoadSidebarV2Layout;
+		styleTheme: LoadSidebarV2ContainerStyleTheme;
 		persistOpenState: boolean;
 		resizable: boolean;
+		chatToggleButton: {
+			enabled: boolean;
+			id: string;
+		};
 	};
 	iframe: {
 		origin: string;
@@ -55,6 +68,7 @@ export type ResolvedConfigV2 = {
 	callbacks: {
 		onClose?: () => void;
 	};
+	widgetConfig?: WidgetConfig;
 };
 
 export type LoadSidebarV2HostConfig = LoadSidebarV2Options & {

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -1,0 +1,90 @@
+export const LOAD_SIDEBAR_V2_CONFIG_VERSION = 2 as const;
+
+export type LoadSidebarV2ContainerPreset = 'sidebar' | 'none';
+export type LoadSidebarV2ContainerStylePreset = 'wordpress' | 'chat';
+
+export type LoadSidebarV2Options = {
+	host: {
+		appId: string;
+		aiContext?: Record<string, unknown>;
+		website?: Record<string, unknown>;
+	};
+	boot?: {
+		allowInIframe?: boolean;
+	};
+	container?: {
+		id?: string;
+		persistOpenState?: boolean;
+		preset?: LoadSidebarV2ContainerPreset;
+		resizable?: boolean;
+		stylePreset?: LoadSidebarV2ContainerStylePreset;
+	};
+	iframe?: {
+		isRTL?: boolean;
+		origin?: string;
+		path?: string;
+		uiTheme?: string;
+	};
+	callbacks?: {
+		onClose?: () => void;
+	};
+};
+
+export type ResolvedConfigV2 = {
+	host: {
+		appId: string;
+		aiContext?: Record<string, unknown>;
+		website?: Record<string, unknown>;
+	};
+	boot: {
+		allowInIframe: boolean;
+	};
+	container: {
+		id: string;
+		preset: LoadSidebarV2ContainerPreset;
+		stylePreset: LoadSidebarV2ContainerStylePreset;
+		persistOpenState: boolean;
+		resizable: boolean;
+	};
+	iframe: {
+		origin: string;
+		path: string;
+		uiTheme: string;
+		isRTL: boolean;
+	};
+	callbacks: {
+		onClose?: () => void;
+	};
+};
+
+export type LoadSidebarV2HostConfig = LoadSidebarV2Options & {
+	configVersion: typeof LOAD_SIDEBAR_V2_CONFIG_VERSION;
+};
+
+export type HostEmbeddedConfigPayload = {
+	aiContext?: Record<string, unknown>;
+	appId?: string;
+	configVersion: typeof LOAD_SIDEBAR_V2_CONFIG_VERSION;
+	telemetry?: Record<string, unknown>;
+	website?: Record<string, unknown>;
+};
+
+export const buildHostEmbeddedConfigPayload = (
+	host: ResolvedConfigV2['host']
+): HostEmbeddedConfigPayload => ( {
+	aiContext: host.aiContext,
+	appId: host.appId,
+	configVersion: LOAD_SIDEBAR_V2_CONFIG_VERSION,
+	telemetry: {
+		screenPath: window.location.pathname,
+	},
+	website: {
+		docTitle: document.title,
+		homeUrl: window.location.origin,
+		name: document.title,
+		platform: 'frontend',
+		siteLang: document.documentElement.lang,
+		tagline: '',
+		...host.website,
+	},
+} );

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -7,7 +7,7 @@ export type LoadSidebarV2ContainerStyleTheme = 'wordpress' | '';
 
 export type ChatToggleButtonConfig = {
 	enabled?: boolean;
-	id?: string;
+	selector?: string;
 };
 
 export type LoadSidebarV2Options = {
@@ -56,7 +56,7 @@ export type ResolvedConfigV2 = {
 		resizable: boolean;
 		chatToggleButton: {
 			enabled: boolean;
-			id: string;
+			selector: string;
 		};
 	};
 	iframe: {

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -10,6 +10,10 @@ export type ChatToggleButtonConfig = {
 	selector?: string;
 };
 
+export type ExternalHeadersCallback = () =>
+	| Record<string, string | undefined>
+	| Promise<Record<string, string | undefined>>;
+
 export type LoadSidebarV2Options = {
 	host: {
 		appId: string;
@@ -35,6 +39,7 @@ export type LoadSidebarV2Options = {
 	};
 	callbacks?: {
 		onClose?: () => void;
+		getExternalHeaders?: ExternalHeadersCallback;
 	};
 	widgetConfig?: WidgetConfig;
 };
@@ -67,6 +72,7 @@ export type ResolvedConfigV2 = {
 	};
 	callbacks: {
 		onClose?: () => void;
+		getExternalHeaders?: ExternalHeadersCallback;
 	};
 	widgetConfig?: WidgetConfig;
 };

--- a/src/load-sidebar-v2/container.ts
+++ b/src/load-sidebar-v2/container.ts
@@ -1,0 +1,18 @@
+import { SIDEBAR_LOADING_ID } from './defaults';
+
+export const ensureSidebarContainer = ( containerId: string, isRTL: boolean ): void => {
+	if ( document.getElementById( containerId ) ) {
+		return;
+	}
+
+	const container = document.createElement( 'div' );
+	container.id = containerId;
+	container.dir = isRTL ? 'rtl' : 'ltr';
+
+	const loading = document.createElement( 'div' );
+	loading.id = SIDEBAR_LOADING_ID;
+	loading.setAttribute( 'aria-live', 'polite' );
+	loading.className = 'angie-sr-only';
+	container.appendChild( loading );
+	document.body.appendChild( container );
+};

--- a/src/load-sidebar-v2/defaults.ts
+++ b/src/load-sidebar-v2/defaults.ts
@@ -1,5 +1,5 @@
 import { DEFAULT_CONTAINER_ID } from '../config';
-import { DEFAULT_CHAT_TOGGLE_BUTTON_ID } from './chat-toggle/constants';
+import { DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR } from './chat-toggle/constants';
 import { FLOATING_CHAT_PRESET_DEFAULTS } from './presets/floating-chat';
 
 export { DEFAULT_CONTAINER_ID };
@@ -13,7 +13,7 @@ export const DEFAULTS = {
 		styleTheme: FLOATING_CHAT_PRESET_DEFAULTS.styleTheme,
 		persistOpenState: FLOATING_CHAT_PRESET_DEFAULTS.persistOpenState,
 		resizable: FLOATING_CHAT_PRESET_DEFAULTS.resizable,
-		chatToggleButtonId: DEFAULT_CHAT_TOGGLE_BUTTON_ID,
+		chatToggleButtonSelector: DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR,
 	},
 	iframe: {
 		origin: 'https://angie.elementor.com',

--- a/src/load-sidebar-v2/defaults.ts
+++ b/src/load-sidebar-v2/defaults.ts
@@ -1,4 +1,6 @@
 import { DEFAULT_CONTAINER_ID } from '../config';
+import { DEFAULT_CHAT_TOGGLE_BUTTON_ID } from './chat-toggle/constants';
+import { FLOATING_CHAT_PRESET_DEFAULTS } from './presets/floating-chat';
 
 export { DEFAULT_CONTAINER_ID };
 
@@ -7,10 +9,11 @@ export const DEFAULTS = {
 		allowInIframe: false,
 	},
 	container: {
-		preset: 'sidebar' as const,
-		stylePreset: 'wordpress' as const,
-		persistOpenState: true,
-		resizable: true,
+		layout: FLOATING_CHAT_PRESET_DEFAULTS.layout,
+		styleTheme: FLOATING_CHAT_PRESET_DEFAULTS.styleTheme,
+		persistOpenState: FLOATING_CHAT_PRESET_DEFAULTS.persistOpenState,
+		resizable: FLOATING_CHAT_PRESET_DEFAULTS.resizable,
+		chatToggleButtonId: DEFAULT_CHAT_TOGGLE_BUTTON_ID,
 	},
 	iframe: {
 		origin: 'https://angie.elementor.com',

--- a/src/load-sidebar-v2/defaults.ts
+++ b/src/load-sidebar-v2/defaults.ts
@@ -1,0 +1,23 @@
+import { DEFAULT_CONTAINER_ID } from '../config';
+
+export { DEFAULT_CONTAINER_ID };
+
+export const DEFAULTS = {
+	boot: {
+		allowInIframe: false,
+	},
+	container: {
+		preset: 'sidebar' as const,
+		stylePreset: 'wordpress' as const,
+		persistOpenState: true,
+		resizable: true,
+	},
+	iframe: {
+		origin: 'https://angie.elementor.com',
+		path: 'angie/embedded',
+		uiTheme: 'light',
+	},
+} as const;
+
+export const SIDEBAR_LOADING_ID = 'angie-sidebar-loading';
+export const EMBEDDED_CONFIG_MESSAGE_TYPE = 'sdk-embedded-config';

--- a/src/load-sidebar-v2/embedded-handshake.ts
+++ b/src/load-sidebar-v2/embedded-handshake.ts
@@ -16,3 +16,10 @@ export const sendEmbeddedConfig = ( payload: HostEmbeddedConfigPayload ): void =
 		type: EMBEDDED_CONFIG_MESSAGE_TYPE,
 	} );
 };
+
+export const sendWidgetConfig = ( widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']> ): void => {
+	postMessageToAngieIframe( {
+		payload: widgetConfig,
+		type: 'sdk-widget-config',
+	} );
+};

--- a/src/load-sidebar-v2/embedded-handshake.ts
+++ b/src/load-sidebar-v2/embedded-handshake.ts
@@ -1,0 +1,18 @@
+import { postMessageToAngieIframe } from '../angie-iframe-utils';
+import {
+	buildHostEmbeddedConfigPayload,
+	type HostEmbeddedConfigPayload,
+	type ResolvedConfigV2,
+} from './config';
+import { EMBEDDED_CONFIG_MESSAGE_TYPE } from './defaults';
+
+export const buildEmbeddedPayload = (
+	host: ResolvedConfigV2['host'],
+): HostEmbeddedConfigPayload => buildHostEmbeddedConfigPayload( host );
+
+export const sendEmbeddedConfig = ( payload: HostEmbeddedConfigPayload ): void => {
+	postMessageToAngieIframe( {
+		payload,
+		type: EMBEDDED_CONFIG_MESSAGE_TYPE,
+	} );
+};

--- a/src/load-sidebar-v2/env.ts
+++ b/src/load-sidebar-v2/env.ts
@@ -1,0 +1,37 @@
+import { DEFAULTS } from './defaults';
+
+export type Env = {
+	browserUiTheme: 'dark' | 'light';
+	isInIframe: boolean;
+	isRTL: boolean;
+};
+
+const detectBrowserUiTheme = (): Env['browserUiTheme'] => {
+	if ( typeof window !== 'undefined' && typeof window.matchMedia === 'function' ) {
+		return window.matchMedia( '(prefers-color-scheme: dark)' ).matches ? 'dark' : 'light';
+	}
+
+	return DEFAULTS.iframe.uiTheme;
+};
+
+const detectIsRTL = (): boolean => {
+	if ( typeof document === 'undefined' ) {
+		return false;
+	}
+
+	return document.documentElement.dir === 'rtl';
+};
+
+const detectIsInIframe = (): boolean => {
+	if ( typeof window === 'undefined' ) {
+		return false;
+	}
+
+	return window !== window.top;
+};
+
+export const readEnv = (): Env => ( {
+	browserUiTheme: detectBrowserUiTheme(),
+	isInIframe: detectIsInIframe(),
+	isRTL: detectIsRTL(),
+} );

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { ExternalHeadersCallback } from './config';
+import { GET_EXTERNAL_HEADERS_MESSAGE_TYPE, initHostApiBridge, resetHostApiBridgeForTests } from './host-api-bridge';
+
+const IFRAME_ORIGIN = 'http://localhost:4000';
+
+const createMockPort = () => ( {
+	postMessage: jest.fn(),
+} );
+
+const flushAsync = () => new Promise( ( resolve ) => {
+	setTimeout( resolve, 0 );
+} );
+
+describe( 'load-sidebar-v2/host-api-bridge', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetHostApiBridgeForTests();
+	} );
+
+	it( 'should respond with empty headers when no callback is provided', async () => {
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: {},
+		} );
+	} );
+
+	it( 'should invoke getExternalHeaders callback on each request', async () => {
+		let callCount = 0;
+		const getExternalHeaders: ExternalHeadersCallback = async () => {
+			callCount += 1;
+			return { 'X-Custom-Token': callCount === 1 ? 'first' : 'second' };
+		};
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders,
+		} );
+
+		const firstPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ firstPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( callCount ).toBe( 1 );
+		expect( firstPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Custom-Token': 'first' },
+		} );
+
+		const secondPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ secondPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( callCount ).toBe( 2 );
+		expect( secondPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Custom-Token': 'second' },
+		} );
+	} );
+
+	it( 'should ignore messages from other origins', async () => {
+		const getExternalHeaders = jest.fn( async () => ( { 'X-Custom-Token': 'token' } ) ) as jest.MockedFunction<ExternalHeadersCallback>;
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders,
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: 'https://evil.example',
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( getExternalHeaders ).not.toHaveBeenCalled();
+		expect( port.postMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should respond with error when callback throws', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders: async () => {
+				throw new Error( 'Token unavailable' );
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'error',
+			payload: { message: 'Token unavailable' },
+		} );
+	} );
+} );

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,0 +1,58 @@
+import { sendErrorMessage, sendSuccessMessage } from '../utils';
+import type { ExternalHeadersCallback } from './config';
+
+export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
+
+type InitHostApiBridgeArgs = {
+	iframeOrigin: string;
+	getExternalHeaders?: ExternalHeadersCallback;
+};
+
+let bridgeConfig: InitHostApiBridgeArgs | null = null;
+let bridgeListenerRegistered = false;
+
+const filterDefinedHeaders = (
+	headers: Record<string, string | undefined>,
+): Record<string, string> => Object.fromEntries(
+	Object.entries( headers ).filter( ( [ , value ] ) => value !== undefined ),
+) as Record<string, string>;
+
+export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
+	bridgeConfig = args;
+
+	if ( bridgeListenerRegistered ) {
+		return;
+	}
+
+	bridgeListenerRegistered = true;
+
+	window.addEventListener( 'message', async ( event: MessageEvent ) => {
+		if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+			return;
+		}
+
+		if ( event.data?.type !== GET_EXTERNAL_HEADERS_MESSAGE_TYPE ) {
+			return;
+		}
+
+		const port = event.ports?.[ 0 ];
+		if ( ! port ) {
+			return;
+		}
+
+		try {
+			const headers = bridgeConfig.getExternalHeaders
+				? await bridgeConfig.getExternalHeaders()
+				: {};
+			sendSuccessMessage( port, filterDefinedHeaders( headers ) );
+		} catch ( error ) {
+			sendErrorMessage( port, {
+				message: error instanceof Error ? error.message : String( error ),
+			} );
+		}
+	} );
+};
+
+export const resetHostApiBridgeForTests = (): void => {
+	bridgeConfig = null;
+};

--- a/src/load-sidebar-v2/index.ts
+++ b/src/load-sidebar-v2/index.ts
@@ -1,2 +1,4 @@
 export type { HostEmbeddedConfigPayload, LoadSidebarV2HostConfig, LoadSidebarV2Options, ResolvedConfigV2 } from './config';
 export { LOAD_SIDEBAR_V2_CONFIG_VERSION, buildHostEmbeddedConfigPayload } from './config';
+export { FLOATING_CHAT_LAYOUT, FLOATING_CHAT_PRESET_DEFAULTS } from './presets/floating-chat';
+export { SIDEBAR_LAYOUT, SIDEBAR_PRESET_DEFAULTS } from './presets/sidebar';

--- a/src/load-sidebar-v2/index.ts
+++ b/src/load-sidebar-v2/index.ts
@@ -1,0 +1,2 @@
+export type { HostEmbeddedConfigPayload, LoadSidebarV2HostConfig, LoadSidebarV2Options, ResolvedConfigV2 } from './config';
+export { LOAD_SIDEBAR_V2_CONFIG_VERSION, buildHostEmbeddedConfigPayload } from './config';

--- a/src/load-sidebar-v2/open-embedded-iframe.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.ts
@@ -22,7 +22,7 @@ export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promis
 	if ( args.container.chatToggleButton.enabled ) {
 		setChatWidgetOpen( {
 			containerId: args.container.id,
-			toggleButtonId: args.container.chatToggleButton.id,
+			toggleButtonSelector: args.container.chatToggleButton.selector,
 			isOpen: false,
 		} );
 	}

--- a/src/load-sidebar-v2/open-embedded-iframe.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.ts
@@ -1,0 +1,33 @@
+import { appState } from '../config';
+import { openIframe } from '../iframe';
+import { toggleAngieSidebar as setIframeAccessibility } from '../utils';
+import type { HostEmbeddedConfigPayload, ResolvedConfigV2 } from './config';
+import { setChatWidgetOpen } from './chat-toggle/chat-shell';
+
+type OpenEmbeddedIframeArgs = {
+	container: ResolvedConfigV2['container'];
+	iframe: ResolvedConfigV2['iframe'];
+	hostReadyEmbedded?: HostEmbeddedConfigPayload;
+};
+
+export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<void> => {
+	await openIframe( {
+		isRTL: args.iframe.isRTL,
+		origin: args.iframe.origin,
+		path: args.iframe.path,
+		uiTheme: args.iframe.uiTheme,
+		hostReadyEmbedded: args.hostReadyEmbedded,
+	} );
+
+	if ( args.container.chatToggleButton.enabled ) {
+		setChatWidgetOpen( {
+			containerId: args.container.id,
+			toggleButtonId: args.container.chatToggleButton.id,
+			isOpen: false,
+		} );
+	}
+
+	if ( appState.iframe ) {
+		setIframeAccessibility( appState.iframe, false );
+	}
+};

--- a/src/load-sidebar-v2/presets/floating-chat.test.ts
+++ b/src/load-sidebar-v2/presets/floating-chat.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { FLOATING_CHAT_LAYOUT, FLOATING_CHAT_PRESET_DEFAULTS } from './floating-chat';
+
+describe( 'load-sidebar-v2/presets/floating-chat', () => {
+	it( 'should define the floating-chat layout defaults', () => {
+		expect( FLOATING_CHAT_LAYOUT ).toBe( 'floating-chat' );
+		expect( FLOATING_CHAT_PRESET_DEFAULTS ).toEqual( {
+			layout: 'floating-chat',
+			styleTheme: '',
+			persistOpenState: false,
+			resizable: false,
+			chatToggleButtonEnabled: true,
+		} );
+	} );
+} );

--- a/src/load-sidebar-v2/presets/floating-chat.ts
+++ b/src/load-sidebar-v2/presets/floating-chat.ts
@@ -1,0 +1,11 @@
+import type { LoadSidebarV2Layout } from '../config';
+
+export const FLOATING_CHAT_LAYOUT: LoadSidebarV2Layout = 'floating-chat';
+
+export const FLOATING_CHAT_PRESET_DEFAULTS = {
+	layout: FLOATING_CHAT_LAYOUT,
+	styleTheme: '' as const,
+	persistOpenState: false,
+	resizable: false,
+	chatToggleButtonEnabled: true,
+} as const;

--- a/src/load-sidebar-v2/presets/sidebar.test.ts
+++ b/src/load-sidebar-v2/presets/sidebar.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from '@jest/globals';
+import { SIDEBAR_LAYOUT, SIDEBAR_PRESET_DEFAULTS } from './sidebar';
+
+describe( 'load-sidebar-v2/presets/sidebar', () => {
+	it( 'should define the sidebar layout defaults', () => {
+		expect( SIDEBAR_LAYOUT ).toBe( 'sidebar' );
+		expect( SIDEBAR_PRESET_DEFAULTS ).toEqual( {
+			layout: 'sidebar',
+			styleTheme: '',
+			persistOpenState: true,
+			resizable: true,
+			chatToggleButtonEnabled: false,
+		} );
+	} );
+} );

--- a/src/load-sidebar-v2/presets/sidebar.ts
+++ b/src/load-sidebar-v2/presets/sidebar.ts
@@ -1,0 +1,11 @@
+import type { LoadSidebarV2Layout } from '../config';
+
+export const SIDEBAR_LAYOUT: LoadSidebarV2Layout = 'sidebar';
+
+export const SIDEBAR_PRESET_DEFAULTS = {
+	layout: SIDEBAR_LAYOUT,
+	styleTheme: '' as const,
+	persistOpenState: true,
+	resizable: true,
+	chatToggleButtonEnabled: false,
+} as const;

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from '@jest/globals';
+import type { Env } from './env';
+import { resolveConfig, shouldBoot } from './resolve-config';
+
+const DEFAULT_ENV: Env = {
+	browserUiTheme: 'light',
+	isInIframe: false,
+	isRTL: false,
+};
+
+describe( 'load-sidebar-v2/resolve-config', () => {
+	it( 'should resolve minimal input with defaults', () => {
+		const config = resolveConfig( { host: { appId: 'editor-lite' } }, DEFAULT_ENV );
+
+		expect( config ).toEqual( {
+			host: {
+				appId: 'editor-lite',
+			},
+			boot: {
+				allowInIframe: false,
+			},
+			container: {
+				id: 'angie-sidebar-container',
+				persistOpenState: true,
+				preset: 'sidebar',
+				resizable: true,
+				stylePreset: 'wordpress',
+			},
+			iframe: {
+				isRTL: false,
+				origin: 'https://angie.elementor.com',
+				path: 'angie/embedded',
+				uiTheme: 'light',
+			},
+			callbacks: {
+				onClose: undefined,
+			},
+		} );
+	} );
+
+	it( 'should preserve callbacks.onClose', () => {
+		const onClose = jest.fn();
+		const config = resolveConfig(
+			{
+				callbacks: { onClose },
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.callbacks.onClose ).toBe( onClose );
+	} );
+
+	it( 'should apply env-detected RTL and theme to iframe', () => {
+		const config = resolveConfig(
+			{ host: { appId: 'editor-lite' } },
+			{
+				...DEFAULT_ENV,
+				browserUiTheme: 'dark',
+				isRTL: true,
+			},
+		);
+
+		expect( config.iframe ).toEqual(
+			expect.objectContaining( {
+				isRTL: true,
+				uiTheme: 'dark',
+			} ),
+		);
+	} );
+
+	it( 'should respect boot.allowInIframe in shouldBoot', () => {
+		const config = resolveConfig(
+			{
+				boot: { allowInIframe: false },
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( shouldBoot( config, { ...DEFAULT_ENV, isInIframe: true } ) ).toBe( false );
+		expect( shouldBoot( config, { ...DEFAULT_ENV, isInIframe: false } ) ).toBe( true );
+	} );
+} );

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -21,10 +21,14 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 			},
 			container: {
 				id: 'angie-sidebar-container',
-				persistOpenState: true,
-				preset: 'sidebar',
-				resizable: true,
-				stylePreset: 'wordpress',
+				layout: 'floating-chat',
+				styleTheme: '',
+				persistOpenState: false,
+				resizable: false,
+				chatToggleButton: {
+					enabled: true,
+					id: 'angie-widget-toggle',
+				},
 			},
 			iframe: {
 				isRTL: false,
@@ -35,6 +39,55 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 			callbacks: {
 				onClose: undefined,
 			},
+			widgetConfig: {
+				closeButton: 'close',
+			},
+		} );
+	} );
+
+	it( 'should resolve sidebar layout defaults', () => {
+		const config = resolveConfig(
+			{
+				container: { layout: 'sidebar' },
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.container ).toEqual( {
+			id: 'angie-sidebar-container',
+			layout: 'sidebar',
+			styleTheme: '',
+			persistOpenState: true,
+			resizable: true,
+			chatToggleButton: {
+				enabled: false,
+				id: 'angie-widget-toggle',
+			},
+		} );
+		expect( config.widgetConfig ).toEqual( {
+			closeButton: 'collapse',
+		} );
+	} );
+
+	it( 'should honor explicit chat toggle on sidebar layout', () => {
+		const config = resolveConfig(
+			{
+				container: {
+					layout: 'sidebar',
+					chatToggleButton: {
+						enabled: true,
+						id: 'angie-lite-toggle',
+					},
+				},
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.container.chatToggleButton ).toEqual( {
+			enabled: true,
+			id: 'angie-lite-toggle',
 		} );
 	} );
 
@@ -67,6 +120,64 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 				uiTheme: 'dark',
 			} ),
 		);
+	} );
+
+	it( 'should enable chat toggle by default when layout is floating-chat', () => {
+		const config = resolveConfig(
+			{
+				container: { layout: 'floating-chat' },
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.container.chatToggleButton.enabled ).toBe( true );
+		expect( config.container.chatToggleButton.id ).toBe( 'angie-widget-toggle' );
+	} );
+
+	it( 'should resolve a custom chat toggle button id', () => {
+		const config = resolveConfig(
+			{
+				container: {
+					chatToggleButton: { id: 'angie-lite-toggle' },
+					layout: 'floating-chat',
+				},
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.container.chatToggleButton.id ).toBe( 'angie-lite-toggle' );
+	} );
+
+	it( 'should allow disabling chat toggle explicitly', () => {
+		const config = resolveConfig(
+			{
+				container: {
+					chatToggleButton: { enabled: false },
+					layout: 'floating-chat',
+				},
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.container.chatToggleButton.enabled ).toBe( false );
+	} );
+
+	it( 'should resolve styleTheme independently from layout', () => {
+		const config = resolveConfig(
+			{
+				container: {
+					layout: 'floating-chat',
+					styleTheme: 'wordpress',
+				},
+				host: { appId: 'editor-lite' },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.container.styleTheme ).toBe( 'wordpress' );
 	} );
 
 	it( 'should respect boot.allowInIframe in shouldBoot', () => {

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -27,7 +27,7 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 				resizable: false,
 				chatToggleButton: {
 					enabled: true,
-					id: 'angie-widget-toggle',
+					selector: '#angie-widget-toggle',
 				},
 			},
 			iframe: {
@@ -62,7 +62,7 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 			resizable: true,
 			chatToggleButton: {
 				enabled: false,
-				id: 'angie-widget-toggle',
+				selector: '#angie-widget-toggle',
 			},
 		} );
 		expect( config.widgetConfig ).toEqual( {
@@ -77,7 +77,7 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 					layout: 'sidebar',
 					chatToggleButton: {
 						enabled: true,
-						id: 'angie-lite-toggle',
+						selector: '#angie-lite-toggle',
 					},
 				},
 				host: { appId: 'editor-lite' },
@@ -87,7 +87,7 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 
 		expect( config.container.chatToggleButton ).toEqual( {
 			enabled: true,
-			id: 'angie-lite-toggle',
+			selector: '#angie-lite-toggle',
 		} );
 	} );
 
@@ -132,14 +132,14 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		);
 
 		expect( config.container.chatToggleButton.enabled ).toBe( true );
-		expect( config.container.chatToggleButton.id ).toBe( 'angie-widget-toggle' );
+		expect( config.container.chatToggleButton.selector ).toBe( '#angie-widget-toggle' );
 	} );
 
-	it( 'should resolve a custom chat toggle button id', () => {
+	it( 'should resolve a custom chat toggle button selector', () => {
 		const config = resolveConfig(
 			{
 				container: {
-					chatToggleButton: { id: 'angie-lite-toggle' },
+					chatToggleButton: { selector: '#angie-lite-toggle' },
 					layout: 'floating-chat',
 				},
 				host: { appId: 'editor-lite' },
@@ -147,7 +147,7 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 			DEFAULT_ENV,
 		);
 
-		expect( config.container.chatToggleButton.id ).toBe( 'angie-lite-toggle' );
+		expect( config.container.chatToggleButton.selector ).toBe( '#angie-lite-toggle' );
 	} );
 
 	it( 'should allow disabling chat toggle explicitly', () => {

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -47,7 +47,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 			resizable: container.resizable ?? layoutDefaults.resizable,
 			chatToggleButton: {
 				enabled: chatToggleEnabled,
-				id: container.chatToggleButton?.id?.trim() || DEFAULTS.container.chatToggleButtonId,
+				selector: container.chatToggleButton?.selector?.trim() || DEFAULTS.container.chatToggleButtonSelector,
 			},
 		},
 		iframe: {

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -1,0 +1,45 @@
+import { DEFAULT_CONTAINER_ID, DEFAULTS } from './defaults';
+import type { Env } from './env';
+import type { LoadSidebarV2Options, ResolvedConfigV2 } from './config';
+
+export const shouldBoot = ( config: ResolvedConfigV2, env: Env ): boolean => {
+	if ( ! config.boot.allowInIframe && env.isInIframe ) {
+		return false;
+	}
+
+	return true;
+};
+
+export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): ResolvedConfigV2 => {
+	const boot = options.boot ?? {};
+	const container = options.container ?? {};
+	const iframe = options.iframe ?? {};
+	const callbacks = options.callbacks ?? {};
+
+	return {
+		host: {
+			appId: options.host.appId,
+			aiContext: options.host.aiContext,
+			website: options.host.website,
+		},
+		boot: {
+			allowInIframe: boot.allowInIframe ?? DEFAULTS.boot.allowInIframe,
+		},
+		container: {
+			id: container.id?.trim() || DEFAULT_CONTAINER_ID,
+			preset: container.preset ?? DEFAULTS.container.preset,
+			stylePreset: container.stylePreset ?? DEFAULTS.container.stylePreset,
+			persistOpenState: container.persistOpenState ?? DEFAULTS.container.persistOpenState,
+			resizable: container.resizable ?? DEFAULTS.container.resizable,
+		},
+		iframe: {
+			origin: iframe.origin?.trim() || DEFAULTS.iframe.origin,
+			path: iframe.path?.trim() || DEFAULTS.iframe.path,
+			uiTheme: iframe.uiTheme ?? env.browserUiTheme,
+			isRTL: iframe.isRTL ?? env.isRTL,
+		},
+		callbacks: {
+			onClose: callbacks.onClose,
+		},
+	};
+};

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -1,6 +1,15 @@
 import { DEFAULT_CONTAINER_ID, DEFAULTS } from './defaults';
 import type { Env } from './env';
-import type { LoadSidebarV2Options, ResolvedConfigV2 } from './config';
+import type { LoadSidebarV2Layout, LoadSidebarV2Options, ResolvedConfigV2 } from './config';
+import { FLOATING_CHAT_PRESET_DEFAULTS } from './presets/floating-chat';
+import { SIDEBAR_PRESET_DEFAULTS } from './presets/sidebar';
+import { resolveWidgetConfig } from './widget-config';
+
+const getLayoutDefaults = ( layout: LoadSidebarV2Layout ) => (
+	layout === 'floating-chat'
+		? FLOATING_CHAT_PRESET_DEFAULTS
+		: SIDEBAR_PRESET_DEFAULTS
+);
 
 export const shouldBoot = ( config: ResolvedConfigV2, env: Env ): boolean => {
 	if ( ! config.boot.allowInIframe && env.isInIframe ) {
@@ -16,6 +25,11 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 	const iframe = options.iframe ?? {};
 	const callbacks = options.callbacks ?? {};
 
+	const layout = container.layout ?? DEFAULTS.container.layout;
+	const layoutDefaults = getLayoutDefaults( layout );
+	const styleTheme = container.styleTheme ?? DEFAULTS.container.styleTheme;
+	const chatToggleEnabled = container.chatToggleButton?.enabled ?? layoutDefaults.chatToggleButtonEnabled;
+
 	return {
 		host: {
 			appId: options.host.appId,
@@ -27,10 +41,14 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		},
 		container: {
 			id: container.id?.trim() || DEFAULT_CONTAINER_ID,
-			preset: container.preset ?? DEFAULTS.container.preset,
-			stylePreset: container.stylePreset ?? DEFAULTS.container.stylePreset,
-			persistOpenState: container.persistOpenState ?? DEFAULTS.container.persistOpenState,
-			resizable: container.resizable ?? DEFAULTS.container.resizable,
+			layout,
+			styleTheme,
+			persistOpenState: container.persistOpenState ?? layoutDefaults.persistOpenState,
+			resizable: container.resizable ?? layoutDefaults.resizable,
+			chatToggleButton: {
+				enabled: chatToggleEnabled,
+				id: container.chatToggleButton?.id?.trim() || DEFAULTS.container.chatToggleButtonId,
+			},
 		},
 		iframe: {
 			origin: iframe.origin?.trim() || DEFAULTS.iframe.origin,
@@ -41,5 +59,6 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		callbacks: {
 			onClose: callbacks.onClose,
 		},
+		widgetConfig: resolveWidgetConfig( layout, options.widgetConfig ),
 	};
 };

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -58,6 +58,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		},
 		callbacks: {
 			onClose: callbacks.onClose,
+			getExternalHeaders: callbacks.getExternalHeaders,
 		},
 		widgetConfig: resolveWidgetConfig( layout, options.widgetConfig ),
 	};

--- a/src/load-sidebar-v2/shell.test.ts
+++ b/src/load-sidebar-v2/shell.test.ts
@@ -33,7 +33,7 @@ describe( 'load-sidebar-v2/shell', () => {
 				styleTheme: 'wordpress',
 				persistOpenState: false,
 				resizable: false,
-				chatToggleButton: { enabled: false, id: 'angie-widget-toggle' },
+				chatToggleButton: { enabled: false, selector: '#angie-widget-toggle' },
 			},
 			{ onClose },
 		);
@@ -53,7 +53,7 @@ describe( 'load-sidebar-v2/shell', () => {
 				styleTheme: '',
 				persistOpenState: false,
 				resizable: false,
-				chatToggleButton: { enabled: false, id: 'angie-widget-toggle' },
+				chatToggleButton: { enabled: false, selector: '#angie-widget-toggle' },
 			},
 			{},
 		);
@@ -72,7 +72,7 @@ describe( 'load-sidebar-v2/shell', () => {
 			styleTheme: 'wordpress',
 			persistOpenState: true,
 			resizable: true,
-			chatToggleButton: { enabled: true, id: 'angie-lite-toggle' },
+			chatToggleButton: { enabled: true, selector: '#angie-lite-toggle' },
 		} );
 
 		expect( applyState ).toHaveBeenCalledWith( 'closed' );
@@ -89,7 +89,7 @@ describe( 'load-sidebar-v2/shell', () => {
 			styleTheme: 'wordpress',
 			persistOpenState: true,
 			resizable: true,
-			chatToggleButton: { enabled: true, id: 'angie-lite-toggle' },
+			chatToggleButton: { enabled: true, selector: '#angie-lite-toggle' },
 		} );
 
 		expect( applyState ).not.toHaveBeenCalled();
@@ -102,7 +102,7 @@ describe( 'load-sidebar-v2/shell', () => {
 			styleTheme: 'wordpress',
 			persistOpenState: true,
 			resizable: true,
-			chatToggleButton: { enabled: true, id: 'angie-lite-toggle' },
+			chatToggleButton: { enabled: true, selector: '#angie-lite-toggle' },
 		} );
 
 		expect( loadState ).toHaveBeenCalledWith( 'closed' );
@@ -116,7 +116,7 @@ describe( 'load-sidebar-v2/shell', () => {
 			styleTheme: 'wordpress',
 			persistOpenState: true,
 			resizable: true,
-			chatToggleButton: { enabled: false, id: 'angie-widget-toggle' },
+			chatToggleButton: { enabled: false, selector: '#angie-widget-toggle' },
 		} );
 
 		expect( loadState ).toHaveBeenCalledWith( 'open' );

--- a/src/load-sidebar-v2/shell.test.ts
+++ b/src/load-sidebar-v2/shell.test.ts
@@ -1,14 +1,22 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import { initAngieSidebar, initializeResize, loadState } from '../sidebar';
-import { initSidebarShell } from './shell';
+import { initAngieSidebar, initializeResize, loadState, applyState, getAngieSidebarSavedState } from '../sidebar';
+import { initSidebarShell, applyInitialSidebarShellState, finalizeSidebarShellState } from './shell';
 
 jest.mock( '../sidebar', () => ( {
+	ANGIE_SIDEBAR_STATE_CLOSED: 'closed',
+	ANGIE_SIDEBAR_STATE_OPEN: 'open',
+	applyState: jest.fn(),
+	getAngieSidebarSavedState: jest.fn(),
 	initAngieSidebar: jest.fn(),
 	initializeResize: jest.fn(),
 	loadState: jest.fn(),
 } ) );
 
 describe( 'load-sidebar-v2/shell', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
 	it( 'should invoke onClose when sidebar closes via onToggle', () => {
 		const onClose = jest.fn();
 		let capturedOnToggle: ( ( isOpen: boolean ) => void ) | undefined;
@@ -21,10 +29,11 @@ describe( 'load-sidebar-v2/shell', () => {
 		initSidebarShell(
 			{
 				id: 'angie-sidebar-container',
+				layout: 'sidebar',
+				styleTheme: 'wordpress',
 				persistOpenState: false,
-				preset: 'sidebar',
 				resizable: false,
-				stylePreset: 'wordpress',
+				chatToggleButton: { enabled: false, id: 'angie-widget-toggle' },
 			},
 			{ onClose },
 		);
@@ -34,5 +43,84 @@ describe( 'load-sidebar-v2/shell', () => {
 		expect( onClose ).toHaveBeenCalledTimes( 1 );
 		expect( loadState ).not.toHaveBeenCalled();
 		expect( initializeResize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should skip default css when styleTheme is empty', () => {
+		initSidebarShell(
+			{
+				id: 'angie-sidebar-container',
+				layout: 'sidebar',
+				styleTheme: '',
+				persistOpenState: false,
+				resizable: false,
+				chatToggleButton: { enabled: false, id: 'angie-widget-toggle' },
+			},
+			{},
+		);
+
+		expect( initAngieSidebar ).toHaveBeenCalledWith(
+			expect.objectContaining( { skipDefaultCss: true, styleTheme: '' } ),
+		);
+	} );
+
+	it( 'should start closed when toggle is enabled and no saved open state', () => {
+		( getAngieSidebarSavedState as jest.Mock ).mockReturnValue( null );
+
+		applyInitialSidebarShellState( {
+			id: 'angie-sidebar-container',
+			layout: 'sidebar',
+			styleTheme: 'wordpress',
+			persistOpenState: true,
+			resizable: true,
+			chatToggleButton: { enabled: true, id: 'angie-lite-toggle' },
+		} );
+
+		expect( applyState ).toHaveBeenCalledWith( 'closed' );
+		expect( loadState ).not.toHaveBeenCalled();
+		expect( initializeResize ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should defer open restore until finalize when saved state is open', () => {
+		( getAngieSidebarSavedState as jest.Mock ).mockReturnValue( 'open' );
+
+		applyInitialSidebarShellState( {
+			id: 'angie-sidebar-container',
+			layout: 'sidebar',
+			styleTheme: 'wordpress',
+			persistOpenState: true,
+			resizable: true,
+			chatToggleButton: { enabled: true, id: 'angie-lite-toggle' },
+		} );
+
+		expect( applyState ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should restore persisted state when toggle is enabled', () => {
+		finalizeSidebarShellState( {
+			id: 'angie-sidebar-container',
+			layout: 'sidebar',
+			styleTheme: 'wordpress',
+			persistOpenState: true,
+			resizable: true,
+			chatToggleButton: { enabled: true, id: 'angie-lite-toggle' },
+		} );
+
+		expect( loadState ).toHaveBeenCalledWith( 'closed' );
+		expect( initializeResize ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should restore persisted state when toggle is disabled', () => {
+		finalizeSidebarShellState( {
+			id: 'angie-sidebar-container',
+			layout: 'sidebar',
+			styleTheme: 'wordpress',
+			persistOpenState: true,
+			resizable: true,
+			chatToggleButton: { enabled: false, id: 'angie-widget-toggle' },
+		} );
+
+		expect( loadState ).toHaveBeenCalledWith( 'open' );
+		expect( applyState ).not.toHaveBeenCalled();
+		expect( initializeResize ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/src/load-sidebar-v2/shell.test.ts
+++ b/src/load-sidebar-v2/shell.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import { initAngieSidebar, initializeResize, loadState } from '../sidebar';
+import { initSidebarShell } from './shell';
+
+jest.mock( '../sidebar', () => ( {
+	initAngieSidebar: jest.fn(),
+	initializeResize: jest.fn(),
+	loadState: jest.fn(),
+} ) );
+
+describe( 'load-sidebar-v2/shell', () => {
+	it( 'should invoke onClose when sidebar closes via onToggle', () => {
+		const onClose = jest.fn();
+		let capturedOnToggle: ( ( isOpen: boolean ) => void ) | undefined;
+
+		( initAngieSidebar as jest.Mock ).mockImplementation( ( ...args: unknown[] ) => {
+			const options = args[ 0 ] as { onToggle?: ( isOpen: boolean ) => void };
+			capturedOnToggle = options.onToggle;
+		} );
+
+		initSidebarShell(
+			{
+				id: 'angie-sidebar-container',
+				persistOpenState: false,
+				preset: 'sidebar',
+				resizable: false,
+				stylePreset: 'wordpress',
+			},
+			{ onClose },
+		);
+
+		capturedOnToggle?.( false );
+
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+		expect( loadState ).not.toHaveBeenCalled();
+		expect( initializeResize ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -1,0 +1,26 @@
+import { initAngieSidebar, initializeResize, loadState } from '../sidebar';
+import type { ResolvedConfigV2 } from './config';
+
+export const initSidebarShell = (
+	container: ResolvedConfigV2['container'],
+	callbacks: ResolvedConfigV2['callbacks'],
+): void => {
+	const skipDefaultCss = container.stylePreset === 'chat';
+
+	initAngieSidebar( {
+		onToggle: ( isOpen ) => {
+			if ( ! isOpen && callbacks.onClose ) {
+				callbacks.onClose();
+			}
+		},
+		skipDefaultCss,
+	} );
+
+	if ( container.persistOpenState ) {
+		loadState();
+	}
+
+	if ( container.resizable ) {
+		initializeResize();
+	}
+};

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -1,23 +1,69 @@
-import { initAngieSidebar, initializeResize, loadState } from '../sidebar';
+import {
+	ANGIE_SIDEBAR_STATE_CLOSED,
+	ANGIE_SIDEBAR_STATE_OPEN,
+	applyState,
+	getAngieSidebarSavedState,
+	initAngieSidebar,
+	initializeResize,
+	loadState,
+} from '../sidebar';
 import type { ResolvedConfigV2 } from './config';
+import { ensureSidebarToggleButton, syncSidebarToggleButton } from './sidebar-toggle';
 
 export const initSidebarShell = (
 	container: ResolvedConfigV2['container'],
 	callbacks: ResolvedConfigV2['callbacks'],
 ): void => {
-	const skipDefaultCss = container.stylePreset === 'chat';
+	const skipDefaultCss = container.styleTheme !== 'wordpress';
+	const toggleButtonId = container.chatToggleButton.enabled
+		? container.chatToggleButton.id
+		: undefined;
 
 	initAngieSidebar( {
 		onToggle: ( isOpen ) => {
+			if ( toggleButtonId ) {
+				syncSidebarToggleButton( toggleButtonId, isOpen );
+			}
+
 			if ( ! isOpen && callbacks.onClose ) {
 				callbacks.onClose();
 			}
 		},
 		skipDefaultCss,
+		styleTheme: container.styleTheme,
 	} );
 
+	if ( toggleButtonId ) {
+		ensureSidebarToggleButton( { toggleButtonId } );
+	}
+};
+
+export const applyInitialSidebarShellState = (
+	container: ResolvedConfigV2['container'],
+): void => {
+	if ( ! container.chatToggleButton.enabled ) {
+		return;
+	}
+
+	if (
+		container.persistOpenState &&
+		getAngieSidebarSavedState() === ANGIE_SIDEBAR_STATE_OPEN
+	) {
+		return;
+	}
+
+	applyState( ANGIE_SIDEBAR_STATE_CLOSED );
+};
+
+export const finalizeSidebarShellState = (
+	container: ResolvedConfigV2['container'],
+): void => {
 	if ( container.persistOpenState ) {
-		loadState();
+		loadState(
+			container.chatToggleButton.enabled
+				? ANGIE_SIDEBAR_STATE_CLOSED
+				: ANGIE_SIDEBAR_STATE_OPEN,
+		);
 	}
 
 	if ( container.resizable ) {

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -15,14 +15,14 @@ export const initSidebarShell = (
 	callbacks: ResolvedConfigV2['callbacks'],
 ): void => {
 	const skipDefaultCss = container.styleTheme !== 'wordpress';
-	const toggleButtonId = container.chatToggleButton.enabled
-		? container.chatToggleButton.id
+	const toggleButtonSelector = container.chatToggleButton.enabled
+		? container.chatToggleButton.selector
 		: undefined;
 
 	initAngieSidebar( {
 		onToggle: ( isOpen ) => {
-			if ( toggleButtonId ) {
-				syncSidebarToggleButton( toggleButtonId, isOpen );
+			if ( toggleButtonSelector ) {
+				syncSidebarToggleButton( toggleButtonSelector, isOpen );
 			}
 
 			if ( ! isOpen && callbacks.onClose ) {
@@ -33,8 +33,8 @@ export const initSidebarShell = (
 		styleTheme: container.styleTheme,
 	} );
 
-	if ( toggleButtonId ) {
-		ensureSidebarToggleButton( { toggleButtonId } );
+	if ( toggleButtonSelector ) {
+		ensureSidebarToggleButton( { toggleButtonSelector } );
 	}
 };
 

--- a/src/load-sidebar-v2/sidebar-toggle.test.ts
+++ b/src/load-sidebar-v2/sidebar-toggle.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals
 import { CHAT_TOGGLE_BUTTON_CLASS } from './chat-toggle/constants';
 import { ensureSidebarToggleButton, syncSidebarToggleButton, wireSidebarToggleButton } from './sidebar-toggle';
 
+const TOGGLE_SELECTOR = '#angie-lite-toggle';
+
 describe( 'load-sidebar-v2/sidebar-toggle', () => {
 	beforeEach( () => {
 		document.body.innerHTML = '';
@@ -19,7 +21,7 @@ describe( 'load-sidebar-v2/sidebar-toggle', () => {
 		toggle.id = 'angie-lite-toggle';
 		document.body.appendChild( toggle );
 
-		expect( wireSidebarToggleButton( { toggleButtonId: 'angie-lite-toggle' } ) ).toBe( true );
+		expect( wireSidebarToggleButton( { toggleButtonSelector: TOGGLE_SELECTOR } ) ).toBe( true );
 
 		toggle.click();
 
@@ -31,23 +33,35 @@ describe( 'load-sidebar-v2/sidebar-toggle', () => {
 		toggle.id = 'angie-lite-toggle';
 		document.body.appendChild( toggle );
 
-		syncSidebarToggleButton( 'angie-lite-toggle', true );
+		syncSidebarToggleButton( TOGGLE_SELECTOR, true );
 
 		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
 		expect( toggle.getAttribute( 'aria-label' ) ).toBe( 'Close Angie' );
 	} );
 
+	it( 'should wire host toggle button matched by attribute selector', () => {
+		const toggle = document.createElement( 'button' );
+		toggle.setAttribute( 'data-test', 'header-toggle-angie-chat' );
+		document.body.appendChild( toggle );
+
+		expect( wireSidebarToggleButton( { toggleButtonSelector: '[data-test="header-toggle-angie-chat"]' } ) ).toBe( true );
+
+		toggle.click();
+
+		expect( window.toggleAngieSidebar ).toHaveBeenCalledWith( true );
+	} );
+
 	it( 'should inject and wire toggle button when host element is missing', () => {
-		ensureSidebarToggleButton( { toggleButtonId: 'angie-lite-toggle' } );
+		ensureSidebarToggleButton( { toggleButtonSelector: TOGGLE_SELECTOR } );
 
 		jest.runAllTimers();
 
-		const toggle = document.getElementById( 'angie-lite-toggle' );
+		const toggle = document.querySelector( TOGGLE_SELECTOR );
 		expect( toggle ).not.toBeNull();
 		expect( toggle?.className ).toBe( CHAT_TOGGLE_BUTTON_CLASS );
 		expect( document.getElementById( 'angie-chat-toggle-styles' ) ).not.toBeNull();
 
-		toggle?.click();
+		toggle?.dispatchEvent( new MouseEvent( 'click', { bubbles: true } ) );
 		expect( window.toggleAngieSidebar ).toHaveBeenCalledWith( true );
 	} );
 } );

--- a/src/load-sidebar-v2/sidebar-toggle.test.ts
+++ b/src/load-sidebar-v2/sidebar-toggle.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { CHAT_TOGGLE_BUTTON_CLASS } from './chat-toggle/constants';
+import { ensureSidebarToggleButton, syncSidebarToggleButton, wireSidebarToggleButton } from './sidebar-toggle';
+
+describe( 'load-sidebar-v2/sidebar-toggle', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '';
+		document.getElementById( 'angie-chat-toggle-styles' )?.remove();
+		window.toggleAngieSidebar = jest.fn();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'should wire host toggle button to toggleAngieSidebar', () => {
+		const toggle = document.createElement( 'button' );
+		toggle.id = 'angie-lite-toggle';
+		document.body.appendChild( toggle );
+
+		expect( wireSidebarToggleButton( { toggleButtonId: 'angie-lite-toggle' } ) ).toBe( true );
+
+		toggle.click();
+
+		expect( window.toggleAngieSidebar ).toHaveBeenCalledWith( true );
+	} );
+
+	it( 'should sync aria attributes on the host toggle button', () => {
+		const toggle = document.createElement( 'button' );
+		toggle.id = 'angie-lite-toggle';
+		document.body.appendChild( toggle );
+
+		syncSidebarToggleButton( 'angie-lite-toggle', true );
+
+		expect( toggle.getAttribute( 'aria-expanded' ) ).toBe( 'true' );
+		expect( toggle.getAttribute( 'aria-label' ) ).toBe( 'Close Angie' );
+	} );
+
+	it( 'should inject and wire toggle button when host element is missing', () => {
+		ensureSidebarToggleButton( { toggleButtonId: 'angie-lite-toggle' } );
+
+		jest.runAllTimers();
+
+		const toggle = document.getElementById( 'angie-lite-toggle' );
+		expect( toggle ).not.toBeNull();
+		expect( toggle?.className ).toBe( CHAT_TOGGLE_BUTTON_CLASS );
+		expect( document.getElementById( 'angie-chat-toggle-styles' ) ).not.toBeNull();
+
+		toggle?.click();
+		expect( window.toggleAngieSidebar ).toHaveBeenCalledWith( true );
+	} );
+} );

--- a/src/load-sidebar-v2/sidebar-toggle.ts
+++ b/src/load-sidebar-v2/sidebar-toggle.ts
@@ -1,0 +1,65 @@
+import { injectChatToggleButton, injectChatToggleButtonStyles } from './chat-toggle/widget-ui';
+
+type WireSidebarToggleButtonArgs = {
+	toggleButtonId: string;
+};
+
+export const syncSidebarToggleButton = ( toggleButtonId: string, isOpen: boolean ): void => {
+	const toggleEl = document.getElementById( toggleButtonId );
+
+	if ( ! toggleEl ) {
+		return;
+	}
+
+	toggleEl.setAttribute( 'aria-expanded', isOpen ? 'true' : 'false' );
+	toggleEl.setAttribute( 'aria-label', isOpen ? 'Close Angie' : 'Open Angie' );
+};
+
+const SIDEBAR_TOGGLE_WIRED_ATTR = 'data-angie-sidebar-toggle-wired';
+
+const attachSidebarToggleClickHandler = ( toggleEl: HTMLElement ): void => {
+	if ( toggleEl.getAttribute( SIDEBAR_TOGGLE_WIRED_ATTR ) === 'true' ) {
+		return;
+	}
+
+	toggleEl.setAttribute( SIDEBAR_TOGGLE_WIRED_ATTR, 'true' );
+	toggleEl.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+		const isOpen = toggleEl.getAttribute( 'aria-expanded' ) === 'true';
+		window.toggleAngieSidebar?.( ! isOpen );
+	} );
+};
+
+export const wireSidebarToggleButton = ( args: WireSidebarToggleButtonArgs ): boolean => {
+	const toggleEl = document.getElementById( args.toggleButtonId );
+
+	if ( ! toggleEl ) {
+		return false;
+	}
+
+	attachSidebarToggleClickHandler( toggleEl );
+	return true;
+};
+
+const injectSidebarToggleButton = ( toggleButtonId: string ): void => {
+	injectChatToggleButtonStyles();
+	injectChatToggleButton( toggleButtonId );
+};
+
+export const ensureSidebarToggleButton = ( args: WireSidebarToggleButtonArgs ): void => {
+	const attempt = (): void => {
+		if ( wireSidebarToggleButton( args ) ) {
+			return;
+		}
+
+		injectSidebarToggleButton( args.toggleButtonId );
+
+		if ( wireSidebarToggleButton( args ) ) {
+			return;
+		}
+
+		setTimeout( attempt, 500 );
+	};
+
+	setTimeout( attempt, 100 );
+};

--- a/src/load-sidebar-v2/sidebar-toggle.ts
+++ b/src/load-sidebar-v2/sidebar-toggle.ts
@@ -1,11 +1,12 @@
 import { injectChatToggleButton, injectChatToggleButtonStyles } from './chat-toggle/widget-ui';
+import { findToggleButton } from './chat-toggle/toggle-button-element';
 
 type WireSidebarToggleButtonArgs = {
-	toggleButtonId: string;
+	toggleButtonSelector: string;
 };
 
-export const syncSidebarToggleButton = ( toggleButtonId: string, isOpen: boolean ): void => {
-	const toggleEl = document.getElementById( toggleButtonId );
+export const syncSidebarToggleButton = ( toggleButtonSelector: string, isOpen: boolean ): void => {
+	const toggleEl = findToggleButton( toggleButtonSelector );
 
 	if ( ! toggleEl ) {
 		return;
@@ -31,7 +32,7 @@ const attachSidebarToggleClickHandler = ( toggleEl: HTMLElement ): void => {
 };
 
 export const wireSidebarToggleButton = ( args: WireSidebarToggleButtonArgs ): boolean => {
-	const toggleEl = document.getElementById( args.toggleButtonId );
+	const toggleEl = findToggleButton( args.toggleButtonSelector );
 
 	if ( ! toggleEl ) {
 		return false;
@@ -41,9 +42,9 @@ export const wireSidebarToggleButton = ( args: WireSidebarToggleButtonArgs ): bo
 	return true;
 };
 
-const injectSidebarToggleButton = ( toggleButtonId: string ): void => {
+const injectSidebarToggleButton = ( toggleButtonSelector: string ): void => {
 	injectChatToggleButtonStyles();
-	injectChatToggleButton( toggleButtonId );
+	injectChatToggleButton( toggleButtonSelector );
 };
 
 export const ensureSidebarToggleButton = ( args: WireSidebarToggleButtonArgs ): void => {
@@ -52,7 +53,7 @@ export const ensureSidebarToggleButton = ( args: WireSidebarToggleButtonArgs ): 
 			return;
 		}
 
-		injectSidebarToggleButton( args.toggleButtonId );
+		injectSidebarToggleButton( args.toggleButtonSelector );
 
 		if ( wireSidebarToggleButton( args ) ) {
 			return;

--- a/src/load-sidebar-v2/widget-config.test.ts
+++ b/src/load-sidebar-v2/widget-config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from '@jest/globals';
+import { resolveWidgetConfig } from './widget-config';
+
+describe( 'load-sidebar-v2/widget-config', () => {
+	it( 'should default closeButton to close for floating-chat layout', () => {
+		expect( resolveWidgetConfig( 'floating-chat' ) ).toEqual( {
+			closeButton: 'close',
+		} );
+	} );
+
+	it( 'should allow overriding floating-chat widget config', () => {
+		expect( resolveWidgetConfig( 'floating-chat', { closeButton: 'collapse', title: 'Angie' } ) ).toEqual( {
+			closeButton: 'collapse',
+			title: 'Angie',
+		} );
+	} );
+
+	it( 'should default closeButton to collapse for sidebar layout', () => {
+		expect( resolveWidgetConfig( 'sidebar' ) ).toEqual( {
+			closeButton: 'collapse',
+		} );
+	} );
+
+	it( 'should allow overriding sidebar widget config', () => {
+		expect( resolveWidgetConfig( 'sidebar', { closeButton: 'close' } ) ).toEqual( {
+			closeButton: 'close',
+		} );
+	} );
+} );

--- a/src/load-sidebar-v2/widget-config.ts
+++ b/src/load-sidebar-v2/widget-config.ts
@@ -1,0 +1,31 @@
+import type { WidgetConfig } from '../angie-mcp-sdk';
+import type { LoadSidebarV2Layout } from './config';
+
+const FLOATING_CHAT_WIDGET_DEFAULTS: WidgetConfig = {
+	closeButton: 'close',
+};
+
+const SIDEBAR_WIDGET_DEFAULTS: WidgetConfig = {
+	closeButton: 'collapse',
+};
+
+export const resolveWidgetConfig = (
+	layout: LoadSidebarV2Layout,
+	widgetConfig?: WidgetConfig,
+): WidgetConfig | undefined => {
+	if ( layout === 'floating-chat' ) {
+		return {
+			...FLOATING_CHAT_WIDGET_DEFAULTS,
+			...widgetConfig,
+		};
+	}
+
+	if ( ! widgetConfig ) {
+		return SIDEBAR_WIDGET_DEFAULTS;
+	}
+
+	return {
+		...SIDEBAR_WIDGET_DEFAULTS,
+		...widgetConfig,
+	};
+};

--- a/src/openSaaSPage.ts
+++ b/src/openSaaSPage.ts
@@ -1,10 +1,13 @@
 import { HostEventType } from "./types";
 
+type HostReadyEmbeddedConfig = Record<string, unknown>;
+
 type OpenSaaSPageInput = {
 	origin: string;
 	path: string;
 	parent?: Document;
 	insertCallback?: ( iframe: HTMLIFrameElement ) => void;
+	hostReadyEmbedded?: HostReadyEmbeddedConfig;
 	css: {
 		[key: string]: string | number;
 	},
@@ -77,6 +80,7 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 					iframe.contentWindow?.postMessage( {
 						type: HostEventType.HOST_READY,
 						instanceId,
+						...( props.hostReadyEmbedded ? { embedded: props.hostReadyEmbedded } : {} ),
 					}, iframeUrlObject.origin );
 					break;
 				default:

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -30,4 +30,5 @@ global.console.warn = jest.fn();
 global.console.error = jest.fn();
 
 // Mock CSS imports globally
-jest.mock('../src/sidebar.css', () => '.angie-sidebar { width: 300px; }', { virtual: true }); 
+jest.mock('../src/sidebar.css', () => '.angie-sidebar { width: 300px; }', { virtual: true });
+jest.mock('../src/sidebar-wordpress.css', () => 'body.admin-bar { --angie-sidebar-z-index: 99999; }', { virtual: true });

--- a/src/sidebar-wordpress.css
+++ b/src/sidebar-wordpress.css
@@ -1,0 +1,38 @@
+body.admin-bar {
+    --angie-sidebar-z-index: 99999;
+}
+
+#angie-body-top-padding {
+    height: 0;
+    transition: height 0.3s ease-in-out;
+}
+
+body.angie-sidebar-transitioning #wpadminbar {
+    transition: var(--angie-sidebar-transition) !important;
+}
+
+@media (min-width: 768px) {
+    body.angie-sidebar-active #angie-body-top-padding {
+        width: 100%;
+        height: 0;
+    }
+
+    body.angie-sidebar-active #wpadminbar {
+        inset-inline-start: var(--angie-sidebar-width) !important;
+        inset-inline-end: 0 !important;
+        width: calc(100% - var(--angie-sidebar-width)) !important;
+        margin-top: 0;
+    }
+}
+
+@media (max-width: 768px) {
+    body.angie-sidebar-active #wpadminbar {
+        inset-inline-start: 0 !important;
+        inset-inline-end: 0 !important;
+        width: 100% !important;
+    }
+}
+
+body:not(.wp-admin) #angie-sidebar-container {
+    margin-top: 3px;
+}

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -115,6 +115,19 @@ describe('sidebar', () => {
       expect(styleElement?.textContent).toContain('angie-sidebar');
     });
 
+    it('should inject wordpress theme CSS when styleTheme is wordpress', () => {
+      initAngieSidebar({ styleTheme: 'wordpress' });
+
+      expect(document.getElementById('angie-sidebar-styles')).toBeTruthy();
+      expect(document.getElementById('angie-sidebar-wordpress-styles')).toBeTruthy();
+    });
+
+    it('should not inject wordpress theme CSS when styleTheme is empty', () => {
+      initAngieSidebar({ styleTheme: '', skipDefaultCss: true });
+
+      expect(document.getElementById('angie-sidebar-wordpress-styles')).toBeNull();
+    });
+
     it('should set up window.toggleAngieSidebar', () => {
       initAngieSidebar();
       

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -3,21 +3,26 @@ import { appState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
 import { isOidcFlowInUrl } from "@elementor/oidc-auth";
-import { waitForDocumentReady } from "./utils";
+import { sendSuccessMessage, toggleAngieSidebar as setIframeAccessibility, waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
+import wordpressSidebarCssContent from "./sidebar-wordpress.css?raw";
 
 const sidebarLogger = createChildLogger( 'sidebar' );
 let cssInjected = false;
+let wordpressCssInjected = false;
 
 function injectCSS(): void {
-	if (typeof document === 'undefined' || cssInjected) {
+	if ( typeof document === 'undefined' ) {
 		return;
 	}
 
 	const styleId = 'angie-sidebar-styles';
-	
-	if (document.getElementById(styleId)) {
-		cssInjected = true;
+
+	if ( ! document.getElementById( styleId ) ) {
+		cssInjected = false;
+	}
+
+	if ( cssInjected ) {
 		return;
 	}
 
@@ -29,6 +34,31 @@ function injectCSS(): void {
 	head.insertBefore(style, head.firstChild);
 	
 	cssInjected = true;
+}
+
+function injectWordPressCSS(): void {
+	if ( typeof document === 'undefined' ) {
+		return;
+	}
+
+	const styleId = 'angie-sidebar-wordpress-styles';
+
+	if ( ! document.getElementById( styleId ) ) {
+		wordpressCssInjected = false;
+	}
+
+	if ( wordpressCssInjected ) {
+		return;
+	}
+
+	const style = document.createElement( 'style' );
+	style.id = styleId;
+	style.textContent = wordpressSidebarCssContent;
+
+	const head = document.head || document.getElementsByTagName( 'head' )[ 0 ];
+	head.appendChild( style );
+
+	wordpressCssInjected = true;
 }
 
 export const ANGIE_SIDEBAR_STATE_OPEN = 'open';
@@ -111,13 +141,13 @@ export function forceSidebarClosedDuringOAuth(): void {
 	}
 }
 
-export function loadState(): void {
+export function loadState( defaultState: AngieSidebarState = ANGIE_SIDEBAR_STATE_OPEN ): void {
 	if ( isOidcFlowInUrl() ) {
 		forceSidebarClosedDuringOAuth();
 		return;
 	}
 
-	applyState( getAngieSidebarSavedState() || ANGIE_SIDEBAR_STATE_OPEN );
+	applyState( getAngieSidebarSavedState() || defaultState );
 }
 
 export function applyState( state: AngieSidebarState ): void {
@@ -228,6 +258,10 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 			body.classList.remove( 'angie-sidebar-active' );
 		}
 
+		if ( appState.iframe ) {
+			setIframeAccessibility( appState.iframe, shouldOpen );
+		}
+
 		const focusDelay = skipTransition ? 0 : 300;
 		handleFocus( shouldOpen, focusDelay );
 
@@ -249,13 +283,33 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 	};
 }
 
+let sidebarToggleMessageListenerAttached = false;
+
 export function setupMessageListener(): void {
+	if ( sidebarToggleMessageListenerAttached ) {
+		return;
+	}
+
+	sidebarToggleMessageListenerAttached = true;
+
 	window.addEventListener( 'message', function( event ) {
-		if ( event.data && event.data.type === 'toggleAngieSidebar' ) {
-			const { force, skipTransition } = event.data.payload || {};
-			if ( window.toggleAngieSidebar ) {
-				window.toggleAngieSidebar( force, skipTransition );
-			}
+		if ( event.data?.type !== 'toggleAngieSidebar' ) {
+			return;
+		}
+
+		const iframeOrigin = appState.iframeUrlObject?.origin;
+		if ( iframeOrigin && event.origin !== iframeOrigin ) {
+			return;
+		}
+
+		const { force, skipTransition } = event.data.payload || {};
+		if ( window.toggleAngieSidebar ) {
+			window.toggleAngieSidebar( force, skipTransition );
+		}
+
+		const port = event.ports?.[ 0 ];
+		if ( port ) {
+			sendSuccessMessage( port );
 		}
 	} );
 }
@@ -263,11 +317,16 @@ export function setupMessageListener(): void {
 type InitAngieSidebarOptions = {
 	onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void;
 	skipDefaultCss?: boolean;
+	styleTheme?: 'wordpress' | '';
 };
 
 export function initAngieSidebar( options?: InitAngieSidebarOptions ): void {
 	if ( ! options?.skipDefaultCss ) {
 		injectCSS();
+	}
+
+	if ( options?.styleTheme === 'wordpress' ) {
+		injectWordPressCSS();
 	}
 
 	if ( typeof window !== 'undefined' ) {


### PR DESCRIPTION
## Problem
Host applications integrating Angie need a structured way to boot the sidebar with host-specific context (appId, website, aiContext), container options, and iframe settings. The current SDK surface does not expose a dedicated v2 load API for this.

## Solution
Add `loadSidebarV2` to AngieMcpSdk with a configurable options model, config resolution, container/shell setup, and embedded host handshake.

Jira: https://elementor.atlassian.net/browse/AI-8410