### PR TITLE
[AI-8410] Prep: sidebar shell hardening and v1 browser demo

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Angie SDK demos</title>
+  <style>
+    body { margin: 0; padding: 2rem; font-family: system-ui, sans-serif; }
+    a { display: block; margin: 0.5rem 0; }
+  </style>
+</head>
+<body>
+  <h1>Angie SDK demos</h1>
+  <a href="./load-sidebar-v1-demo/">loadSidebar (v1)</a>
+</body>
+</html>

--- a/demo/load-sidebar-v1-demo/host.js
+++ b/demo/load-sidebar-v1-demo/host.js
@@ -1,0 +1,6 @@
+import { AngieMcpSdk } from '../../dist/index.js';
+
+const sdk = new AngieMcpSdk();
+
+await sdk.loadSidebar();
+window.toggleAngieSidebar?.( true );

--- a/demo/load-sidebar-v1-demo/index.html
+++ b/demo/load-sidebar-v1-demo/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>loadSidebar v1 demo</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/types.js": "/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod/v4": "/node_modules/zod/v4/index.js"
+    }
+  }
+  </script>
+  <style>
+    body { margin: 0; padding: 1rem; font-family: system-ui, sans-serif; }
+  </style>
+</head>
+<body>
+  <p>Host page — legacy <code>loadSidebar()</code> (v1 API)</p>
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <script type="module" src="./host.js"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "dev": "tsc --watch",
     "test": "jest",
     "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix"
+    "lint:fix": "eslint src/**/*.ts --fix",
+    "demo": "npm run build && npx --yes serve . -l 8080"
   },
   "keywords": [
     "mcp",

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -8,6 +8,7 @@ import { HostEventType, MessageEventType } from './types';
 import { isMobile, isSafeUrl, sendSuccessMessage, toggleAngieSidebar } from './utils';
 import { ANGIE_SDK_VERSION } from './version';
 import { openSaaSPage } from './openSaaSPage';
+import { setAngieIframeRef } from './angie-iframe-utils';
 
 type OpenIframeProps = {
 	origin?: string;
@@ -138,13 +139,6 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 
 		// Insert iframe into sidebar
 		sidebarContainer?.appendChild( iframeElement );
-
-		toggleAngieSidebar( iframeElement, true );
-
-		// Focus management after iframe loads
-		iframeElement.addEventListener( 'load', () => {
-			iframeElement.focus();
-		} );
 	};
 
 	// Determine CSS styling based on mode
@@ -168,6 +162,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 
 	appState.iframe = iframe;
 	appState.iframeUrlObject = iframeUrlObject;
+	setAngieIframeRef( iframe );
 
 	addLocalStorageListener();
 

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -6,6 +6,7 @@ import {
   ANGIE_SIDEBAR_STATE_OPEN,
   ANGIE_SIDEBAR_STATE_CLOSED,
 } from './sidebar';
+import { appState } from './config';
 
 // CSS is mocked globally in setupTests.ts
 
@@ -23,6 +24,8 @@ jest.mock('./iframe', () => ({
 
 jest.mock('./utils', () => ({
   waitForDocumentReady: jest.fn().mockImplementation(() => Promise.resolve()),
+  sendSuccessMessage: jest.fn(),
+  toggleAngieSidebar: jest.fn(),
 }));
 
 describe('sidebar', () => {
@@ -151,4 +154,52 @@ describe('sidebar', () => {
       );
     });
   });
+
+  describe('setupMessageListener', () => {
+    const trustedOrigin = 'https://angie.example.com';
+
+    beforeEach(() => {
+      const sidebarContainer = document.createElement('div');
+      sidebarContainer.id = 'angie-sidebar-container';
+      document.body.appendChild(sidebarContainer);
+      appState.iframeUrlObject = new URL( 'https://angie.example.com/angie/embedded' );
+      initAngieSidebar();
+      ( global.window as any ).toggleAngieSidebar = jest.fn();
+    });
+
+    it( 'should ignore toggleAngieSidebar messages from untrusted origins', () => {
+      const toggle = ( global.window as any ).toggleAngieSidebar as jest.Mock;
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: 'https://evil.example.com',
+        data: { type: 'toggleAngieSidebar', payload: { force: true } },
+      } ) );
+
+      expect( toggle ).not.toHaveBeenCalled();
+    } );
+
+    it( 'should handle toggleAngieSidebar from the iframe origin', () => {
+      const toggle = ( global.window as any ).toggleAngieSidebar as jest.Mock;
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: trustedOrigin,
+        data: { type: 'toggleAngieSidebar', payload: { force: true } },
+      } ) );
+
+      expect( toggle ).toHaveBeenCalledWith( true, undefined );
+    } );
+
+    it( 'should ack toggleAngieSidebar requests over MessagePort', () => {
+      const { sendSuccessMessage } = require( './utils' ) as { sendSuccessMessage: jest.Mock };
+      const port = { postMessage: jest.fn() } as unknown as MessagePort;
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: trustedOrigin,
+        data: { type: 'toggleAngieSidebar', payload: { force: false } },
+        ports: [ port ],
+      } ) );
+
+      expect( sendSuccessMessage ).toHaveBeenCalledWith( port );
+    } );
+  } );
 });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -3,7 +3,7 @@ import { appState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
 import { isOidcFlowInUrl } from "@elementor/oidc-auth";
-import { waitForDocumentReady } from "./utils";
+import { sendSuccessMessage, toggleAngieSidebar as setIframeAccessibility, waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
 
 const sidebarLogger = createChildLogger( 'sidebar' );
@@ -111,13 +111,13 @@ export function forceSidebarClosedDuringOAuth(): void {
 	}
 }
 
-export function loadState(): void {
+export function loadState( defaultState: AngieSidebarState = ANGIE_SIDEBAR_STATE_OPEN ): void {
 	if ( isOidcFlowInUrl() ) {
 		forceSidebarClosedDuringOAuth();
 		return;
 	}
 
-	applyState( getAngieSidebarSavedState() || ANGIE_SIDEBAR_STATE_OPEN );
+	applyState( getAngieSidebarSavedState() || defaultState );
 }
 
 export function applyState( state: AngieSidebarState ): void {
@@ -228,6 +228,10 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 			body.classList.remove( 'angie-sidebar-active' );
 		}
 
+		if ( appState.iframe ) {
+			setIframeAccessibility( appState.iframe, shouldOpen );
+		}
+
 		const focusDelay = skipTransition ? 0 : 300;
 		handleFocus( shouldOpen, focusDelay );
 
@@ -249,13 +253,33 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 	};
 }
 
