### PR TITLE
[AI-8410] Feature: Host apps can load Angie sidebar with v2 config — host API bridge

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=/demo/" />
+  <title>Angie SDK demos</title>
+</head>
+<body>
+  <p><a href="/demo/">Angie SDK demos</a></p>
+</body>
+</html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSw
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,
+	type ExternalHeadersCallback,
 	type LoadSidebarV2Options,
 } from './load-sidebar-v2/config';
 export { AngieDetector } from './angie-detector';

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -21,6 +21,10 @@ jest.mock( './embedded-handshake', () => ( {
 	sendWidgetConfig: jest.fn(),
 } ) );
 
+jest.mock( './host-api-bridge', () => ( {
+	initHostApiBridge: jest.fn(),
+} ) );
+
 describe( 'load-sidebar-v2/boot-sidebar', () => {
 	let mockApplyState: jest.Mock;
 	let mockInitAngieSidebar: jest.Mock;

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -3,6 +3,7 @@ import { ensureSidebarContainer } from './container';
 import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
 import { readEnv } from './env';
+import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { resolveConfig, shouldBoot } from './resolve-config';
@@ -14,6 +15,11 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 	if ( ! shouldBoot( config, env ) ) {
 		return;
 	}
+
+	initHostApiBridge( {
+		iframeOrigin: config.iframe.origin,
+		getExternalHeaders: config.callbacks.getExternalHeaders,
+	} );
 
 	appState.containerId = config.container.id;
 

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -18,6 +18,7 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 
 	initHostApiBridge( {
 		iframeOrigin: config.iframe.origin,
+		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
 	} );
 

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -45,8 +45,13 @@ export type IframeConfig = {
 
 export type IframeOptions = Partial<IframeConfig>;
 
+export type ExternalHeadersCallback = () =>
+	| Record<string, string | undefined>
+	| Promise<Record<string, string | undefined>>;
+
 export type CallbacksConfig = {
 	onClose?: () => void;
+	getExternalHeaders?: ExternalHeadersCallback;
 };
 
 export type LoadSidebarV2Options = {

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -14,6 +14,7 @@ export type HostConfig = {
 	appId: string;
 	aiContext?: Record<string, unknown>;
 	website?: Record<string, unknown>;
+	analytics?: Record<string, unknown>;
 };
 
 export type BootConfig = {

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { HostLocalStorageEventType } from '../types';
 import type { ExternalHeadersCallback } from './config';
-import { GET_EXTERNAL_HEADERS_MESSAGE_TYPE, initHostApiBridge, resetHostApiBridgeForTests } from './host-api-bridge';
+import {
+	GET_ANALYTICS_CONTEXT_MESSAGE_TYPE,
+	GET_EXTERNAL_HEADERS_MESSAGE_TYPE,
+	GET_WEBSITE_CONTEXT_MESSAGE_TYPE,
+	initHostApiBridge,
+	resetHostApiBridgeForTests,
+} from './host-api-bridge';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -121,5 +128,110 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 			status: 'error',
 			payload: { message: 'Token unavailable' },
 		} );
+	} );
+
+	it( 'should respond with website context from host config', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: {
+				appId: 'test-app',
+				website: { name: 'Custom Site', wpVersion: '6.4' },
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_WEBSITE_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: expect.objectContaining( {
+				payload: expect.objectContaining( {
+					name: 'Custom Site',
+					wpVersion: '6.4',
+					platform: 'frontend',
+					homeUrl: expect.any( String ),
+					timezone: expect.any( String ),
+					today: expect.stringMatching( /^\d{4}-\d{2}-\d{2}$/ ),
+				} ),
+			} ),
+		} );
+	} );
+
+	it( 'should respond with analytics context from host config', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: {
+				appId: 'test-app',
+				analytics: {
+					pluginVersion: '1.0.0',
+					siteKey: 'test-key',
+					plugins: { elementor: true },
+				},
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_ANALYTICS_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: expect.objectContaining( {
+				payload: expect.objectContaining( {
+					pluginVersion: '1.0.0',
+					siteKey: 'test-key',
+					screenPath: expect.any( String ),
+					plugins: { elementor: true },
+				} ),
+			} ),
+		} );
+	} );
+
+	it( 'should handle localStorage GET', async () => {
+		window.localStorage.setItem( 'angie-test-key', 'stored-value' );
+
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: HostLocalStorageEventType.GET, key: 'angie-test-key' },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( { value: 'stored-value' } );
+
+		window.localStorage.removeItem( 'angie-test-key' );
+	} );
+
+	it( 'should handle localStorage SET', async () => {
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: {
+				type: HostLocalStorageEventType.SET,
+				key: 'angie-set-key',
+				value: 'new-value',
+			},
+			origin: IFRAME_ORIGIN,
+		} ) );
+
+		await flushAsync();
+
+		expect( window.localStorage.getItem( 'angie-set-key' ) ).toBe( 'new-value' );
+		window.localStorage.removeItem( 'angie-set-key' );
 	} );
 } );

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { ExternalHeadersCallback } from './config';
+import { GET_EXTERNAL_HEADERS_MESSAGE_TYPE, initHostApiBridge, resetHostApiBridgeForTests } from './host-api-bridge';
+
+const IFRAME_ORIGIN = 'http://localhost:4000';
+
+const createMockPort = () => ( {
+	postMessage: jest.fn(),
+} );
+
+const flushAsync = () => new Promise( ( resolve ) => {
+	setTimeout( resolve, 0 );
+} );
+
+describe( 'load-sidebar-v2/host-api-bridge', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetHostApiBridgeForTests();
+	} );
+
+	it( 'should respond with empty headers when no callback is provided', async () => {
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: {},
+		} );
+	} );
+
+	it( 'should invoke getExternalHeaders callback on each request', async () => {
+		let callCount = 0;
+		const getExternalHeaders: ExternalHeadersCallback = async () => {
+			callCount += 1;
+			return { 'X-Custom-Token': callCount === 1 ? 'first' : 'second' };
+		};
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders,
+		} );
+
+		const firstPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ firstPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( callCount ).toBe( 1 );
+		expect( firstPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Custom-Token': 'first' },
+		} );
+
+		const secondPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ secondPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( callCount ).toBe( 2 );
+		expect( secondPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Custom-Token': 'second' },
+		} );
+	} );
+
+	it( 'should ignore messages from other origins', async () => {
+		const getExternalHeaders = jest.fn( async () => ( { 'X-Custom-Token': 'token' } ) ) as jest.MockedFunction<ExternalHeadersCallback>;
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders,
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: 'https://evil.example',
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( getExternalHeaders ).not.toHaveBeenCalled();
+		expect( port.postMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should respond with error when callback throws', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders: async () => {
+				throw new Error( 'Token unavailable' );
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'error',
+			payload: { message: 'Token unavailable' },
+		} );
+	} );
+} );

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,10 +1,16 @@
 import { sendErrorMessage, sendSuccessMessage } from '../utils';
