### PR TITLE
[AI-8410] loadSidebarV2 host API bridge, context, and integration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This SDK enables you to create custom MCP servers that Angie can discover and us
 - [Error Handling](#error-handling)
 - [Changelog](#changelog)
 - [Demo Plugin](#demo-plugin)
+- [Embedded Angie in any web page](#embedded-angie-loadsidebarv2)
 - [Debugging & Testing](#debugging--testing)
 - [FAQ](#faq)
 
@@ -485,6 +486,11 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 ## Demo Plugin
 
 **For more examples, see the demo plugin and MCP server in the example folder**
+
+## Embedded Angie in any web page
+
+To embed the Angie UI in your own site (sidebar or floating chat), use `AngieMcpSdk.loadSidebarV2()`. See the dedicated guide: [loadSidebarV2](./src/load-sidebar-v2/README.md).
+
 
 If you have questions or need help, open an issue or contact the Elementor team! 
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -12,7 +12,8 @@
 <body>
   <h1>Angie SDK demos</h1>
   <a href="./load-sidebar-v1-demo/">loadSidebar (v1)</a>
-  <a href="./load-sidebar-v2-floating-chat/">loadSidebarV2 — floatingChat</a>
   <a href="./load-sidebar-v2-sidebar/">loadSidebarV2 — sidebar</a>
+  <a href="./load-sidebar-v2-floating-chat/">loadSidebarV2 — floatingChat</a>
+  <a href="./load-sidebar-v2-full-config/">loadSidebarV2 — full example</a>
 </body>
 </html>

--- a/demo/load-sidebar-v2-floating-chat/index.html
+++ b/demo/load-sidebar-v2-floating-chat/index.html
@@ -17,7 +17,8 @@
   </style>
 </head>
 <body>
-  <p>Host page — <code>loadSidebarV2</code> with <code>layout: LAYOUT_FLOATING_CHAT</code></p>
+  <p><a href="../">← All demos</a></p>
+  <p>Minimal <code>loadSidebarV2</code> with <code>layout: floatingChat</code>.</p>
   <div id="angie-sidebar-container" aria-hidden="true"></div>
   <script type="module" src="./host.js"></script>
 </body>

--- a/demo/load-sidebar-v2-full-config/demo-host.css
+++ b/demo/load-sidebar-v2-full-config/demo-host.css
@@ -1,0 +1,57 @@
+/**
+ * Host-owned styles for loadSidebarV2 (sidebar layout).
+ *
+ * Toggle: your element — use the same selector as container.chatToggleButton.selector (#demo-toggle).
+ * Panel: container.id (default angie-sidebar-container). SDK sets layout when open (body.angie-sidebar-active).
+ * Iframe: #angie-iframe inside the container.
+ */
+
+:root {
+	--angie-sidebar-width: 380px;
+	--angie-sidebar-z-index: 1300;
+	/* Extra space between the sidebar panel and your page content */
+	--angie-sidebar-content-gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+	body.angie-sidebar-active {
+		padding-inline-start: calc(var(--angie-sidebar-width) + var(--angie-sidebar-content-gap)) !important;
+	}
+}
+
+/* Host toggle button (not injected by the SDK) */
+#demo-toggle {
+	padding: 0.6rem 1.25rem;
+	font: inherit;
+	font-weight: 600;
+	color: #fff;
+	background: linear-gradient(135deg, #4f46e5, #7c3aed);
+	border: none;
+	border-radius: 999px;
+	cursor: pointer;
+	box-shadow: 0 4px 14px rgba(79, 70, 229, 0.35);
+}
+
+#demo-toggle:hover {
+	filter: brightness(1.05);
+}
+
+#demo-toggle[aria-expanded="true"] {
+	background: linear-gradient(135deg, #374151, #1f2937);
+}
+
+/* Sidebar panel — override SDK defaults (see src/sidebar.css) */
+#angie-sidebar-container {
+	background: #f8fafc;
+	box-shadow: 4px 0 24px rgba(15, 23, 42, 0.12);
+	border-inline-end: 1px solid #e2e8f0;
+}
+
+body.angie-sidebar-active #angie-sidebar-container {
+	border-inline-end-color: #c7d2fe;
+}
+
+/* Angie iframe inside the panel */
+#angie-sidebar-container iframe#angie-iframe {
+	border-radius: 12px 0 0 0;
+}

--- a/demo/load-sidebar-v2-full-config/host.js
+++ b/demo/load-sidebar-v2-full-config/host.js
@@ -1,0 +1,72 @@
+import { AngieMcpSdk, LAYOUT_SIDEBAR } from '../../dist/index.js';
+
+const root = document.getElementById( 'demo-host-app' );
+
+const aiContext = {
+	whatUserSees: {
+		screen: 'Product editor',
+		productName: root?.querySelector( '[data-field="name"]' )?.textContent?.trim() ?? 'Wireless Headphones',
+		status: root?.dataset.status ?? 'draft',
+		price: `$${ root?.dataset.price ?? '79.99' }`,
+		sku: root?.dataset.sku ?? 'WH-100',
+		description: root?.querySelector( '[data-field="description"]' )?.textContent?.trim() ?? '',
+	},
+	whatUserCanDo: [
+		'Edit the product name, description, price, and status',
+		'Publish the product when ready (currently draft)',
+		'Ask Angie to improve the description or suggest a publish checklist',
+	],
+};
+
+const sdk = new AngieMcpSdk();
+
+await sdk.loadSidebarV2( {
+	host: {
+		appId: 'demo-full-config',
+		aiContext,
+	},
+	boot: {
+		allowInIframe: false,
+	},
+	container: {
+		// Default id angie-sidebar-container — matches SDK sidebar.css; override in demo-host.css
+		layout: LAYOUT_SIDEBAR,
+		styleTheme: 'wordpress',
+		persistOpenState: true,
+		resizable: true,
+		chatToggleButton: {
+			enabled: true,
+			selector: '#demo-toggle',
+		},
+	},
+	iframe: {
+		origin: 'https://angie.elementor.com',
+		path: 'angie/embedded',
+		uiTheme: 'light',
+		isRTL: false,
+	},
+	callbacks: {
+		onClose: () => console.log( 'onClose' ),
+		getExternalHeaders: async () => ( {
+			'X-Demo-App-Id': 'demo-full-config',
+		} ),
+	},
+	widgetConfig: {
+		title: 'Angie',
+		subtitle: 'Acme Store Builder',
+		suggestions: {
+			items: [
+				{
+					label: 'What am I looking at?',
+					value: 'What do I see on this screen?',
+				},
+				{
+					label: 'What can I do here?',
+					value: 'What can I do on this screen?',
+				},
+			],
+		},
+		aiContextGuidance: { enabled: true },
+		closeButton: 'collapse',
+	},
+} );

--- a/demo/load-sidebar-v2-full-config/index.html
+++ b/demo/load-sidebar-v2-full-config/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>loadSidebarV2 — full config example</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/types.js": "/node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod/v4": "/node_modules/zod/v4/index.js"
+    }
+  }
+  </script>
+  <link rel="stylesheet" href="./demo-host.css" />
+  <style>
+    body { margin: 0; padding: 1rem; font-family: system-ui, sans-serif; max-width: 40rem; }
+    a { color: #2563eb; }
+    #demo-host-app { margin: 1rem 0; padding: 1rem; border: 1px solid #d8dde6; border-radius: 6px; }
+    #demo-host-app h2 { margin: 0 0 0.5rem; font-size: 1.1rem; }
+  </style>
+</head>
+<body>
+  <p><a href="../">← All demos</a></p>
+  <h1>loadSidebarV2 — full config</h1>
+  <p>
+    Options in <code>host.js</code>. Host styles in <code>demo-host.css</code>
+    (<code>#demo-toggle</code>, <code>#angie-sidebar-container</code>, <code>iframe#angie-iframe</code>).
+  </p>
+  <main
+    id="demo-host-app"
+    data-screen-id="product-editor"
+    data-product-id="prod_42"
+    data-status="draft"
+    data-price="79.99"
+    data-sku="WH-100"
+  >
+    <h2 data-field="name">Wireless Headphones</h2>
+    <p><strong>Status:</strong> draft · <strong>Price:</strong> $79.99 · <strong>SKU:</strong> WH-100</p>
+    <p data-field="description">
+      Lightweight over-ear headphones with noise isolation.
+    </p>
+  </main>
+  <button type="button" id="demo-toggle">Open Angie</button>
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <script type="module" src="./host.js"></script>
+</body>
+</html>

--- a/demo/load-sidebar-v2-sidebar/index.html
+++ b/demo/load-sidebar-v2-sidebar/index.html
@@ -14,14 +14,12 @@
   </script>
   <style>
     body { margin: 0; padding: 1rem; font-family: system-ui, sans-serif; }
-    #demo-sidebar-toggle {
-      padding: 0.5rem 1rem;
-      cursor: pointer;
-    }
+    #demo-sidebar-toggle { padding: 0.5rem 1rem; cursor: pointer; }
   </style>
 </head>
 <body>
-  <p>Host page — <code>loadSidebarV2</code> with <code>layout: sidebar</code></p>
+  <p><a href="../">← All demos</a></p>
+  <p>Minimal <code>loadSidebarV2</code> with <code>layout: sidebar</code>.</p>
   <button type="button" id="demo-sidebar-toggle">Open Angie</button>
   <div id="angie-sidebar-container" aria-hidden="true"></div>
   <script type="module" src="./host.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta http-equiv="refresh" content="0; url=/demo/" />
+  <title>Angie SDK demos</title>
+</head>
+<body>
+  <p><a href="/demo/">Angie SDK demos</a></p>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.8",
+  "version": "1.4.9",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSw
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,
+	type ExternalHeadersCallback,
 	type LoadSidebarV2Options,
 } from './load-sidebar-v2/config';
 export { AngieDetector } from './angie-detector';

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -1,0 +1,134 @@
+# loadSidebarV2
+
+Embeds the Angie assistant in a host page (SaaS app, WordPress frontend, or any site) via an iframe and a small host-side shell. Use `AngieMcpSdk.loadSidebarV2()` from the public package API.
+
+## Quick start
+
+```typescript
+import { AngieMcpSdk, LAYOUT_FLOATING_CHAT } from '@elementor/angie-sdk';
+
+const sdk = new AngieMcpSdk();
+
+await sdk.loadSidebarV2({
+  host: { appId: 'my-app' },
+  container: { layout: LAYOUT_FLOATING_CHAT },
+});
+```
+
+**Sidebar layout** (dock-style panel, resizable, open state persisted):
+
+```typescript
+await sdk.loadSidebarV2({
+  host: { appId: 'my-app' },
+  container: {
+    layout: 'sidebar',
+    styleTheme: 'wordpress',
+    chatToggleButton: {
+      enabled: true,
+      selector: '#my-toggle',
+    },
+  },
+});
+```
+
+Local demos:
+
+- [`demo/load-sidebar-v2-sidebar/`](../../demo/load-sidebar-v2-sidebar/) — minimal sidebar
+- [`demo/load-sidebar-v2-floating-chat/`](../../demo/load-sidebar-v2-floating-chat/) — minimal floating chat
+- [`demo/load-sidebar-v2-full-config/`](../../demo/load-sidebar-v2-full-config/) — full example (`aiContext`, custom CSS)
+
+## Layouts
+
+| Layout | Constant | Typical use |
+|--------|----------|-------------|
+| Sidebar | `LAYOUT_SIDEBAR` (`'sidebar'`) | Fixed side panel, resize, persist open/closed |
+| Floating chat | `LAYOUT_FLOATING_CHAT` (`'floatingChat'`) | Bottom-corner widget with optional injected toggle button |
+
+Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `resizable`, `chatToggleButton`, etc.). Override any field via `container` options.
+
+## Configuration
+
+`LoadSidebarV2Options` (see [`config.ts`](./config.ts)):
+
+| Section | Purpose |
+|---------|---------|
+| `host` | **Required.** `appId`, optional `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
+| `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
+| `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
+| `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
+| `callbacks` | `onClose`, `getExternalHeaders` for auth/API headers |
+| `widgetConfig` | Close button behavior (`collapse` vs `close`); layout-specific defaults in [`widget-config.ts`](./widget-config.ts) |
+
+Embedded config uses `configVersion: 2` (`LOAD_SIDEBAR_V2_CONFIG_VERSION`).
+
+### host.aiContext
+
+Object passed in `embedded.aiContext` on `HOST_READY` (and `sdk-embedded-config`). The embedded Angie app injects it into the agent so replies can use your host app state.
+
+Keep it focused on what helps the agent answer screen-level questions:
+
+| Key | Purpose |
+|-----|---------|
+| `whatUserSees` | What is on the current screen (labels, selection, visible fields) |
+| `whatUserCanDo` | Actions the user can take on this screen |
+
+Example: [`demo/load-sidebar-v2-full-config/host.js`](../../demo/load-sidebar-v2-full-config/host.js) reads `#demo-host-app` into `whatUserSees` and lists allowed actions in `whatUserCanDo`.
+
+Enable `widgetConfig.aiContextGuidance: { enabled: true }` so users see that host context is available.
+
+### Custom CSS (toggle + sidebar panel)
+
+| Target | Selector | Notes |
+|--------|----------|--------|
+| Toggle button | Your selector (e.g. `#my-angie-toggle`) | Host DOM; wire via `container.chatToggleButton.selector` |
+| Sidebar panel | `#${container.id}` (default `#angie-sidebar-container`) | SDK injects layout rules in `src/sidebar.css` |
+| Panel width / z-index | `:root { --angie-sidebar-width; --angie-sidebar-z-index; }` | Read by SDK when opening/resizing |
+| Gap from sidebar | `body.angie-sidebar-active { padding-inline-start: calc(var(--angie-sidebar-width) + 1.5rem) }` | SDK sets padding to width only; add your own gap (see demo CSS) |
+| Iframe | `#angie-sidebar-container iframe#angie-iframe` | `id="angie-iframe"` is set by the SDK |
+
+If you use a custom `container.id`, copy or adapt the rules from `sidebar.css` for your id.
+
+Example: [`demo/load-sidebar-v2-full-config/demo-host.css`](../../demo/load-sidebar-v2-full-config/demo-host.css).
+
+## Boot flow
+
+```
+loadSidebarV2(options)
+  → resolveConfig + shouldBoot
+  → initHostApiBridge (postMessage API)
+  → ensureSidebarContainer
+  → layout strategy (initShell → open iframe → afterOpen)
+  → sendEmbeddedConfig / sendWidgetConfig
+```
+
+Entry point: [`boot-sidebar.ts`](./boot-sidebar.ts). Layout strategies: [`layouts/index.ts`](./layouts/index.ts).
+
+## Host API bridge
+
+[`host-api-bridge.ts`](./host-api-bridge.ts) listens for messages from the Angie iframe (origin-checked) and responds on a `MessagePort`:
+
+- `GET_EXTERNAL_HEADERS` — `callbacks.getExternalHeaders()`
+- `angie/context/get-website-context` — host + document metadata
+- `angie/context/get-analytics-context` — screen path + `host.analytics`
+- Host localStorage get/set (for embedded persistence)
+
+## Module map
+
+| File / folder | Role |
+|---------------|------|
+| `boot-sidebar.ts` | Orchestration |
+| `resolve-config.ts` | Merge options, env, presets |
+| `open-embedded-iframe.ts` | Open iframe via shared `iframe.ts` |
+| `embedded-handshake.ts` | Post-open config messages |
+| `shell.ts`, `sidebar-toggle.ts` | Sidebar layout DOM/state |
+| `chat-toggle/` | Floating chat shell and toggle UI |
+| `presets/` | Per-layout defaults |
+| `inject-style-theme.ts` | Optional WordPress theme CSS |
+
+## Tests
+
+Jest specs live next to modules (`*.test.ts`). Run the package test script from the repo root.
+
+## Exports
+
+From `@elementor/angie-sdk`: `loadSidebarV2` on `AngieMcpSdk`, plus `LAYOUT_SIDEBAR`, `LAYOUT_FLOATING_CHAT`, `LoadSidebarV2Options`, `ExternalHeadersCallback`.

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -21,6 +21,10 @@ jest.mock( './embedded-handshake', () => ( {
 	sendWidgetConfig: jest.fn(),
 } ) );
 
