### PR TITLE
Demo: triggerAngie with programmatic and hash deep links

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -100,6 +100,10 @@
     </p>
 
     <div class="cards">
+      <a class="card featured" href="./trigger-angie-prompt/">
+        <strong>triggerAngie — prompt trigger</strong>
+        <span>Open Angie with a pre-filled prompt via SDK call or hash deep link.</span>
+      </a>
       <a class="card featured" href="./load-sidebar-v2-full-config/">
         <strong>loadSidebarV2 — full example</strong>
         <span>Product editor UI, aiContext, custom CSS, and triggerAngie.</span>

--- a/demo/trigger-angie-prompt/demo-host.css
+++ b/demo/trigger-angie-prompt/demo-host.css
@@ -1,0 +1,367 @@
+:root {
+	--demo-bg: #f4f6fb;
+	--demo-surface: #ffffff;
+	--demo-border: #e2e8f0;
+	--demo-text: #0f172a;
+	--demo-muted: #64748b;
+	--demo-accent: #4f46e5;
+	--demo-accent-strong: #4338ca;
+	--demo-accent-soft: #eef2ff;
+	--demo-success: #059669;
+	--demo-radius: 12px;
+	--demo-font: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
+}
+
+html {
+	color-scheme: light;
+}
+
+body {
+	margin: 0;
+	min-height: 100vh;
+	font-family: var(--demo-font);
+	font-size: 15px;
+	line-height: 1.5;
+	color: var(--demo-text);
+	background: var(--demo-bg);
+}
+
+a {
+	color: var(--demo-accent);
+	text-decoration: none;
+}
+
+a:hover {
+	text-decoration: underline;
+}
+
+code {
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 0.88em;
+	background: #f1f5f9;
+	padding: 0.12em 0.35em;
+	border-radius: 4px;
+}
+
+.demo-app {
+	min-height: 100vh;
+	display: flex;
+	flex-direction: column;
+}
+
+.demo-app-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 1rem;
+	padding: 0.85rem 1.25rem;
+	background: var(--demo-surface);
+	border-bottom: 1px solid var(--demo-border);
+	position: sticky;
+	top: 0;
+	z-index: 10;
+}
+
+.demo-app-brand {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.65rem;
+	color: inherit;
+	text-decoration: none;
+}
+
+.demo-app-logo {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 8px;
+	background: var(--demo-accent);
+	color: #fff;
+	font-weight: 700;
+}
+
+.demo-app-brand-text {
+	display: flex;
+	flex-direction: column;
+	line-height: 1.2;
+}
+
+.demo-app-brand-text span {
+	color: var(--demo-muted);
+	font-size: 0.82rem;
+}
+
+.demo-main {
+	flex: 1;
+	max-width: 52rem;
+	width: 100%;
+	margin: 0 auto;
+	padding: 1.5rem 1.25rem 2.5rem;
+}
+
+.demo-breadcrumb {
+	display: flex;
+	align-items: center;
+	gap: 0.45rem;
+	margin-bottom: 1rem;
+	font-size: 0.9rem;
+	color: var(--demo-muted);
+}
+
+.demo-hero h1 {
+	margin: 0 0 0.5rem;
+	font-size: clamp(1.5rem, 4vw, 1.9rem);
+	letter-spacing: -0.02em;
+}
+
+.demo-hero p {
+	margin: 0 0 1.5rem;
+	color: var(--demo-muted);
+	line-height: 1.6;
+}
+
+.demo-grid {
+	display: grid;
+	gap: 1rem;
+}
+
+.demo-card {
+	padding: 1.1rem 1.15rem;
+	border: 1px solid var(--demo-border);
+	border-radius: var(--demo-radius);
+	background: var(--demo-surface);
+	box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
+}
+
+.demo-card h2 {
+	margin: 0 0 0.35rem;
+	font-size: 1.05rem;
+}
+
+.demo-card-lead {
+	margin: 0 0 0.9rem;
+	color: var(--demo-muted);
+	font-size: 0.94rem;
+}
+
+.demo-field {
+	display: grid;
+	gap: 0.35rem;
+	margin-bottom: 0.85rem;
+}
+
+.demo-field label {
+	font-size: 0.88rem;
+	font-weight: 600;
+}
+
+.demo-field input,
+.demo-field textarea {
+	width: 100%;
+	padding: 0.55rem 0.7rem;
+	border: 1px solid var(--demo-border);
+	border-radius: 8px;
+	font: inherit;
+	color: inherit;
+	background: #fff;
+}
+
+.demo-field textarea {
+	min-height: 4.5rem;
+	resize: vertical;
+}
+
+.demo-hash-group-title {
+	margin: 0 0 0.5rem;
+	font-size: 0.82rem;
+	font-weight: 700;
+	letter-spacing: 0.04em;
+	text-transform: uppercase;
+	color: var(--demo-muted);
+}
+
+.demo-hash-group-title:not( :first-of-type ) {
+	margin-top: 1rem;
+}
+
+.demo-hash-links {
+	display: grid;
+	gap: 0.55rem;
+	margin: 0 0 0.85rem;
+	padding: 0;
+	list-style: none;
+}
+
+.demo-hash-links a {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.45rem 0.7rem;
+	border: 1px solid var(--demo-border);
+	border-radius: 8px;
+	background: #fff;
+	color: var(--demo-accent-strong);
+	text-decoration: none;
+	font-weight: 600;
+}
+
+.demo-hash-link--new-tab::after {
+	content: '';
+	flex-shrink: 0;
+	width: 0.9em;
+	height: 0.9em;
+	background-color: currentColor;
+	opacity: 0.65;
+	mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3Cpolyline points='15 3 21 3 21 9'/%3E%3Cline x1='10' y1='14' x2='21' y2='3'/%3E%3C/svg%3E");
+	mask-size: contain;
+	mask-repeat: no-repeat;
+	mask-position: center;
+	-webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6'/%3E%3Cpolyline points='15 3 21 3 21 9'/%3E%3Cline x1='10' y1='14' x2='21' y2='3'/%3E%3C/svg%3E");
+	-webkit-mask-size: contain;
+	-webkit-mask-repeat: no-repeat;
+	-webkit-mask-position: center;
+}
+
+.demo-hash-links a:hover {
+	border-color: #c7d2fe;
+	background: var(--demo-accent-soft);
+	text-decoration: none;
+}
+
+.demo-hash-link--new-tab:hover::after {
+	opacity: 0.9;
+}
+
+.demo-sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+}
+
+.demo-actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.55rem;
+}
+
+.demo-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	gap: 0.35rem;
+	padding: 0.55rem 0.9rem;
+	border: 1px solid transparent;
+	border-radius: 8px;
+	font: inherit;
+	font-weight: 600;
+	cursor: pointer;
+	transition: background 0.15s ease, border-color 0.15s ease;
+}
+
+.demo-btn-primary {
+	background: var(--demo-accent);
+	color: #fff;
+}
+
+.demo-btn-primary:hover {
+	background: var(--demo-accent-strong);
+}
+
+.demo-btn-secondary {
+	background: var(--demo-accent-soft);
+	color: var(--demo-accent-strong);
+	border-color: #c7d2fe;
+}
+
+.demo-btn-secondary:hover {
+	background: #e0e7ff;
+}
+
+.demo-btn-ghost {
+	background: transparent;
+	color: var(--demo-text);
+	border-color: var(--demo-border);
+}
+
+.demo-btn-ghost:hover {
+	background: #f8fafc;
+}
+
+.demo-status {
+	margin-top: 0.85rem;
+	padding: 0.65rem 0.75rem;
+	border-radius: 8px;
+	font-size: 0.9rem;
+	background: #f8fafc;
+	border: 1px solid var(--demo-border);
+	color: var(--demo-muted);
+}
+
+.demo-status.is-success {
+	background: #ecfdf5;
+	border-color: #a7f3d0;
+	color: #047857;
+}
+
+.demo-status.is-error {
+	background: #fef2f2;
+	border-color: #fecaca;
+	color: #b91c1c;
+}
+
+.demo-code-block {
+	margin: 0.75rem 0 0;
+	padding: 0.75rem 0.85rem;
+	border-radius: 8px;
+	background: #0f172a;
+	color: #e2e8f0;
+	font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+	font-size: 0.8rem;
+	line-height: 1.55;
+	overflow-x: auto;
+	white-space: pre;
+}
+
+.demo-chip-list {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.45rem;
+	margin: 0 0 0.85rem;
+	padding: 0;
+	list-style: none;
+}
+
+.demo-chip {
+	padding: 0.35rem 0.7rem;
+	border: 1px solid var(--demo-border);
+	border-radius: 999px;
+	background: #fff;
+	font-size: 0.86rem;
+	cursor: pointer;
+}
+
+.demo-chip:hover {
+	border-color: #c7d2fe;
+	background: var(--demo-accent-soft);
+}
+
+.demo-app-footer {
+	padding: 1rem 1.25rem 1.5rem;
+	text-align: center;
+	font-size: 0.88rem;
+	color: var(--demo-muted);
+}