-import type { ExternalHeadersCallback } from './config';
+import { HostLocalStorageEventType } from '../types';
+import type { ExternalHeadersCallback, HostConfig } from './config';
 
 export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
 
+export const GET_WEBSITE_CONTEXT_MESSAGE_TYPE = 'angie/context/get-website-context';
+
+export const GET_ANALYTICS_CONTEXT_MESSAGE_TYPE = 'angie/context/get-analytics-context';
+
 type InitHostApiBridgeArgs = {
 	iframeOrigin: string;
+	host?: HostConfig;
 	getExternalHeaders?: ExternalHeadersCallback;
 };
 
@@ -17,6 +23,113 @@ const filterDefinedHeaders = (
 	Object.entries( headers ).filter( ( [ , value ] ) => value !== undefined ),
 ) as Record<string, string>;
 
+const getHostDateContext = (): { timezone: string; today: string } => {
+	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const today = new Date().toISOString().split( 'T' )[ 0 ];
+	return { timezone, today };
+};
+
+export const buildWebsiteContextResponse = ( host?: HostConfig ) => ( {
+	payload: {
+		name: document.title,
+		tagline: '',
+		homeUrl: window.location.origin,
+		siteLang: document.documentElement.lang,
+		docTitle: document.title,
+		platform: 'frontend',
+		...getHostDateContext(),
+		...host?.website,
+	},
+} );
+
+export const buildAnalyticsContextResponse = ( host?: HostConfig ) => ( {
+	payload: {
+		screenPath: window.location.pathname,
+		...host?.analytics,
+	},
+} );
+
+const handleGetExternalHeaders = async (
+	port: MessagePort,
+	getExternalHeaders?: ExternalHeadersCallback,
+): Promise<void> => {
+	try {
+		const headers = getExternalHeaders
+			? await getExternalHeaders()
+			: {};
+		sendSuccessMessage( port, filterDefinedHeaders( headers ) );
+	} catch ( error ) {
+		sendErrorMessage( port, {
+			message: error instanceof Error ? error.message : String( error ),
+		} );
+	}
+};
+
+const handleHostLocalStorageGet = ( port: MessagePort, key: string ): void => {
+	try {
+		const value = window.localStorage?.getItem( key ) ?? null;
+		port.postMessage( { value } );
+	} catch {
+		port.postMessage( { value: null } );
+	}
+};
+
+const handleHostLocalStorageSet = ( key: string, value: string ): void => {
+	try {
+		window.localStorage?.setItem( key, value );
+	} catch {
+		// localStorage unavailable (e.g. private browsing mode)
+	}
+};
+
+const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
+	if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+		return;
+	}
+
+	const messageType = event.data?.type;
+	const port = event.ports?.[ 0 ];
+
+	switch ( messageType ) {
+		case GET_EXTERNAL_HEADERS_MESSAGE_TYPE: {
+			if ( ! port ) {
+				return;
+			}
+			await handleGetExternalHeaders( port, bridgeConfig.getExternalHeaders );
+			break;
+		}
+
+		case GET_WEBSITE_CONTEXT_MESSAGE_TYPE: {
+			if ( ! port ) {
+				return;
+			}
+			sendSuccessMessage( port, buildWebsiteContextResponse( bridgeConfig.host ) );
+			break;
+		}
+
+		case GET_ANALYTICS_CONTEXT_MESSAGE_TYPE: {
+			if ( ! port ) {
+				return;
+			}
+			sendSuccessMessage( port, buildAnalyticsContextResponse( bridgeConfig.host ) );
+			break;
+		}
+
+		case HostLocalStorageEventType.GET: {
+			if ( ! port ) {
+				return;
+			}
+			handleHostLocalStorageGet( port, event.data.key );
+			break;
+		}
+
+		case HostLocalStorageEventType.SET: {
+			handleHostLocalStorageSet( event.data.key, event.data.value );
+			break;
+		}
+	}
+};
+
 export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 	bridgeConfig = args;
 