+jest.mock( './host-api-bridge', () => ( {
+	initHostApiBridge: jest.fn(),
+} ) );
+
 describe( 'load-sidebar-v2/boot-sidebar', () => {
 	let mockApplyState: jest.Mock;
 	let mockInitAngieSidebar: jest.Mock;

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -3,6 +3,7 @@ import { ensureSidebarContainer } from './container';
 import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
 import { readEnv } from './env';
+import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { resolveConfig, shouldBoot } from './resolve-config';
@@ -14,6 +15,11 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 	if ( ! shouldBoot( config, env ) ) {
 		return;
 	}
+
+	initHostApiBridge( {
+		iframeOrigin: config.iframe.origin,
+		getExternalHeaders: config.callbacks.getExternalHeaders,
+	} );
 
 	appState.containerId = config.container.id;
 

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -18,6 +18,7 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 
 	initHostApiBridge( {
 		iframeOrigin: config.iframe.origin,
+		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
 	} );
 

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -45,8 +45,13 @@ export type IframeConfig = {
 
 export type IframeOptions = Partial<IframeConfig>;
 
+export type ExternalHeadersCallback = () =>
+	| Record<string, string | undefined>
+	| Promise<Record<string, string | undefined>>;
+
 export type CallbacksConfig = {
 	onClose?: () => void;
+	getExternalHeaders?: ExternalHeadersCallback;
 };
 
 export type LoadSidebarV2Options = {

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -14,6 +14,7 @@ export type HostConfig = {
 	appId: string;
 	aiContext?: Record<string, unknown>;
 	website?: Record<string, unknown>;
+	analytics?: Record<string, unknown>;
 };
 
 export type BootConfig = {

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -1,6 +1,13 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { HostLocalStorageEventType } from '../types';
 import type { ExternalHeadersCallback } from './config';
-import { GET_EXTERNAL_HEADERS_MESSAGE_TYPE, initHostApiBridge, resetHostApiBridgeForTests } from './host-api-bridge';
+import {
+	GET_ANALYTICS_CONTEXT_MESSAGE_TYPE,
+	GET_EXTERNAL_HEADERS_MESSAGE_TYPE,
+	GET_WEBSITE_CONTEXT_MESSAGE_TYPE,
+	initHostApiBridge,
+	resetHostApiBridgeForTests,
+} from './host-api-bridge';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -121,5 +128,110 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 			status: 'error',
 			payload: { message: 'Token unavailable' },
 		} );
+	} );
+
+	it( 'should respond with website context from host config', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: {
+				appId: 'test-app',
+				website: { name: 'Custom Site', wpVersion: '6.4' },
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_WEBSITE_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: expect.objectContaining( {
+				payload: expect.objectContaining( {
+					name: 'Custom Site',
+					wpVersion: '6.4',
+					platform: 'frontend',
+					homeUrl: expect.any( String ),
+					timezone: expect.any( String ),
+					today: expect.stringMatching( /^\d{4}-\d{2}-\d{2}$/ ),
+				} ),
+			} ),
+		} );
+	} );
+
+	it( 'should respond with analytics context from host config', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: {
+				appId: 'test-app',
+				analytics: {
+					pluginVersion: '1.0.0',
+					siteKey: 'test-key',
+					plugins: { elementor: true },
+				},
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_ANALYTICS_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: expect.objectContaining( {
+				payload: expect.objectContaining( {
+					pluginVersion: '1.0.0',
+					siteKey: 'test-key',
+					screenPath: expect.any( String ),
+					plugins: { elementor: true },
+				} ),
+			} ),
+		} );
+	} );
+
+	it( 'should handle localStorage GET', async () => {
+		window.localStorage.setItem( 'angie-test-key', 'stored-value' );
+
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: HostLocalStorageEventType.GET, key: 'angie-test-key' },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( { value: 'stored-value' } );
+
+		window.localStorage.removeItem( 'angie-test-key' );
+	} );
+
+	it( 'should handle localStorage SET', async () => {
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: {
+				type: HostLocalStorageEventType.SET,
+				key: 'angie-set-key',
+				value: 'new-value',
+			},
+			origin: IFRAME_ORIGIN,
+		} ) );
+
+		await flushAsync();
+
+		expect( window.localStorage.getItem( 'angie-set-key' ) ).toBe( 'new-value' );
+		window.localStorage.removeItem( 'angie-set-key' );
 	} );
 } );

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { ExternalHeadersCallback } from './config';
+import { GET_EXTERNAL_HEADERS_MESSAGE_TYPE, initHostApiBridge, resetHostApiBridgeForTests } from './host-api-bridge';
+
+const IFRAME_ORIGIN = 'http://localhost:4000';
+
+const createMockPort = () => ( {
+	postMessage: jest.fn(),
+} );
+
+const flushAsync = () => new Promise( ( resolve ) => {
+	setTimeout( resolve, 0 );
+} );
+
+describe( 'load-sidebar-v2/host-api-bridge', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetHostApiBridgeForTests();
+	} );
+
+	it( 'should respond with empty headers when no callback is provided', async () => {
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: {},
+		} );
+	} );
+
+	it( 'should invoke getExternalHeaders callback on each request', async () => {
+		let callCount = 0;
+		const getExternalHeaders: ExternalHeadersCallback = async () => {
+			callCount += 1;
+			return { 'X-Custom-Token': callCount === 1 ? 'first' : 'second' };
+		};
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders,
+		} );
+
+		const firstPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ firstPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( callCount ).toBe( 1 );
+		expect( firstPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Custom-Token': 'first' },
+		} );
+
+		const secondPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ secondPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( callCount ).toBe( 2 );
+		expect( secondPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Custom-Token': 'second' },
+		} );
+	} );
+
+	it( 'should ignore messages from other origins', async () => {
+		const getExternalHeaders = jest.fn( async () => ( { 'X-Custom-Token': 'token' } ) ) as jest.MockedFunction<ExternalHeadersCallback>;
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders,
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: 'https://evil.example',
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( getExternalHeaders ).not.toHaveBeenCalled();
+		expect( port.postMessage ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should respond with error when callback throws', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders: async () => {
+				throw new Error( 'Token unavailable' );
+			},
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'error',
+			payload: { message: 'Token unavailable' },
+		} );
+	} );
+} );

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,10 +1,16 @@
 import { sendErrorMessage, sendSuccessMessage } from '../utils';
