### PR TITLE
Add widgetConfig docs and interactive demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,7 +489,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
 
 ## Embedded Angie in any web page
 
-To embed the Angie UI in your own site (sidebar or floating chat), use `AngieMcpSdk.loadSidebarV2()`. See the dedicated guide: [loadSidebarV2](./src/load-sidebar-v2/README.md).
+To embed the Angie UI in your own site (sidebar or floating chat), use `AngieMcpSdk.loadSidebarV2()`. See the dedicated guide: [loadSidebarV2](./src/load-sidebar-v2/README.md). To customize the embedded chat UI (title, suggestions, feature toggles), see [widgetConfig](./src/load-sidebar-v2/widget-config.md) and the [widgetConfig demo](./demo/load-sidebar-v2-widget-config/).
 
 
 If you have questions or need help, open an issue or contact the Elementor team! 

--- a/demo/index.html
+++ b/demo/index.html
@@ -104,6 +104,10 @@
         <strong>loadSidebarV2 — full example</strong>
         <span>Product editor UI, aiContext, custom CSS, and triggerAngie.</span>
       </a>
+      <a class="card featured" href="./load-sidebar-v2-widget-config/">
+        <strong>widgetConfig</strong>
+        <span>Customize embedded UI copy, features, and MCP focus — production-style presets.</span>
+      </a>
       <a class="card" href="./load-sidebar-v2-sidebar/">
         <strong>loadSidebarV2 — sidebar</strong>
         <span>Minimal sidebar layout with a host toggle button.</span>