--- a/demo/trigger-angie-prompt/host.js
+++ b/demo/trigger-angie-prompt/host.js
@@ -1,0 +1,188 @@
+import { AngieMcpSdk, LAYOUT_SIDEBAR } from '../../dist/index.js';
+
+const DEFAULT_PROMPT = 'Help me improve the headline on this page for conversions.';
+const HASH_PARAM_PROMPT = 'angie-prompt';
+const HASH_PARAM_NEW_CHAT = 'angie-new-chat';
+
+const sdk = new AngieMcpSdk();
+const statusEl = document.getElementById( 'demo-status' );
+const promptInput = document.getElementById( 'demo-prompt-input' );
+
+const setStatus = ( message, type = 'idle' ) => {
+	if ( ! statusEl ) {
+		return;
+	}
+
+	statusEl.textContent = message;
+	statusEl.classList.remove( 'is-success', 'is-error' );
+
+	if ( type === 'success' ) {
+		statusEl.classList.add( 'is-success' );
+	}
+
+	if ( type === 'error' ) {
+		statusEl.classList.add( 'is-error' );
+	}
+};
+
+const getPrompt = () => promptInput?.value?.trim() || DEFAULT_PROMPT;
+
+const parseHashParams = ( hash ) => {
+	const paramString = hash.startsWith( '#' ) ? hash.substring( 1 ) : hash;
+	return new URLSearchParams( paramString );
+};
+
+const readPromptFromHash = ( hash ) => {
+	if ( ! hash.includes( `${ HASH_PARAM_PROMPT }=` ) ) {
+		return null;
+	}
+
+	const params = parseHashParams( hash );
+	const prompt = params.get( HASH_PARAM_PROMPT ) || '';
+
+	if ( ! prompt ) {
+		return null;
+	}
+
+	return {
+		prompt,
+		newChat: params.get( HASH_PARAM_NEW_CHAT ) === 'true',
+	};
+};
+
+const clearPromptHash = () => {
+	if ( ! window.location.hash ) {
+		return;
+	}
+
+	const scrollY = window.scrollY;
+	history.replaceState( null, '', `${ window.location.pathname }${ window.location.search }` );
+	window.scrollTo( 0, scrollY );
+};
+
+const consumeHashOnLoad = () => {
+	const hashPrompt = readPromptFromHash( window.location.hash );
+
+	if ( ! hashPrompt ) {
+		return null;
+	}
+
+	const scrollY = window.scrollY;
+	clearPromptHash();
+	window.scrollTo( 0, scrollY );
+
+	return hashPrompt;
+};
+
+const pendingHashPrompt = consumeHashOnLoad();
+
+const triggerWithPrompt = async ( { newChat = false, prompt = getPrompt() } = {} ) => {
+	try {
+		setStatus( 'Waiting for Angie…' );
+		await sdk.waitForReady();
+
+		const response = await sdk.triggerAngie( {
+			prompt,
+			options: {
+				newChat,
+				timeout: 30000,
+			},
+		} );
+
+		if ( response.success ) {
+			setStatus( `Angie opened with your prompt. Request ID: ${ response.requestId }`, 'success' );
+			return;
+		}
+
+		setStatus( response.error || 'Angie trigger failed.', 'error' );
+	} catch ( error ) {
+		setStatus( error instanceof Error ? error.message : 'Unknown error', 'error' );
+	}
+};
+
+document.getElementById( 'demo-trigger-fill' )?.addEventListener( 'click', () => {
+	void triggerWithPrompt();
+} );
+
+document.getElementById( 'demo-trigger-new-chat' )?.addEventListener( 'click', () => {
+	void triggerWithPrompt( { newChat: true } );
+} );
+
+document.querySelectorAll( '[data-prompt-chip]' ).forEach( ( chip ) => {
+	chip.addEventListener( 'click', () => {
+		const prompt = chip.getAttribute( 'data-prompt-chip' );
+
+		if ( promptInput && prompt ) {
+			promptInput.value = prompt;
+		}
+
+		void triggerWithPrompt();
+	} );
+} );
+
+document.querySelectorAll( '.demo-hash-link--in-page' ).forEach( ( link ) => {
+	link.addEventListener( 'click', ( event ) => {
+		event.preventDefault();
+		const hash = link.getAttribute( 'href' );
+		const hashPrompt = hash ? readPromptFromHash( hash ) : null;
+
+		if ( ! hashPrompt ) {
+			setStatus( 'Hash link is missing a prompt.', 'error' );
+			return;
+		}
+
+		if ( promptInput ) {
+			promptInput.value = hashPrompt.prompt;
+		}
+
+		void triggerWithPrompt( hashPrompt );
+	} );
+} );
+
+sdk.loadSidebarV2( {
+	host: {
+		appId: 'demo-trigger-angie-prompt',
+	},
+	container: {
+		layout: LAYOUT_SIDEBAR,
+		styleTheme: 'wordpress',
+		persistOpenState: true,
+		chatToggleButton: {
+			enabled: true,
+			selector: '#demo-toggle',
+		},
+	},
+	iframe: {
+		origin: 'https://angie.elementor.com',
+		path: 'angie/embedded',
+		uiTheme: 'light',
+	},
+	widgetConfig: {
+		title: 'Angie',
+		subtitle: 'Prompt trigger demo',
+		suggestions: {
+			items: [
+				{
+					label: 'Improve headline',
+					value: 'Suggest three stronger headlines for this page.',
+				},
+				{
+					label: 'SEO check',
+					value: 'Review this page for basic SEO issues and quick wins.',
+				},
+			],
+		},
+	},
+} ).then( () => {
+	setStatus( 'Angie sidebar loaded. Use the controls or hash links below.' );
+
+	if ( pendingHashPrompt ) {
+		if ( promptInput ) {
+			promptInput.value = pendingHashPrompt.prompt;
+		}
+
+		void triggerWithPrompt( pendingHashPrompt );
+	}
+} ).catch( ( error ) => {
+	setStatus( error instanceof Error ? error.message : 'Failed to load Angie', 'error' );
+} );

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Interactive demo of triggerAngie — open Angie with a pre-filled prompt from your host app." />
+  <title>triggerAngie · Angie SDK Demo</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/types.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod/v4": "../../node_modules/zod/v4/index.js"
+    }
+  }
+  </script>
+  <link rel="stylesheet" href="./demo-host.css" />
+</head>
+<body>
+  <div class="demo-app">
+    <header class="demo-app-header">
+      <a class="demo-app-brand" href="../">
+        <span class="demo-app-logo" aria-hidden="true">A</span>
+        <span class="demo-app-brand-text">
+          <strong>Angie SDK</strong>
+          <span>triggerAngie</span>
+        </span>
+      </a>
+      <button type="button" id="demo-toggle" aria-expanded="false">
+        Open Angie
+      </button>
+    </header>
+
+    <main class="demo-main">
+      <nav class="demo-breadcrumb" aria-label="Breadcrumb">
+        <a href="../">Demos</a>
+        <span aria-hidden="true">/</span>
+        <span>triggerAngie</span>
+      </nav>
+
+      <div class="demo-hero">
+        <h1>Trigger Angie with a prompt</h1>
+        <p>
+          Use <code>sdk.triggerAngie()</code> from your host page to open Angie with a prompt
+          already in the input — for help buttons, onboarding flows, or deep links.
+          Call <code>await sdk.waitForReady()</code> before triggering.
+        </p>
+      </div>
+
+      <div class="demo-grid">
+        <section class="demo-card" aria-labelledby="prompt-heading">
+          <h2 id="prompt-heading">1. Programmatic trigger</h2>
+          <p class="demo-card-lead">
+            The most common pattern: your UI calls <code>triggerAngie</code> with a prompt string.
+          </p>
+
+          <div class="demo-field">
+            <label for="demo-prompt-input">Prompt</label>
+            <textarea id="demo-prompt-input" spellcheck="false">Help me improve the headline on this page for conversions.</textarea>
+          </div>
+
+          <ul class="demo-chip-list" aria-label="Quick prompts">
+            <li><button type="button" class="demo-chip" data-prompt-chip="Summarize this page in three bullet points.">Summarize page</button></li>
+            <li><button type="button" class="demo-chip" data-prompt-chip="What should I change before publishing this page?">Pre-publish review</button></li>
+            <li><button type="button" class="demo-chip" data-prompt-chip="Suggest a clearer call to action for this screen.">Better CTA</button></li>
+          </ul>
+
+          <div class="demo-actions">
+            <button type="button" class="demo-btn demo-btn-primary" id="demo-trigger-fill">
+              Fill input &amp; open Angie
+            </button>
+            <button type="button" class="demo-btn demo-btn-secondary" id="demo-trigger-new-chat">
+              New chat + prompt
+            </button>
+          </div>
+
+          <pre class="demo-code-block" aria-hidden="true">await sdk.waitForReady();
+await sdk.triggerAngie({
+  prompt: 'Help me improve the headline…',
+  options: { newChat: false },
+});</pre>
+        </section>
+
+        <section class="demo-card" aria-labelledby="hash-heading">
+          <h2 id="hash-heading">2. Hash deep link</h2>
+          <p class="demo-card-lead">
+            Share a URL with <code>#angie-prompt=…</code> in the hash. Use an in-page link on the
+            same screen, or open in a new tab when linking from emails, docs, or another page.
+            Add <code>&amp;angie-new-chat=true</code> to start a fresh chat.
+          </p>
+
+          <h3 class="demo-hash-group-title">In this page</h3>
+          <ul class="demo-hash-links">
+            <li>
+              <a
+                class="demo-hash-link--in-page"
+                href="#angie-prompt=What%20should%20I%20change%20before%20publishing%3F"
+              >
+                Pre-publish review
+              </a>
+            </li>
+            <li>
+              <a
+                class="demo-hash-link--in-page"
+                href="#angie-prompt=Suggest%20a%20clearer%20call%20to%20action%20for%20this%20screen."
+              >
+                Better CTA
+              </a>
+            </li>
+          </ul>
+
+          <h3 class="demo-hash-group-title">New tab</h3>
+          <ul class="demo-hash-links">
+            <li>
+              <a
+                class="demo-hash-link--new-tab"
+                href="#angie-prompt=Help%20me%20optimize%20this%20page%20for%20SEO"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Opens in new tab"
+              >
+                Optimize for SEO
+                <span class="demo-sr-only">Opens in new tab</span>
+              </a>
+            </li>
+            <li>
+              <a
+                class="demo-hash-link--new-tab"
+                href="#angie-prompt=Fix%20this%20error%20on%20my%20site&amp;angie-new-chat=true"
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Opens in new tab"
+              >
+                Fix an error (new chat)
+                <span class="demo-sr-only">Opens in new tab</span>
+              </a>
+            </li>
+          </ul>
+
+          <pre class="demo-code-block" aria-hidden="true">&lt;a
+  href="#angie-prompt=Help%20me%20create%20a%20contact%20page"
+  target="_blank"
+  rel="noopener noreferrer"
+&gt;
+  Get help creating a contact page
+&lt;/a&gt;</pre>
+        </section>
+
+        <section class="demo-card" aria-labelledby="status-heading">
+          <h2 id="status-heading">3. Status</h2>
+          <p class="demo-card-lead">Last trigger result from the host page.</p>
+          <div class="demo-status" id="demo-status" role="status" aria-live="polite">
+            Loading Angie sidebar…
+          </div>
+        </section>
+      </div>
+    </main>
+
+    <footer class="demo-app-footer">
+      <a href="https://github.com/elementor/angie-sdk">Angie SDK</a>
+      ·
+      <a href="../">All demos</a>
+      ·
+      <a href="https://github.com/elementor/angie-sdk#triggering-angie-with-prompts">triggerAngie docs</a>
+    </footer>
+  </div>
+
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <script type="module" src="./host.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `demo/trigger-angie-prompt/` — interactive demo for opening Angie with a pre-filled prompt via `sdk.triggerAngie()`
- Cover programmatic triggers (fill input, new chat, quick chips) and hash deep links (`#angie-prompt=…`, optional `angie-new-chat=true`)
- Split hash examples into in-page links (same tab, no scroll) and new-tab links (simulates arrival from email/docs) with an external-link icon
- Link the new demo from `demo/index.html`