-import type { ExternalHeadersCallback } from './config';
+import { HostLocalStorageEventType } from '../types';
+import type { ExternalHeadersCallback, HostConfig } from './config';
 
 export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
 
+export const GET_WEBSITE_CONTEXT_MESSAGE_TYPE = 'angie/context/get-website-context';
+
+export const GET_ANALYTICS_CONTEXT_MESSAGE_TYPE = 'angie/context/get-analytics-context';
+
 type InitHostApiBridgeArgs = {
 	iframeOrigin: string;
+	host?: HostConfig;
 	getExternalHeaders?: ExternalHeadersCallback;
 };
 
@@ -17,6 +23,113 @@ const filterDefinedHeaders = (
 	Object.entries( headers ).filter( ( [ , value ] ) => value !== undefined ),
 ) as Record<string, string>;
 
+const getHostDateContext = (): { timezone: string; today: string } => {
+	const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+	const today = new Date().toISOString().split( 'T' )[ 0 ];
+	return { timezone, today };
+};
+
+export const buildWebsiteContextResponse = ( host?: HostConfig ) => ( {
+	payload: {
+		name: document.title,
+		tagline: '',
+		homeUrl: window.location.origin,
+		siteLang: document.documentElement.lang,
+		docTitle: document.title,
+		platform: 'frontend',
+		...getHostDateContext(),
+		...host?.website,
+	},
+} );
+
+export const buildAnalyticsContextResponse = ( host?: HostConfig ) => ( {
+	payload: {
+		screenPath: window.location.pathname,
+		...host?.analytics,
+	},
+} );
+
+const handleGetExternalHeaders = async (
+	port: MessagePort,
+	getExternalHeaders?: ExternalHeadersCallback,
+): Promise<void> => {
+	try {
+		const headers = getExternalHeaders
+			? await getExternalHeaders()
+			: {};
+		sendSuccessMessage( port, filterDefinedHeaders( headers ) );
+	} catch ( error ) {
+		sendErrorMessage( port, {
+			message: error instanceof Error ? error.message : String( error ),
+		} );
+	}
+};
+
+const handleHostLocalStorageGet = ( port: MessagePort, key: string ): void => {
+	try {
+		const value = window.localStorage?.getItem( key ) ?? null;
+		port.postMessage( { value } );
+	} catch {
+		port.postMessage( { value: null } );
+	}
+};
+
+const handleHostLocalStorageSet = ( key: string, value: string ): void => {
+	try {
+		window.localStorage?.setItem( key, value );
+	} catch {
+		// localStorage unavailable (e.g. private browsing mode)
+	}
+};
+
+const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
+	if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+		return;
+	}
+
+	const messageType = event.data?.type;
+	const port = event.ports?.[ 0 ];
+
+	switch ( messageType ) {
+		case GET_EXTERNAL_HEADERS_MESSAGE_TYPE: {
+			if ( ! port ) {
+				return;
+			}
+			await handleGetExternalHeaders( port, bridgeConfig.getExternalHeaders );
+			break;
+		}
+
+		case GET_WEBSITE_CONTEXT_MESSAGE_TYPE: {
+			if ( ! port ) {
+				return;
+			}
+			sendSuccessMessage( port, buildWebsiteContextResponse( bridgeConfig.host ) );
+			break;
+		}
+
+		case GET_ANALYTICS_CONTEXT_MESSAGE_TYPE: {
+			if ( ! port ) {
+				return;
+			}
+			sendSuccessMessage( port, buildAnalyticsContextResponse( bridgeConfig.host ) );
+			break;
+		}
+
+		case HostLocalStorageEventType.GET: {
+			if ( ! port ) {
+				return;
+			}
+			handleHostLocalStorageGet( port, event.data.key );
+			break;
+		}
+
+		case HostLocalStorageEventType.SET: {
+			handleHostLocalStorageSet( event.data.key, event.data.value );
+			break;
+		}
+	}
+};
+
 export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 	bridgeConfig = args;
 