+let sidebarToggleMessageListenerAttached = false;
+
 export function setupMessageListener(): void {
+	if ( sidebarToggleMessageListenerAttached ) {
+		return;
+	}
+
+	sidebarToggleMessageListenerAttached = true;
+
 	window.addEventListener( 'message', function( event ) {
-		if ( event.data && event.data.type === 'toggleAngieSidebar' ) {
-			const { force, skipTransition } = event.data.payload || {};
-			if ( window.toggleAngieSidebar ) {
-				window.toggleAngieSidebar( force, skipTransition );
-			}
+		if ( event.data?.type !== 'toggleAngieSidebar' ) {
+			return;
+		}
+
+		const iframeOrigin = appState.iframeUrlObject?.origin;
+		if ( iframeOrigin && event.origin !== iframeOrigin ) {
+			return;
+		}
+
+		const { force, skipTransition } = event.data.payload || {};
+		if ( window.toggleAngieSidebar ) {
+			window.toggleAngieSidebar( force, skipTransition );
+		}
+
+		const port = event.ports?.[ 0 ];
+		if ( port ) {
+			sendSuccessMessage( port );
 		}
 	} );
 }


### PR DESCRIPTION
## Summary
- Tie iframe accessibility (`aria-hidden`, `tabindex`) to sidebar toggle state instead of iframe insert time
- Harden `toggleAngieSidebar` postMessage handling: idempotent listener, iframe origin check, MessagePort ack
- Wire `setAngieIframeRef` when opening the iframe
- Add `demo/load-sidebar-v1-demo` and `npm run demo` to verify legacy `loadSidebar()` locally

Prep for [AI-8410] loadSidebarV2 — safe to merge before the v2 API PR.

## Test plan
- [x] `npm test`
- [x] `npm run lint`
- [ ] `npm run demo` → http://localhost:8080/demo/load-sidebar-v1-demo/

## Links
- Jira: https://elementor.atlassian.net/browse/AI-8410
- Follow-up PR: #43 (loadSidebarV2 core)

[AI-8410]: https://elementor.atlassian.net/browse/AI-8410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Hardening sidebar iframe messaging with origin validation and refactoring focus/accessibility management into dedicated utilities. Adds v1 API demo to validate `loadSidebar()` UX in browser environment.

## 2. What Changed (Where)

- **src/iframe.ts**: Removed inline focus/toggle logic; delegates to `setAngieIframeRef()` utility
- **src/sidebar.ts**: Added origin validation + MessagePort ack in `setupMessageListener()`; parameterized `loadState()` with default state; added guard against duplicate listener attachment
- **src/angie-iframe-utils.ts**: New `setAngieIframeRef()` hook (inferred from imports)
- **demo/**: Added v1 browser demo (`load-sidebar-v1-demo/`) with host page + import maps
- **package.json**: Added `lint:fix` script and `demo` serve script
- **src/sidebar.test.ts**: Added origin validation + MessagePort ack test coverage

## 3. How It Works

Message flow now validates: (1) event type check, (2) origin matches `appState.iframeUrlObject.origin`, (3) executes toggle, (4) sends ack via port if provided. Focus/accessibility calls moved to sidebar's toggle handler, triggered on iframe load via `setAngieIframeRef()` callback.

## 4. Risks

**Timing dependency**: `setAngieIframeRef()` must execute before iframe load fires; if delayed, focus may miss. **Duplicate listener guard**: Relies on module-level flag; async init races could bypass (mitigate: call `setupMessageListener()` once in `initAngieSidebar()`). **Origin validation**: Blocks legit cross-origin scenarios if iframe URL not set early enough.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