## Test plan
- [ ] Run `npm run demo` and open `/demo/trigger-angie-prompt/`
- [ ] Click **Fill input & open Angie** — sidebar opens with prompt in input
- [ ] Click **New chat + prompt** — fresh chat with prompt filled
- [ ] Click in-page hash links — Angie opens without page jump
- [ ] Click new-tab hash links — new tab loads, hash consumed, Angie opens with prompt
- [ ] Confirm demo index links to the new demo
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

New demo showcasing `triggerAngie()` API with two interaction patterns: programmatic calls from UI and hash-based deep linking for shareable URLs. Demonstrates waitForReady flow and newChat option.

## 2. What Changed (Where)

- **demo/trigger-angie-prompt/index.html** — 170-line demo page with prompt input, quick-action chips, hash link examples, status display
- **demo/trigger-angie-prompt/host.js** — SDK initialization, hash parsing (readPromptFromHash), click handlers for buttons/chips/links, triggerAngie invocation with error handling
- **demo/trigger-angie-prompt/demo-host.css** — 367-line design system (variables, layout grid, form controls, status states, code blocks)
- **demo/index.html** — Added card linking to new demo in carousel

## 3. How It Works

Hash params parsed on load via `readPromptFromHash()` and consumed before clearing hash. Prompt state flows: input field → getPrompt() → triggerAngie({ prompt, options: { newChat } }). Event listeners on buttons (fill/new-chat), chips (quick prompts), and in-page hash links (preventDefault, parse, trigger). New-tab hash links skip interception. Status element updated with response.requestId on success or error details on failure.

## 4. Risks

None—isolated demo module. Minor: hash link UX assumes users won't manually edit params (gracefully fails with "missing prompt" error). New-tab links don't handle hash consumption, but that's by design (separate session).

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