@@ -25,31 +138,8 @@ export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 	}
 
 	bridgeListenerRegistered = true;
-
-	window.addEventListener( 'message', async ( event: MessageEvent ) => {
-		if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
-			return;
-		}
-
-		if ( event.data?.type !== GET_EXTERNAL_HEADERS_MESSAGE_TYPE ) {
-			return;
-		}
-
-		const port = event.ports?.[ 0 ];
-		if ( ! port ) {
-			return;
-		}
-
-		try {
-			const headers = bridgeConfig.getExternalHeaders
-				? await bridgeConfig.getExternalHeaders()
-				: {};
-			sendSuccessMessage( port, filterDefinedHeaders( headers ) );
-		} catch ( error ) {
-			sendErrorMessage( port, {
-				message: error instanceof Error ? error.message : String( error ),
-			} );
-		}
+	window.addEventListener( 'message', ( event: MessageEvent ) => {
+		void handleHostApiMessage( event );
 	} );
 };
 

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,0 +1,58 @@
+import { sendErrorMessage, sendSuccessMessage } from '../utils';
+import type { ExternalHeadersCallback } from './config';
+
+export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
+
+type InitHostApiBridgeArgs = {
+	iframeOrigin: string;
+	getExternalHeaders?: ExternalHeadersCallback;
+};
+
+let bridgeConfig: InitHostApiBridgeArgs | null = null;
+let bridgeListenerRegistered = false;
+
+const filterDefinedHeaders = (
+	headers: Record<string, string | undefined>,
+): Record<string, string> => Object.fromEntries(
+	Object.entries( headers ).filter( ( [ , value ] ) => value !== undefined ),
+) as Record<string, string>;
+
+export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
+	bridgeConfig = args;
+
+	if ( bridgeListenerRegistered ) {
+		return;
+	}
+
+	bridgeListenerRegistered = true;
+
+	window.addEventListener( 'message', async ( event: MessageEvent ) => {
+		if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+			return;
+		}
+
+		if ( event.data?.type !== GET_EXTERNAL_HEADERS_MESSAGE_TYPE ) {
+			return;
+		}
+
+		const port = event.ports?.[ 0 ];
+		if ( ! port ) {
+			return;
+		}
+
+		try {
+			const headers = bridgeConfig.getExternalHeaders
+				? await bridgeConfig.getExternalHeaders()
+				: {};
+			sendSuccessMessage( port, filterDefinedHeaders( headers ) );
+		} catch ( error ) {
+			sendErrorMessage( port, {
+				message: error instanceof Error ? error.message : String( error ),
+			} );
+		}
+	} );
+};
+
+export const resetHostApiBridgeForTests = (): void => {
+	bridgeConfig = null;
+};

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -77,6 +77,16 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		expect( config.callbacks.onClose ).toBe( onClose );
 	} );
 