@@ -25,31 +138,8 @@ export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 	}
 
 	bridgeListenerRegistered = true;
-
-	window.addEventListener( 'message', async ( event: MessageEvent ) => {
-		if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
-			return;
-		}
-
-		if ( event.data?.type !== GET_EXTERNAL_HEADERS_MESSAGE_TYPE ) {
-			return;
-		}
-
-		const port = event.ports?.[ 0 ];
-		if ( ! port ) {
-			return;
-		}
-
-		try {
-			const headers = bridgeConfig.getExternalHeaders
-				? await bridgeConfig.getExternalHeaders()
-				: {};
-			sendSuccessMessage( port, filterDefinedHeaders( headers ) );
-		} catch ( error ) {
-			sendErrorMessage( port, {
-				message: error instanceof Error ? error.message : String( error ),
-			} );
-		}
+	window.addEventListener( 'message', ( event: MessageEvent ) => {
+		void handleHostApiMessage( event );
 	} );
 };
 

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,0 +1,58 @@
+import { sendErrorMessage, sendSuccessMessage } from '../utils';
+import type { ExternalHeadersCallback } from './config';
+
+export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
+
+type InitHostApiBridgeArgs = {
+	iframeOrigin: string;
+	getExternalHeaders?: ExternalHeadersCallback;
+};
+
+let bridgeConfig: InitHostApiBridgeArgs | null = null;
+let bridgeListenerRegistered = false;
+
+const filterDefinedHeaders = (
+	headers: Record<string, string | undefined>,
+): Record<string, string> => Object.fromEntries(
+	Object.entries( headers ).filter( ( [ , value ] ) => value !== undefined ),
+) as Record<string, string>;
+
+export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
+	bridgeConfig = args;
+
+	if ( bridgeListenerRegistered ) {
+		return;
+	}
+
+	bridgeListenerRegistered = true;
+
+	window.addEventListener( 'message', async ( event: MessageEvent ) => {
+		if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+			return;
+		}
+
+		if ( event.data?.type !== GET_EXTERNAL_HEADERS_MESSAGE_TYPE ) {
+			return;
+		}
+
+		const port = event.ports?.[ 0 ];
+		if ( ! port ) {
+			return;
+		}
+
+		try {
+			const headers = bridgeConfig.getExternalHeaders
+				? await bridgeConfig.getExternalHeaders()
+				: {};
+			sendSuccessMessage( port, filterDefinedHeaders( headers ) );
+		} catch ( error ) {
+			sendErrorMessage( port, {
+				message: error instanceof Error ? error.message : String( error ),
+			} );
+		}
+	} );
+};
+
+export const resetHostApiBridgeForTests = (): void => {
+	bridgeConfig = null;
+};

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -77,6 +77,16 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		expect( config.callbacks.onClose ).toBe( onClose );
 	} );
 
