### PR TITLE
[AI-8644] Add localServers.includedServers allowlist to WidgetConfig

### DIFF
--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -43,7 +43,7 @@ const buildHelpCenterWidgetConfig = () => {
 		closeButton: 'collapse',
 		betaBanner: { enabled: false },
 		aiContextGuidance: { enabled: true },
-		localServers: { skipLoading: true },
+		localServers: { skipLoading: true, includedServers: [ HELP_CENTER_SERVER ] },
 		userProfileMenu: { enabled: false },
 	};
 };

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -46,7 +46,7 @@
         <h1>Customize the embedded Angie UI</h1>
         <p>
           <code>widgetConfig</code> controls empty-state copy, starter prompts, feature toggles,
-          close behavior, and which host MCP server Angie should feature first.
+          close behavior, which host MCP servers appear in the tools UI, and which server Angie should feature first.
           Config is sent to the iframe as <code>sdk-widget-config</code>.
         </p>
       </div>
@@ -121,8 +121,12 @@
               <dd><code>collapse</code> (sidebar default) or <code>close</code> (floating chat default)</dd>
             </div>
             <div>
-              <dt><code>localServers.skipLoading</code></dt>
-              <dd>Register MCP servers yourself after <code>waitForReady()</code></dd>
+              <dt><code>localServers</code></dt>
+              <dd>
+                <code>skipLoading: true</code> — register MCP servers after <code>waitForReady()</code>.
+                <code>includedServers</code> — optional allowlist of <code>registerServer({ name })</code> values
+                to show in the tools UI when the host registers more than one server.
+              </dd>
             </div>
             <div>
               <dt><code>aiContextGuidance</code></dt>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.4.9",
+      "version": "1.4.10",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.9",
+  "version": "1.4.10",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -29,6 +29,7 @@ export type ModeSwitcherConfig = {
 
 export type LocalServersConfig = {
   skipLoading?: boolean;
+  includedServers?: string[];
 };
 
 export type WidgetConfig = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type LocalServersConfig, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -85,7 +85,7 @@ Each toggle uses `{ enabled: boolean }`.
 |-------|------|---------|
 | `modeSwitcher` | `{ enabled?: boolean; default?: 'agent' \| 'plan' \| 'ask' }` | Show or hide Agent / Plan / Ask switcher; set the initial mode |
 | `featuredMcpServer` | `string` | Name of a **host-registered** local MCP server Angie should surface first (must match `registerServer({ name })`) |
-| `localServers` | `{ skipLoading?: boolean }` | When `skipLoading: true`, Angie does not auto-load host local servers — use when you register servers yourself after `waitForReady()` |
+| `localServers` | `{ skipLoading?: boolean; includedServers?: string[] }` | `skipLoading: true` — Angie does not auto-load host local servers (register after `waitForReady()`). `includedServers` — optional allowlist of host-registered local MCP server names to expose in the tools UI (must match `registerServer({ name })`) |
 
 ### Close behavior
 
@@ -121,7 +121,7 @@ const widgetConfig: WidgetConfig = {
   closeButton: 'collapse',
   betaBanner: { enabled: false },
   aiContextGuidance: { enabled: false },
-  localServers: { skipLoading: true },
+  localServers: { skipLoading: true, includedServers: [ HELP_CENTER_SERVER ] },
   userProfileMenu: { enabled: false },
 };
 
@@ -135,7 +135,7 @@ await sdk.waitForReady();
 sdk.registerServer({ name: HELP_CENTER_SERVER, /* ... */ });
 ```
 
-`localServers.skipLoading: true` avoids a race: register your MCP servers after `waitForReady()`, then Angie uses `featuredMcpServer` to prioritize the right one.
+`localServers.skipLoading: true` avoids a race: register your MCP servers after `waitForReady()`, then Angie uses `featuredMcpServer` to prioritize the right one. Use `includedServers` to limit which registered local servers appear in the tools panel when the host registers more than one server but only wants specific ones visible (for example `help-center`).
 
 ### Visitor floating search widget
 


### PR DESCRIPTION
## Summary

Adds an optional `localServers.includedServers` allowlist to `WidgetConfig` so hosts that register multiple local MCP servers can control which ones Angie surfaces in the tools UI.

Bumps `@elementor/angie-sdk` to **1.4.10**.

Jira: https://elementor.atlassian.net/browse/AI-8644

## Problem

Hosts can register several local MCP servers via `registerServer({ name })`, but Angie currently exposes all of them in the tools UI. There is no SDK-supported way to show only a subset (for example, hide internal servers while keeping a user-facing one visible).

## Solution

Extend `LocalServersConfig` with an optional `includedServers?: string[]` field:

```ts
widgetConfig: {
  localServers: {
    skipLoading: true,
    includedServers: ['help-center', 'user-data'],
  },
}