+	it( 'should preserve callbacks.getExternalHeaders', () => {
+		const getExternalHeaders = jest.fn<() => Record<string, string>>();
+		const config = resolveConfig(
+			{ callbacks: { getExternalHeaders }, host: { appId: 'editor-lite' } },
+			DEFAULT_ENV,
+		);
+
+		expect( config.callbacks.getExternalHeaders ).toBe( getExternalHeaders );
+	} );
+
 	it( 'should apply env-detected RTL and theme to iframe', () => {
 		const config = resolveConfig(
 			{ host: { appId: 'editor-lite' } },

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -60,6 +60,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		},
 		callbacks: {
 			onClose: callbacks.onClose,
+			getExternalHeaders: callbacks.getExternalHeaders,
 		},
 		widgetConfig: resolveWidgetConfig( layout, options.widgetConfig ),
 	};


### PR DESCRIPTION
## Summary

- Add **host API bridge** for `loadSidebarV2`: postMessage handlers for `GET_EXTERNAL_HEADERS`, website/analytics context, and host localStorage.
- Wire bridge into sidebar boot and export `ExternalHeadersCallback`, `LAYOUT_SIDEBAR`, and `LAYOUT_FLOATING_CHAT` from the package.
- Expand **browser demos** (sidebar, floating chat, full-config example with `aiContext`, custom CSS, and callbacks) and add **`src/load-sidebar-v2/README.md`** plus root README link.
- Bump version to **1.4.9**.

Builds on merged loadSidebarV2 core (#43) and layouts/chat toggle (#44).

## Test plan

- [x] `npm test` (171 tests)
- [ ] `npm run build` then open `demo/load-sidebar-v2-sidebar/`, `demo/load-sidebar-v2-floating-chat/`, and `demo/load-sidebar-v2-full-config/` via local static server
- [ ] Confirm host toggle opens sidebar; full-config demo logs `onClose` and sends demo headers via `getExternalHeaders`
- [ ] Verify embedded Angie receives `aiContext` / widget config on `HOST_READY`
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Implements host-side postMessage API bridge for `loadSidebarV2` to enable secure two-way communication between embedded Angie iframe and host page. Allows iframe to request external auth headers, website/analytics context, and localStorage access without exposing host internals.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `host-api-bridge.ts` | New 148-line module handling iframe postMessage, origin validation, external headers callback, context builders |
| `config.ts` | Added `ExternalHeadersCallback` type, `analytics` field to `HostConfig`, `getExternalHeaders` to `CallbacksConfig` |
| `boot-sidebar.ts` | Calls `initHostApiBridge()` before container setup with iframe origin + callbacks |
| `resolve-config.ts` | Threads `getExternalHeaders` callback through config resolution |
| `index.ts` | Exports `ExternalHeadersCallback` type |
| Demo + docs | Full-config example, README.md integration guide, test coverage (237-line test suite) |

## 3. How It Works

On boot, `initHostApiBridge()` registers a global `message` listener (origin-checked against iframe). When iframe posts `GET_EXTERNAL_HEADERS`, `GET_WEBSITE_CONTEXT`, `GET_ANALYTICS_CONTEXT`, or localStorage ops on a `MessagePort`, host invokes the callback (or fetches from config) and responds via `port.postMessage()`. Undefined headers filtered; errors wrapped in error response. Bridge state is singleton per page (prevents double-registration).

## 4. Risks

**None material.** Origin validation prevents CSRF. Callback is optional (defaults to empty). localStorage errors gracefully degrade (catch blocks). Test coverage is comprehensive (237 lines). Minor: `resetHostApiBridgeForTests()` is export-only used in tests—fine for test cleanup.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