+	it( 'should preserve callbacks.getExternalHeaders', () => {
+		const getExternalHeaders = jest.fn<() => Record<string, string>>();
+		const config = resolveConfig(
+			{ callbacks: { getExternalHeaders }, host: { appId: 'editor-lite' } },
+			DEFAULT_ENV,
+		);
+
+		expect( config.callbacks.getExternalHeaders ).toBe( getExternalHeaders );
+	} );
+
 	it( 'should apply env-detected RTL and theme to iframe', () => {
 		const config = resolveConfig(
 			{ host: { appId: 'editor-lite' } },

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -60,6 +60,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		},
 		callbacks: {
 			onClose: callbacks.onClose,
+			getExternalHeaders: callbacks.getExternalHeaders,
 		},
 		widgetConfig: resolveWidgetConfig( layout, options.widgetConfig ),
 	};


### PR DESCRIPTION
## Summary

Stacked PR **3/3** for [AI-8410](https://elementor.atlassian.net/browse/AI-8410): **Feature: Host apps can load Angie sidebar with v2 config**.

Adds the host API bridge and `getExternalHeaders` callback wiring for embedded iframe API calls. Completes the split of the original monolithic branch; diff vs `AI-8410-load-sidebar-v2` is bridge-only on top of #44.

## Jira

https://elementor.atlassian.net/browse/AI-8410

## Test plan

- [x] `npm test`
- [x] `npm run lint`
- [ ] Verify host bridge / external headers in a host app

[AI-8410]: https://elementor.atlassian.net/browse/AI-8410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Hosts need bidirectional communication with embedded Angie sidebar to provide external headers, website context, and analytics data. This PR establishes a postMessage-based API bridge enabling the iframe to request host-side information with origin validation.

## 2. What Changed (Where)

- **host-api-bridge.ts** (new): Message handler for GET_EXTERNAL_HEADERS, website/analytics context, and localStorage operations with origin gating
- **config.ts**: Added `ExternalHeadersCallback` type and `analytics` field to HostConfig; wired `getExternalHeaders` through CallbacksConfig
- **boot-sidebar.ts**: Initialize bridge before rendering with iframe origin and callbacks
- **resolve-config.ts**: Pass getExternalHeaders callback through config resolution pipeline
- **Tests & exports**: Added comprehensive bridge tests (237 lines), mocked in boot tests, exported new type

## 3. How It Works

Boot initiates bridge with iframe origin and callback reference → iframe sends MessageEvent with transferable port → bridge validates origin → routes to handler (headers/context/storage) → callback executes if provided → response posted back on port. Undefined headers filtered before sending; errors caught and reported as error payloads.

## 4. Risks

**Origin spoofing**: Mitigated by explicit origin check against configured iframe origin. **Callback exceptions**: Wrapped in try-catch with error reporting. **localStorage failures**: Gracefully degrade in private browsing mode. **No cleanup**: `bridgeListenerRegistered` prevents duplicate listeners but lacks explicit teardown—acceptable for single-boot lifecycle.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