--- a/demo/load-sidebar-v2-widget-config/demo-host.css
+++ b/demo/load-sidebar-v2-widget-config/demo-host.css
@@ -1,0 +1,331 @@
+:root {
+	--demo-bg: #f4f6fb;
+	--demo-surface: #ffffff;
+	--demo-border: #e2e8f0;
+	--demo-text: #0f172a;
+	--demo-muted: #64748b;
+	--demo-accent: #4f46e5;
+	--demo-accent-soft: #eef2ff;
+	--demo-radius: 12px;
+	--demo-font: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+	--angie-sidebar-width: 380px;
+	--angie-sidebar-z-index: 1300;
+	--angie-sidebar-content-gap: 1.5rem;
+	/* Dock sidebar on the right (overrides SDK default left placement) */
+	--angie-sidebar-hide-transform: translateX(100%);
+}
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html {
+	color-scheme: light;
+}
+
+body {
+	margin: 0;
+	min-height: 100vh;
+	font-family: var(--demo-font);
+	font-size: 15px;
+	line-height: 1.5;
+	color: var(--demo-text);
+	background: var(--demo-bg);
+}
+
+a {
+	color: var(--demo-accent);
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
+code {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 0.88em;
+	background: #f1f5f9;
+	padding: 0.12em 0.35em;
+	border-radius: 4px;
+}
+
+.demo-app {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+}
+
+.demo-app-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 0.85rem 1.25rem;
+	background: var(--demo-surface);
+	border-bottom: 1px solid var(--demo-border);
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+.demo-app-brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.65rem;
+	color: inherit;
+	text-decoration: none;
+}
+
+.demo-app-brand:hover {
+	text-decoration: none;
+}
+
+.demo-app-logo {
+	display: inline-grid;
+	place-items: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 8px;
+	background: linear-gradient(135deg, #6366f1, #4f46e5);
+	color: #fff;
+	font-weight: 700;
+	font-size: 0.95rem;
+}
+
+.demo-app-brand-text {
+	display: flex;
+	flex-direction: column;
+	line-height: 1.2;
+}
+
+.demo-app-brand-text span {
+	color: var(--demo-muted);
+	font-size: 0.82rem;
+}
+
+#demo-toggle {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.45rem;
+	padding: 0.5rem 0.9rem;
+	border: 1px solid #c7d2fe;
+	border-radius: 999px;
+	background: var(--demo-accent-soft);
+	color: var(--demo-accent);
+	font: inherit;
+	font-weight: 600;
+	cursor: pointer;
+}
+
+#demo-toggle:hover {
+	background: #e0e7ff;
+}
+
+.demo-toggle-icon {
+	font-size: 1rem;
+}
+
+.demo-main {
+	width: min(960px, 100%);
+	margin: 0 auto;
+	padding: 1.25rem 1rem 2.5rem;
+}
+
+.demo-breadcrumb {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.35rem;
+	align-items: center;
+	margin-bottom: 1rem;
+	font-size: 0.9rem;
+	color: var(--demo-muted);
+}
+
+.demo-hero h1 {
+	margin: 0 0 0.5rem;
+	font-size: clamp(1.5rem, 4vw, 1.9rem);
+	letter-spacing: -0.02em;
+}
+
+.demo-hero p {
+	margin: 0 0 1.25rem;
+	color: var(--demo-muted);
+	max-width: 52rem;
+}
+
+.demo-main > .demo-card {
+	margin-bottom: 1rem;
+}
+
+.demo-grid {
+	display: grid;
+	gap: 1rem;
+}
+
+.demo-grid > .demo-card {
+	min-width: 0;
+}
+
+@media (min-width: 800px) {
+	.demo-grid {
+		grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+		align-items: start;
+	}
+}
+
+.demo-card {
+	padding: 1rem 1.1rem;
+	border: 1px solid var(--demo-border);
+	border-radius: var(--demo-radius);
+	background: var(--demo-surface);
+	min-width: 0;
+}
+
+.demo-card h2 {
+	margin: 0 0 0.5rem;
+	font-size: 1.05rem;
+}
+
+.demo-card-lead {
+	margin: 0 0 0.85rem;
+	color: var(--demo-muted);
+	font-size: 0.92rem;
+}
+
+.demo-preset-list {
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	display: grid;
+	gap: 0.55rem;
+}
+
+.demo-preset-link {
+	display: block;
+	padding: 0.7rem 0.85rem;
+	border: 1px solid var(--demo-border);
+	border-radius: 10px;
+	color: inherit;
+	text-decoration: none;
+	transition: border-color 0.15s ease, background 0.15s ease;
+}
+
+.demo-preset-link:hover {
+	border-color: #c7d2fe;
+	text-decoration: none;
+}
+
+.demo-preset-link.is-active {
+	border-color: #818cf8;
+	background: var(--demo-accent-soft);
+}
+
+.demo-preset-link strong {
+	display: block;
+	margin-bottom: 0.15rem;
+}
+
+.demo-preset-link span {
+	color: var(--demo-muted);
+	font-size: 0.88rem;
+}
+
+.demo-active-preset {
+	margin: 0.85rem 0 0;
+	font-size: 0.92rem;
+	color: var(--demo-muted);
+}
+
+.demo-code {
+	margin: 0;
+	padding: 0.85rem 1rem;
+	border-radius: 8px;
+	background: #0f172a;
+	color: #e2e8f0;
+	font-size: 0.78rem;
+	line-height: 1.45;
+	overflow: auto;
+	max-height: 22rem;
+	min-width: 0;
+	max-width: 100%;
+}
+
+.demo-code code {
+	background: transparent;
+	padding: 0;
+	color: inherit;
+	font-size: inherit;
+}
+
+.demo-hint {
+	margin: 0.75rem 0 0;
+	font-size: 0.85rem;
+	color: var(--demo-muted);
+	word-break: break-word;
+}
+
+.demo-field-list {
+	margin: 0;
+	display: grid;
+	gap: 0.65rem;
+}
+
+.demo-field-list div {
+	display: grid;
+	gap: 0.15rem;
+}
+
+.demo-field-list dt {
+	font-weight: 600;
+}
+
+.demo-field-list dd {
+	margin: 0;
+	color: var(--demo-muted);
+	font-size: 0.9rem;
+}
+
+.demo-app-footer {
+	margin-top: auto;
+	padding: 1rem 1.25rem;
+	border-top: 1px solid var(--demo-border);
+	font-size: 0.88rem;
+	color: var(--demo-muted);
+	text-align: center;
+}
+
+/* Sidebar panel — dock on the right (see load-sidebar-v2-full-config demo) */
+#angie-sidebar-container {
+	background: #f8fafc;
+	box-shadow: -4px 0 24px rgba(15, 23, 42, 0.12);
+	border-inline-start: 1px solid var(--demo-border);
+	border-inline-end: none;
+}
+
+body.angie-sidebar-active #angie-sidebar-container {
+	border-inline-start-color: #c7d2fe;
+}
+
+#angie-sidebar-container iframe#angie-iframe {
+	border-radius: 0 12px 0 0;
+}
+
+@media (min-width: 768px) {
+	body.angie-sidebar-active {
+		padding-inline-start: 0 !important;
+		padding-inline-end: calc(var(--angie-sidebar-width) + var(--angie-sidebar-content-gap)) !important;
+	}
+
+	#angie-sidebar-container {
+		inset-inline-start: auto !important;
+		inset-inline-end: 0 !important;
+	}
+
+	#angie-sidebar-container::after {
+		inset-inline-end: auto !important;
+		inset-inline-start: 0 !important;
+	}
+}

