### PR TITLE
Fix loadSidebarV2 docs links in demo footers

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -121,7 +121,7 @@
     <footer>
       <a href="https://github.com/elementor/angie-sdk">View on GitHub</a>
       ·
-      <a href="https://github.com/elementor/angie-sdk/blob/main/src/load-sidebar-v2/README.md">loadSidebarV2 docs</a>
+      <a href="https://github.com/elementor/angie-sdk/blob/master/src/load-sidebar-v2/README.md">loadSidebarV2 docs</a>
     </footer>
   </div>
 </body>

--- a/demo/load-sidebar-v2-full-config/index.html
+++ b/demo/load-sidebar-v2-full-config/index.html
@@ -138,7 +138,7 @@
         ·
         <a href="../">All demos</a>
         ·
-        <a href="https://github.com/elementor/angie-sdk/blob/main/src/load-sidebar-v2/README.md">loadSidebarV2 docs</a>
+        <a href="https://github.com/elementor/angie-sdk/blob/master/src/load-sidebar-v2/README.md">loadSidebarV2 docs</a>
       </p>
     </footer>
   </div>


### PR DESCRIPTION
## Summary
- Point demo footer "loadSidebarV2 docs" links at `blob/master` instead of `blob/main`.
- Updates `demo/index.html` and `demo/load-sidebar-v2-full-config/index.html`.

## Test plan
- [ ] Open demo index and full-config demo footers; confirm the docs link resolves on GitHub.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Branch naming indicates a docs URL fix for loadSidebarV2. Changed `main` to `master` branch reference in demo footer links.

## 2. What Changed (Where)

- `demo/index.html`: Updated docs link branch from `main` to `master`
- `demo/load-sidebar-v2-full-config/index.html`: Updated docs link branch from `main` to `master`

## 3. How It Works

Both footer links now point to `blob/master/src/load-sidebar-v2/README.md` instead of `blob/main/`. Aligns documentation URLs with actual default branch.

## 4. Risks

None — straightforward URL correction assuming `master` is the correct default branch. Verify branch name matches actual repository default.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