--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -1,0 +1,218 @@
+import { AngieMcpSdk, LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from '../../dist/index.js';
+
+const PRESET_PARAM = new URLSearchParams( window.location.search ).get( 'preset' ) || 'helpCenter';
+
+const HELP_CENTER_SERVER = 'demo-help-center';
+const SEARCH_SERVER = 'demo-wp-search';
+
+const readAngieConfig = () => window.angieConfig || {};
+
+const buildHelpCenterWidgetConfig = () => {
+	const cfg = readAngieConfig();
+	const title = cfg.title?.trim() || 'Need help with your store?';
+	const subtitle =
+		cfg.subtitle?.trim() ||
+		'Ask questions, learn how features work, and get help with products and orders.';
+	const prompts =
+		cfg.prompts?.length > 0
+			? cfg.prompts
+			: [
+					{
+						label: 'Review my listing',
+						value: 'Review this product listing before I publish. What should I improve?',
+					},
+					{
+						label: 'Pricing tips',
+						value: 'What pricing strategy fits this product category?',
+					},
+					{
+						label: 'SEO checklist',
+						value: 'Give me a short SEO checklist for this product page.',
+					},
+				];
+
+	return {
+		title,
+		subtitle,
+		suggestions: { items: prompts },
+		promptLibrary: { enabled: false },
+		fileUpload: { enabled: false },
+		feedback: { enabled: false },
+		featuredMcpServer: HELP_CENTER_SERVER,
+		modeSwitcher: { enabled: false, default: 'agent' },
+		closeButton: 'collapse',
+		betaBanner: { enabled: false },
+		aiContextGuidance: { enabled: true },
+		localServers: { skipLoading: true },
+		userProfileMenu: { enabled: false },
+	};
+};
+
+const buildVisitorWidgetConfig = () => {
+	const cfg = readAngieConfig();
+	const config = {
+		promptLibrary: { enabled: false },
+		fileUpload: { enabled: false },
+		feedback: { enabled: false },
+		featuredMcpServer: SEARCH_SERVER,
+		modeSwitcher: { enabled: false, default: 'ask' },
+		closeButton: 'close',
+	};
+
+	if ( cfg.title ) {
+		config.title = cfg.title;
+	} else {
+		config.title = 'Search this demo site';
+	}
+
+	if ( cfg.subtitle ) {
+		config.subtitle = cfg.subtitle;
+	} else {
+		config.subtitle = 'Ask about pages, products, and docs on this site.';
+	}
+
+	if ( cfg.prompts?.length > 0 ) {
+		config.suggestions = { items: cfg.prompts };
+	} else {
+		config.suggestions = {
+			items: [
+				{ label: 'Find products', value: 'What products do you sell?' },
+				{ label: 'Shipping', value: 'What are your shipping options?' },
+			],
+		};
+	}
+
+	return config;
+};
+
+const buildSandboxWidgetConfig = () => ( {
+	title: 'Widget config sandbox',
+	subtitle: 'Most Angie features enabled for exploration.',
+	suggestions: {
+		items: [
+			{ label: 'Try agent mode', value: 'What can you help me with on this demo page?' },
+			{ label: 'Try plan mode', value: 'Plan a small marketing campaign for this product.' },
+		],
+	},
+	promptLibrary: { enabled: true },
+	fileUpload: { enabled: true },
+	feedback: { enabled: true },
+	modeSwitcher: { enabled: true, default: 'agent' },
+	closeButton: 'collapse',
+	betaBanner: { enabled: true },
+	aiContextGuidance: { enabled: true },
+	userProfileMenu: { enabled: true },
+} );
+
+const PRESETS = {
+	helpCenter: {
+		label: 'Help center sidebar',
+		description: 'my.elementor-style: custom copy, featured MCP, minimal chrome.',
+		layout: LAYOUT_SIDEBAR,
+		buildWidgetConfig: buildHelpCenterWidgetConfig,
+		loadOptions: {
+			container: {
+				layout: LAYOUT_SIDEBAR,
+				styleTheme: 'wordpress',
+				persistOpenState: true,
+				resizable: true,
+				chatToggleButton: {
+					enabled: true,
+					selector: '#demo-toggle',
+				},
+			},
+		},
+	},
+	visitor: {
+		label: 'Visitor floating search',
+		description: 'angie-for-visitors-style: floating chat, ask mode, close dismisses.',
+		layout: LAYOUT_FLOATING_CHAT,
+		buildWidgetConfig: buildVisitorWidgetConfig,
+		loadOptions: {
+			container: { layout: LAYOUT_FLOATING_CHAT },
+		},
+	},
+	sandbox: {
+		label: 'Feature sandbox',
+		description: 'Sidebar with most widget toggles enabled.',
+		layout: LAYOUT_SIDEBAR,
+		buildWidgetConfig: buildSandboxWidgetConfig,
+		loadOptions: {
+			container: {
+				layout: LAYOUT_SIDEBAR,
+				persistOpenState: true,
+				resizable: true,
+				chatToggleButton: {
+					enabled: true,
+					selector: '#demo-toggle',
+				},
+			},
+		},
+	},
+};
+
+const preset = PRESETS[ PRESET_PARAM ] || PRESETS.helpCenter;
+const widgetConfig = preset.buildWidgetConfig();
+
+const configJsonEl = document.getElementById( 'demo-config-json' );
+const presetLabelEl = document.getElementById( 'demo-preset-label' );
+const presetDescEl = document.getElementById( 'demo-preset-desc' );
+
+if ( configJsonEl ) {
+	configJsonEl.textContent = JSON.stringify( widgetConfig, null, 2 );
+}
+
+if ( presetLabelEl ) {
+	presetLabelEl.textContent = preset.label;
+}
+
+if ( presetDescEl ) {
+	presetDescEl.textContent = preset.description;
+}
+
+document.querySelectorAll( '[data-preset-link]' ).forEach( ( link ) => {
+	const name = link.getAttribute( 'data-preset-link' );
+	link.classList.toggle( 'is-active', name === PRESET_PARAM || ( ! PRESETS[ PRESET_PARAM ] && name === 'helpCenter' ) );
+} );
+
+const sdk = new AngieMcpSdk();
+
+const toggle = document.getElementById( 'demo-toggle' );
+
+if ( preset.layout === LAYOUT_FLOATING_CHAT && toggle ) {
+	toggle.style.display = 'none';
+}
+
+toggle?.addEventListener( 'click', async () => {
+	if ( toggle.getAttribute( 'aria-expanded' ) !== 'true' ) {
+		await sdk.waitForReady();
+	}
+} );
+
+sdk.loadSidebarV2( {
+	host: {
+		appId: `demo-widget-config-${ PRESET_PARAM }`,
+		aiContext: {
+			whatUserSees: {
+				screen: 'Widget config demo',
+				preset: preset.label,
+				layout: preset.layout,
+			},
+			whatUserCanDo: [
+				'Switch presets via the links on this page (reloads with ?preset=)',
+				'Override copy via window.angieConfig in the console, then reload',
+				'Open Angie and try the starter suggestions',
+			],
+		},
+	},
+	iframe: {
+		origin: 'https://angie.elementor.com',
+		path: 'angie/embedded',
+		uiTheme: 'light',
+		isRTL: false,
+	},
+	...preset.loadOptions,
+	widgetConfig,
+} ).catch( ( error ) => {
+	console.error( 'loadSidebarV2 failed:', error );
+} );

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -1,0 +1,153 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Interactive demo of widgetConfig — customize Angie embedded UI copy, features, and MCP focus." />
+  <title>widgetConfig · Angie SDK Demo</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/types.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod/v4": "../../node_modules/zod/v4/index.js"
+    }
+  }
+  </script>
+  <link rel="stylesheet" href="./demo-host.css" />
+</head>
+<body>
+  <div class="demo-app">
+    <header class="demo-app-header">
+      <div class="demo-app-header-start">
+        <a class="demo-app-brand" href="../">
+          <span class="demo-app-logo" aria-hidden="true">A</span>
+          <span class="demo-app-brand-text">
+            <strong>Angie SDK</strong>
+            <span>widgetConfig</span>
+          </span>
+        </a>
+      </div>
+      <div class="demo-app-header-end">
+        <button type="button" id="demo-toggle" aria-expanded="false">
+          <span class="demo-toggle-icon" aria-hidden="true">✦</span>
+          Open Angie
+        </button>
+      </div>
+    </header>
+
+    <main class="demo-main">
+      <nav class="demo-breadcrumb" aria-label="Breadcrumb">
+        <a href="../">Demos</a>
+        <span aria-hidden="true">/</span>
+        <span>widgetConfig</span>
+      </nav>
+
+      <div class="demo-hero">
+        <h1>Customize the embedded Angie UI</h1>
+        <p>
+          <code>widgetConfig</code> controls empty-state copy, starter prompts, feature toggles,
+          close behavior, and which host MCP server Angie should feature first.
+          Config is sent to the iframe as <code>sdk-widget-config</code>.
+        </p>
+      </div>
+
+      <section class="demo-card" aria-labelledby="preset-heading">
+        <h2 id="preset-heading">Presets</h2>
+        <p class="demo-card-lead">
+          Patterns from Elementor production hosts. Pick a preset to reload with a different
+          <code>widgetConfig</code> and layout.
+        </p>
+        <ul class="demo-preset-list">
+          <li>
+            <a class="demo-preset-link" data-preset-link="helpCenter" href="?preset=helpCenter">
+              <strong>Help center sidebar</strong>
+              <span>my.elementor-style embed</span>
+            </a>
+          </li>
+          <li>
+            <a class="demo-preset-link" data-preset-link="visitor" href="?preset=visitor">
+              <strong>Visitor floating search</strong>
+              <span>angie-for-visitors-style widget</span>
+            </a>
+          </li>
+          <li>
+            <a class="demo-preset-link" data-preset-link="sandbox" href="?preset=sandbox">
+              <strong>Feature sandbox</strong>
+              <span>most toggles enabled</span>
+            </a>
+          </li>
+        </ul>
+        <p class="demo-active-preset">
+          Active: <strong id="demo-preset-label">Help center sidebar</strong>
+          — <span id="demo-preset-desc"></span>
+        </p>
+      </section>
+
+      <div class="demo-grid">
+        <section class="demo-card" aria-labelledby="config-heading">
+          <h2 id="config-heading">Resolved <code>widgetConfig</code></h2>
+          <p class="demo-card-lead">
+            Built by <code>buildWidgetConfig()</code> in <code>host.js</code>.
+            Override copy at runtime with <code>window.angieConfig</code> then reload.
+          </p>
+          <pre class="demo-code" aria-label="widgetConfig JSON"><code id="demo-config-json">{}</code></pre>
+          <p class="demo-hint">
+            Try in the console:
+            <code>window.angieConfig = { title: 'Custom', prompts: [{ label: 'Hi', value: 'Hello' }] }</code>
+          </p>
+        </section>
+
+        <section class="demo-card" aria-labelledby="fields-heading">
+          <h2 id="fields-heading">Common fields</h2>
+          <dl class="demo-field-list">
+            <div>
+              <dt><code>title</code> / <code>subtitle</code></dt>
+              <dd>Empty-state heading and supporting line</dd>
+            </div>
+            <div>
+              <dt><code>suggestions.items</code></dt>
+              <dd>Starter chips — <code>label</code> shown, <code>value</code> sent as prompt</dd>
+            </div>
+            <div>
+              <dt><code>featuredMcpServer</code></dt>
+              <dd>Matches <code>registerServer({ name })</code> on the host</dd>
+            </div>
+            <div>
+              <dt><code>modeSwitcher</code></dt>
+              <dd><code>enabled</code> + <code>default</code>: <code>agent</code> | <code>plan</code> | <code>ask</code></dd>
+            </div>
+            <div>
+              <dt><code>closeButton</code></dt>
+              <dd><code>collapse</code> (sidebar default) or <code>close</code> (floating chat default)</dd>
+            </div>
+            <div>
+              <dt><code>localServers.skipLoading</code></dt>
+              <dd>Register MCP servers yourself after <code>waitForReady()</code></dd>
+            </div>
+            <div>
+              <dt><code>aiContextGuidance</code></dt>
+              <dd>Show that <code>host.aiContext</code> is available (enabled in help center preset)</dd>
+            </div>
+          </dl>
+          <p>
+            <a href="https://github.com/elementor/angie-sdk/blob/master/src/load-sidebar-v2/widget-config.md">Full widgetConfig docs</a>
+          </p>
+        </section>
+      </div>
+    </main>
+
+    <footer class="demo-app-footer">
+      <p>
+        <a href="https://github.com/elementor/angie-sdk">Angie SDK</a>
+        ·
+        <a href="../">All demos</a>
+        ·
+        <a href="https://github.com/elementor/angie-sdk/blob/master/src/load-sidebar-v2/widget-config.md">widgetConfig reference</a>
+      </p>
+    </footer>
+  </div>
+
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <script type="module" src="./host.js"></script>
+</body>
+</html>

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -36,6 +36,7 @@ Local demos:
 - [`demo/load-sidebar-v2-sidebar/`](../../demo/load-sidebar-v2-sidebar/) — minimal sidebar
 - [`demo/load-sidebar-v2-floating-chat/`](../../demo/load-sidebar-v2-floating-chat/) — minimal floating chat
 - [`demo/load-sidebar-v2-full-config/`](../../demo/load-sidebar-v2-full-config/) — full example (`aiContext`, custom CSS)
+- [`demo/load-sidebar-v2-widget-config/`](../../demo/load-sidebar-v2-widget-config/) — `widgetConfig` presets (help center, visitor widget, sandbox)
 
 ## Layouts
 
@@ -57,7 +58,7 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 | `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
 | `callbacks` | `onClose`, `getExternalHeaders` for auth/API headers |
-| `widgetConfig` | Close button behavior (`collapse` vs `close`); layout-specific defaults in [`widget-config.ts`](./widget-config.ts) |
+| `widgetConfig` | Embedded UI copy, feature toggles, MCP focus, close behavior — see [widgetConfig guide](./widget-config.md) |
 
 Embedded config uses `configVersion: 2` (`LOAD_SIDEBAR_V2_CONFIG_VERSION`).
 
@@ -74,7 +75,7 @@ Keep it focused on what helps the agent answer screen-level questions:
 
 Example: [`demo/load-sidebar-v2-full-config/host.js`](../../demo/load-sidebar-v2-full-config/host.js) reads `#demo-host-app` into `whatUserSees` and lists allowed actions in `whatUserCanDo`.
 
-Enable `widgetConfig.aiContextGuidance: { enabled: true }` so users see that host context is available.
+Enable `widgetConfig.aiContextGuidance: { enabled: true }` so users see that host context is available. Full reference: [widget-config.md](./widget-config.md).
 
 ### Custom CSS (toggle + sidebar panel)
 
@@ -131,4 +132,4 @@ Jest specs live next to modules (`*.test.ts`). Run the package test script from 
 
 ## Exports
 
-From `@elementor/angie-sdk`: `loadSidebarV2` on `AngieMcpSdk`, plus `LAYOUT_SIDEBAR`, `LAYOUT_FLOATING_CHAT`, `LoadSidebarV2Options`, `ExternalHeadersCallback`.
+From `@elementor/angie-sdk`: `loadSidebarV2` on `AngieMcpSdk`, plus `LAYOUT_SIDEBAR`, `LAYOUT_FLOATING_CHAT`, `LoadSidebarV2Options`, `WidgetConfig`, `ExternalHeadersCallback`.

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -1,0 +1,224 @@
+# widgetConfig
+
+Customize the embedded Angie chat UI — copy, starter prompts, feature toggles, close behavior, and which local MCP server Angie should prefer on first open.
+
+`widgetConfig` is sent to the Angie iframe as a `postMessage` with type `sdk-widget-config` after the host opens the embedded app. It works with both APIs:
+
+| API | When config is sent |
+|-----|---------------------|
+| `AngieMcpSdk.loadSidebar()` | Immediately after `openIframe()` if `widgetConfig` is provided |
+| `AngieMcpSdk.loadSidebarV2()` | After iframe open via `sendWidgetConfig()` in the v2 boot flow |
+
+Type definition: [`WidgetConfig`](../angie-mcp-sdk.ts) (exported from `@elementor/angie-sdk`).
+
+## Quick start
+
+```typescript
+import { AngieMcpSdk, LAYOUT_SIDEBAR } from '@elementor/angie-sdk';
+
+const sdk = new AngieMcpSdk();
+
+await sdk.loadSidebarV2({
+  host: { appId: 'my-app' },
+  container: { layout: LAYOUT_SIDEBAR },
+  widgetConfig: {
+    title: 'Need help?',
+    subtitle: 'Ask questions about this screen.',
+    suggestions: {
+      items: [
+        { label: 'What can I do here?', value: 'What actions are available on this screen?' },
+      ],
+    },
+    closeButton: 'collapse',
+    aiContextGuidance: { enabled: true },
+  },
+});
+```
+
+Live demo: [`demo/load-sidebar-v2-widget-config/`](../../demo/load-sidebar-v2-widget-config/).
+
+## Layout defaults
+
+`loadSidebarV2` merges your options with layout-specific defaults in [`widget-config.ts`](./widget-config.ts):
+
+| Layout | Default `closeButton` | Notes |
+|--------|----------------------|--------|
+| `sidebar` | `'collapse'` | Hides the panel; host toggle can reopen it |
+| `floatingChat` | `'close'` | Dismisses the floating widget |
+
+Your values override these defaults. Example: pass `closeButton: 'close'` on a sidebar layout if you want full dismiss instead of collapse.
+
+`loadSidebar()` has no layout presets — only fields you pass are sent.
+
+## Field reference
+
+All fields are optional. Omitted fields use Angie embedded-app defaults.
+
+### Copy and prompts
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `title` | `string` | Main heading in the empty chat state |
+| `subtitle` | `string` | Supporting line under the title |
+| `suggestions` | `{ items: { label: string; value: string }[] }` | Starter prompt chips. `label` is shown in the UI; `value` is the prompt sent when clicked |
+
+`suggestions.items` is the same shape used in production Elementor hosts (`window.angieConfig.prompts` mapped to `suggestions.items`).
+
+### Feature toggles
+
+Each toggle uses `{ enabled: boolean }`.
+
+| Field | Typical host use |
+|-------|------------------|
+| `promptLibrary` | Hide built-in prompt library when the host supplies its own `suggestions` |
+| `fileUpload` | Disable attachments in locked-down or read-only embeds |
+| `feedback` | Turn off thumbs up/down when you handle feedback elsewhere |
+| `commands` | Hide slash commands |
+| `testMode` | Hide internal test tooling in production embeds |
+| `betaBanner` | Hide beta messaging in stable product surfaces |
+| `aiContextGuidance` | Show users that `host.aiContext` is available — pair with `host.aiContext` in `loadSidebarV2` |
+| `userProfileMenu` | Hide account/profile menu when the host owns auth UI |
+
+### Mode and MCP
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `modeSwitcher` | `{ enabled?: boolean; default?: 'agent' \| 'plan' \| 'ask' }` | Show or hide Agent / Plan / Ask switcher; set the initial mode |
+| `featuredMcpServer` | `string` | Name of a **host-registered** local MCP server Angie should surface first (must match `registerServer({ name })`) |
+| `localServers` | `{ skipLoading?: boolean }` | When `skipLoading: true`, Angie does not auto-load host local servers — use when you register servers yourself after `waitForReady()` |
+
+### Close behavior
+
+| Field | Type | Values |
+|-------|------|--------|
+| `closeButton` | `'collapse' \| 'close'` | `collapse` — hide panel, keep session; `close` — dismiss widget |
+
+## Patterns from production hosts
+
+These mirror [`ai-remote-integration`](https://github.com/elementor/elementor-ai/tree/main/editor-saas-services/packages/ai-remote-integration) (Elementor my.elementor sidebar and visitor floating widget).
+
+### Help center sidebar (my.elementor)
+
+Focused help surface: custom copy, starter prompts, help-center MCP featured, most Angie chrome disabled.
+
+```typescript
+const HELP_CENTER_SERVER = 'help-center';
+
+const widgetConfig: WidgetConfig = {
+  title: 'Need Help with Elementor?',
+  subtitle: 'Ask questions, learn how features work, and get help with your Elementor websites or products.',
+  suggestions: {
+    items: [
+      { label: 'How to back up your website', value: 'How to create a backup of my website before making major changes or updates.' },
+      { label: 'What is Elementor One?', value: 'What is Elementor One?' },
+    ],
+  },
+  promptLibrary: { enabled: false },
+  fileUpload: { enabled: false },
+  feedback: { enabled: false },
+  featuredMcpServer: HELP_CENTER_SERVER,
+  modeSwitcher: { enabled: false, default: 'agent' },
+  closeButton: 'collapse',
+  betaBanner: { enabled: false },
+  aiContextGuidance: { enabled: false },
+  localServers: { skipLoading: true },
+  userProfileMenu: { enabled: false },
+};
+
+await sdk.loadSidebarV2({
+  host: { appId: 'my-elementor' },
+  container: { layout: 'sidebar' /* ... */ },
+  widgetConfig,
+});
+
+await sdk.waitForReady();
+sdk.registerServer({ name: HELP_CENTER_SERVER, /* ... */ });
+```
+
+`localServers.skipLoading: true` avoids a race: register your MCP servers after `waitForReady()`, then Angie uses `featuredMcpServer` to prioritize the right one.
+
+### Visitor floating search widget
+
+Minimal floating chat: search MCP featured, ask mode, close dismisses the widget.
+
+```typescript
+const SEARCH_SERVER = 'wp-search';
+
+const widgetConfig: WidgetConfig = {
+  promptLibrary: { enabled: false },
+  fileUpload: { enabled: false },
+  feedback: { enabled: false },
+  featuredMcpServer: SEARCH_SERVER,
+  modeSwitcher: { enabled: false, default: 'ask' },
+  closeButton: 'close',
+  // Optional host-provided copy:
+  title: window.angieConfig?.title,
+  subtitle: window.angieConfig?.subtitle,
+  suggestions: window.angieConfig?.prompts?.length
+    ? { items: window.angieConfig.prompts }
+    : undefined,
+};
+
+await sdk.loadSidebarV2({
+  host: { appId: 'visitor-widget' },
+  container: { layout: LAYOUT_FLOATING_CHAT },
+  widgetConfig,
+});
+```
+
+### Runtime overrides via `window.angieConfig`
+
+Hosts can inject copy from PHP or a build step without recompiling the integration bundle:
+
+```html
+<script>
+  window.angieConfig = {
+    title: 'Search this site',
+    subtitle: 'Ask anything about our docs and pages.',
+    prompts: [
+      { label: 'Pricing', value: 'What are your pricing plans?' },
+    ],
+  };
+</script>
+```
+
+Read `window.angieConfig` inside a `buildWidgetConfig()` helper and merge with your defaults (see demo [`host.js`](../../demo/load-sidebar-v2-widget-config/host.js)).
+
+## Pairing with `host.aiContext`
+
+When the host passes screen context via `loadSidebarV2({ host: { aiContext } })`, enable the guidance affordance:
+
+```typescript
+widgetConfig: {
+  aiContextGuidance: { enabled: true },
+}
+```
+
+Example with full host context: [`demo/load-sidebar-v2-full-config/host.js`](../../demo/load-sidebar-v2-full-config/host.js).
+
+## loadSidebar (v1) vs loadSidebarV2
+
+| | `loadSidebar()` | `loadSidebarV2()` |
+|--|-----------------|-------------------|
+| Config location | Top-level `widgetConfig` on `AngieMcpSdkOptions` | `widgetConfig` on `LoadSidebarV2Options` |
+| Layout defaults | None | `closeButton` preset per layout |
+| Send timing | Right after iframe open | After v2 boot + `sendEmbeddedConfig` |
+
+v1 example:
+
+```typescript
+await sdk.loadSidebar({
+  origin: 'https://angie.elementor.com',
+  path: 'angie/embedded',
+  widgetConfig: { title: 'Angie', closeButton: 'close' },
+});
+```
+
+## Module map
+
+| File | Role |
+|------|------|
+| [`angie-mcp-sdk.ts`](../angie-mcp-sdk.ts) | `WidgetConfig` type; v1 send path |
+| [`widget-config.ts`](./widget-config.ts) | Layout default merge for v2 |
+| [`embedded-handshake.ts`](./embedded-handshake.ts) | `sendWidgetConfig()` → `sdk-widget-config` |
+| [`boot-sidebar.ts`](./boot-sidebar.ts) | Calls `sendWidgetConfig` when resolved config includes `widgetConfig` |


### PR DESCRIPTION
## Summary
- Add a dedicated `widgetConfig` guide covering all fields, layout defaults, v1/v2 usage, and production patterns from Elementor hosts (my.elementor help center + visitor floating widget).
- Add an interactive demo at `demo/load-sidebar-v2-widget-config/` with three presets (`helpCenter`, `visitor`, `sandbox`), live resolved JSON, and `window.angieConfig` override support.
- Link the new docs and demo from the root README, loadSidebarV2 README, and demos index.

## Test plan
- [ ] Run `npm run demo` and open `/demo/load-sidebar-v2-widget-config/?preset=helpCenter`
- [ ] Verify two-column layout (JSON + Common fields) does not overlap
- [ ] Open Angie sidebar — confirm it docks on the right without covering page content
- [ ] Switch presets via `?preset=visitor` and `?preset=sandbox` and confirm layout/config changes
- [ ] Override copy via `window.angieConfig` in the console and reload
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Angie SDK lacks user-facing documentation and interactive examples for `widgetConfig` — the key API for customizing embedded chat UI (copy, features, MCP focus). This PR ships comprehensive docs plus a production-patterned demo with runtime overrides.

## 2. What Changed (Where)

| File | Purpose |
|------|---------|
| `src/load-sidebar-v2/widget-config.md` | Full reference: field types, layout defaults, production patterns (help center, visitor widget), `window.angieConfig` runtime override pattern |
| `demo/load-sidebar-v2-widget-config/` | Three interactive presets (help center sidebar, visitor floating search, feature sandbox) with live config JSON inspector and console override hints |
| `src/load-sidebar-v2/README.md`, `README.md` | Links to new docs and demo; export list now includes `WidgetConfig` type |
| `demo/index.html` | New featured card linking to widget-config demo |

## 3. How It Works

Demo host (`host.js`) reads `?preset=` param → builds `widgetConfig` via preset-specific builders → calls `sdk.loadSidebarV2({ widgetConfig })` → JS renders resolved config as JSON and highlights active preset. Users can override `window.angieConfig` in console before reload to test copy/prompts without rebuilding. `localServers.skipLoading: true` pattern shown to avoid MCP registration race. CSS (`demo-host.css`) mirrors Elementor production UI tokens and right-docked sidebar layout.

## 4. Risks

None material. Demo is isolated; docs are additive reference. Only note: `window.angieConfig` override pattern in demo assumes hosts will inject that global — document clearly that this is optional and for iteration only, not production auth/secrets (already done in widget-config.md § Runtime overrides).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
