### PR TITLE
[AI-8800] Add guidedScreens configuration and event callbacks to WidgetConfig

### DIFF
--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -136,7 +136,7 @@ const buildGuidedScreensWidgetConfig = () => ( {
 				ctaLabel: 'I understand',
 			},
 			{
-				type: 'widget-picker',
+				type: 'prompts-picker',
 				title: 'Create your first widget',
 				subtitle: 'Start with an example or describe what you need.',
 				items: [
@@ -217,7 +217,7 @@ const PRESETS = {
 	},
 	guided: {
 		label: 'Guided screens',
-		description: 'Sidebar with guided intro screens: Meet Angie + widget picker.',
+		description: 'Sidebar with guided intro screens: Meet Angie + prompts picker.',
 		layout: LAYOUT_SIDEBAR,
 		buildWidgetConfig: buildGuidedScreensWidgetConfig,
 		loadOptions: {

--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -230,6 +230,14 @@ const PRESETS = {
 					selector: '#demo-toggle',
 				},
 			},
+			// The SDK invokes these when the embedded app emits the guided-screen events.
+			// Bodies run here (host) — e.g. analytics + persisting "already seen".
+			// They won't fire until the embedded app emits the events end-to-end.
+			callbacks: {
+				onGuidedWelcomeConfirm: () => console.log( '[guided] welcome confirmed' ),
+				onGuidedWidgetSelect: ( selection ) =>
+					console.log( '[guided] widget selected', selection ),
+			},
 		},
 	},
 };

--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -106,11 +106,12 @@ const buildSandboxWidgetConfig = () => ( {
 
 // Placeholder content — the production copy, widget list, and preview images are
 // owned by Design/Product. The "Beta" badge is rendered by the embedded app, not configured here.
-const buildFirstTimeWidgetConfig = () => ( {
+// The SDK forwards these screens; the host/app decides when to render them.
+const buildGuidedScreensWidgetConfig = () => ( {
 	title: 'Welcome to Angie',
 	subtitle: 'Let Angie help you build your first widget.',
 	closeButton: 'collapse',
-	firstTimeExperience: {
+	guidedScreens: {
 		screens: [
 			{
 				type: 'welcome',
@@ -214,11 +215,11 @@ const PRESETS = {
 			},
 		},
 	},
-	firstTime: {
-		label: 'First-time experience',
-		description: 'Sidebar with a one-time onboarding: Meet Angie + widget picker.',
+	guided: {
+		label: 'Guided screens',
+		description: 'Sidebar with guided intro screens: Meet Angie + widget picker.',
 		layout: LAYOUT_SIDEBAR,
-		buildWidgetConfig: buildFirstTimeWidgetConfig,
+		buildWidgetConfig: buildGuidedScreensWidgetConfig,
 		loadOptions: {
 			container: {
 				layout: LAYOUT_SIDEBAR,

--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -104,6 +104,71 @@ const buildSandboxWidgetConfig = () => ( {
 	userProfileMenu: { enabled: true },
 } );
 
+// Placeholder content — the production copy, widget list, and preview images are
+// owned by Design/Product. The "Beta" badge is rendered by the embedded app, not configured here.
+const buildFirstTimeWidgetConfig = () => ( {
+	title: 'Welcome to Angie',
+	subtitle: 'Let Angie help you build your first widget.',
+	closeButton: 'collapse',
+	firstTimeExperience: {
+		screens: [
+			{
+				type: 'welcome',
+				title: 'Meet Angie',
+				subtitle:
+					"Angie is an active experiment. We're exploring new ways to make building and managing WordPress sites faster and more powerful.",
+				highlights: [
+					{
+						title: 'Angie is in beta',
+						description: 'Features evolve quickly, and your feedback helps shape what comes next.',
+					},
+					{
+						title: 'You stay in control',
+						description: 'Review and edit every change before publishing to your live site.',
+					},
+					{
+						title: 'Free to explore',
+						description: 'Use your beta credits freely - no payment required during beta.',
+					},
+					{ title: "AI isn't perfect", description: 'Always review results before publishing.' },
+				],
+				ctaLabel: 'I understand',
+			},
+			{
+				type: 'widget-picker',
+				title: 'Create your first widget',
+				subtitle: 'Start with an example or describe what you need.',
+				items: [
+					{
+						id: 'hero',
+						label: 'Hero section',
+						description: 'A bold above-the-fold section with a headline and CTA.',
+						prompt: 'Create a hero section with a bold headline, supporting subtext, and a call-to-action button.',
+					},
+					{
+						id: 'pricing',
+						label: 'Pricing table',
+						description: 'Compare plans side by side.',
+						prompt: 'Create a three-column pricing table with monthly and yearly options.',
+					},
+					{
+						id: 'testimonials',
+						label: 'Testimonials',
+						description: 'Social proof from happy customers.',
+						prompt: 'Create a testimonials section with three customer quotes and avatars.',
+					},
+					{
+						id: 'contact',
+						label: 'Contact form',
+						description: 'Let visitors get in touch.',
+						prompt: 'Create a contact form with name, email, and message fields.',
+					},
+				],
+			},
+		],
+	},
+} );
+
 const PRESETS = {
 	helpCenter: {
 		label: 'Help center sidebar',
@@ -137,6 +202,23 @@ const PRESETS = {
 		description: 'Sidebar with most widget toggles enabled.',
 		layout: LAYOUT_SIDEBAR,
 		buildWidgetConfig: buildSandboxWidgetConfig,
+		loadOptions: {
+			container: {
+				layout: LAYOUT_SIDEBAR,
+				persistOpenState: true,
+				resizable: true,
+				chatToggleButton: {
+					enabled: true,
+					selector: '#demo-toggle',
+				},
+			},
+		},
+	},
+	firstTime: {
+		label: 'First-time experience',
+		description: 'Sidebar with a one-time onboarding: Meet Angie + widget picker.',
+		layout: LAYOUT_SIDEBAR,
+		buildWidgetConfig: buildFirstTimeWidgetConfig,
 		loadOptions: {
 			container: {
 				layout: LAYOUT_SIDEBAR,

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -76,6 +76,12 @@
               <span>most toggles enabled</span>
             </a>
           </li>
+          <li>
+            <a class="demo-preset-link" data-preset-link="firstTime" href="?preset=firstTime">
+              <strong>First-time experience</strong>
+              <span>onboarding + widget picker</span>
+            </a>
+          </li>
         </ul>
         <p class="demo-active-preset">
           Active: <strong id="demo-preset-label">Help center sidebar</strong>

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -79,7 +79,7 @@
           <li>
             <a class="demo-preset-link" data-preset-link="guided" href="?preset=guided">
               <strong>Guided screens</strong>
-              <span>welcome + widget picker</span>
+              <span>welcome + prompts picker</span>
             </a>
           </li>
         </ul>

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -77,9 +77,9 @@
             </a>
           </li>
           <li>
-            <a class="demo-preset-link" data-preset-link="firstTime" href="?preset=firstTime">
-              <strong>First-time experience</strong>
-              <span>onboarding + widget picker</span>
+            <a class="demo-preset-link" data-preset-link="guided" href="?preset=guided">
+              <strong>Guided screens</strong>
+              <span>welcome + widget picker</span>
             </a>
           </li>
         </ul>

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -31,7 +31,7 @@ export type LocalServersConfig = {
   skipLoading?: boolean;
 };
 
-export type FteWidgetItem = {
+export type GuidedWidgetItem = {
   id: string;
   label: string;
   prompt: string;
@@ -39,28 +39,28 @@ export type FteWidgetItem = {
   image?: string;
 };
 
-export type FteHighlight = {
+export type GuidedHighlight = {
   title: string;
   description?: string;
 };
 
-export type FteScreen =
+export type GuidedScreen =
   | {
       type: 'welcome';
       title: string;
       subtitle?: string;
-      highlights?: FteHighlight[];
+      highlights?: GuidedHighlight[];
       ctaLabel: string;
     }
   | {
       type: 'widget-picker';
       title: string;
       subtitle?: string;
-      items: FteWidgetItem[];
+      items: GuidedWidgetItem[];
     };
 
-export type FirstTimeExperienceConfig = {
-  screens: FteScreen[];
+export type GuidedScreensConfig = {
+  screens: GuidedScreen[];
 };
 
 export type WidgetConfig = {
@@ -79,7 +79,7 @@ export type WidgetConfig = {
   aiContextGuidance?: FeatureToggle;
   userProfileMenu?: FeatureToggle;
   localServers?: LocalServersConfig;
-  firstTimeExperience?: FirstTimeExperienceConfig;
+  guidedScreens?: GuidedScreensConfig;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -53,7 +53,7 @@ export type GuidedScreen =
       ctaLabel: string;
     }
   | {
-      type: 'widget-picker';
+      type: 'prompts-picker';
       title: string;
       subtitle?: string;
       items: GuidedWidgetItem[];

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -31,6 +31,38 @@ export type LocalServersConfig = {
   skipLoading?: boolean;
 };
 
+export type FteWidgetItem = {
+  id: string;
+  label: string;
+  prompt: string;
+  description?: string;
+  image?: string;
+};
+
+export type FteHighlight = {
+  title: string;
+  description?: string;
+};
+
+export type FteScreen =
+  | {
+      type: 'welcome';
+      title: string;
+      subtitle?: string;
+      highlights?: FteHighlight[];
+      ctaLabel: string;
+    }
+  | {
+      type: 'widget-picker';
+      title: string;
+      subtitle?: string;
+      items: FteWidgetItem[];
+    };
+
+export type FirstTimeExperienceConfig = {
+  screens: FteScreen[];
+};
+
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -47,6 +79,7 @@ export type WidgetConfig = {
   aiContextGuidance?: FeatureToggle;
   userProfileMenu?: FeatureToggle;
   localServers?: LocalServersConfig;
+  firstTimeExperience?: FirstTimeExperienceConfig;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,
 	type ExternalHeadersCallback,
+	type GuidedWidgetSelection,
 	type LoadSidebarV2Options,
 } from './load-sidebar-v2/config';
 export { AngieDetector } from './angie-detector';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type FirstTimeExperienceConfig, type FteHighlight, type FteScreen, type FteWidgetItem, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type GuidedHighlight, type GuidedScreen, type GuidedScreensConfig, type GuidedWidgetItem, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type FirstTimeExperienceConfig, type FteHighlight, type FteScreen, type FteWidgetItem, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -57,7 +57,7 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 | `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
 | `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
-| `callbacks` | `onClose`, `getExternalHeaders` for auth/API headers |
+| `callbacks` | `onClose`, `getExternalHeaders` for auth/API headers, `onGuidedWelcomeConfirm` / `onGuidedWidgetSelect` for [guided screen events](#guided-screens-events) |
 | `widgetConfig` | Embedded UI copy, feature toggles, MCP focus, close behavior — see [widgetConfig guide](./widget-config.md) |
 
 Embedded config uses `configVersion: 2` (`LOAD_SIDEBAR_V2_CONFIG_VERSION`).
@@ -97,6 +97,7 @@ Example: [`demo/load-sidebar-v2-full-config/demo-host.css`](../../demo/load-side
 loadSidebarV2(options)
   → resolveConfig + shouldBoot
   → initHostApiBridge (postMessage API)
+  → initGuidedScreensBridge (guided screen event callbacks)
   → ensureSidebarContainer
   → layout strategy (initShell → open iframe → afterOpen)
   → sendEmbeddedConfig / sendWidgetConfig
@@ -112,6 +113,17 @@ Entry point: [`boot-sidebar.ts`](./boot-sidebar.ts). Layout strategies: [`layout
 - `angie/context/get-website-context` — host + document metadata
 - `angie/context/get-analytics-context` — screen path + `host.analytics`
 - Host localStorage get/set (for embedded persistence)
+
+## Guided screens events
+
+[`guided-screens-bridge.ts`](./guided-screens-bridge.ts) listens (origin-checked) for fire-and-forget notifications the embedded app emits while the [`guidedScreens`](./widget-config.md#guided-screens) flow is shown, and invokes the matching `callbacks`:
+
+| Message type (iframe → host) | Callback | Payload |
+|------------------------------|----------|---------|
+| `angie/guided-screens/welcome-confirm` | `onGuidedWelcomeConfirm()` | — |
+| `angie/guided-screens/widget-select` | `onGuidedWidgetSelect(selection)` | `{ id, label, prompt }` |
+
+The SDK only forwards these; the callback bodies (analytics, persistence) run in the host. No listener is registered if neither callback is provided.
 
 ## Module map
 
@@ -132,4 +144,4 @@ Jest specs live next to modules (`*.test.ts`). Run the package test script from 
 
 ## Exports
 
-From `@elementor/angie-sdk`: `loadSidebarV2` on `AngieMcpSdk`, plus `LAYOUT_SIDEBAR`, `LAYOUT_FLOATING_CHAT`, `LoadSidebarV2Options`, `WidgetConfig`, `ExternalHeadersCallback`.
+From `@elementor/angie-sdk`: `loadSidebarV2` on `AngieMcpSdk`, plus `LAYOUT_SIDEBAR`, `LAYOUT_FLOATING_CHAT`, `LoadSidebarV2Options`, `WidgetConfig`, `ExternalHeadersCallback`, `GuidedWidgetSelection`.

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -3,6 +3,7 @@ import { ensureSidebarContainer } from './container';
 import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
 import { readEnv } from './env';
+import { initGuidedScreensBridge } from './guided-screens-bridge';
 import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
@@ -20,6 +21,11 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 		iframeOrigin: config.iframe.origin,
 		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
+	} );
+
+	initGuidedScreensBridge( {
+		iframeOrigin: config.iframe.origin,
+		callbacks: config.callbacks,
 	} );
 
 	appState.containerId = config.container.id;

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -1,4 +1,4 @@
-import type { WidgetConfig } from '../angie-mcp-sdk';
+import type { GuidedWidgetItem, WidgetConfig } from '../angie-mcp-sdk';
 
 export const LOAD_SIDEBAR_V2_CONFIG_VERSION = 2 as const;
 
@@ -50,9 +50,13 @@ export type ExternalHeadersCallback = () =>
 	| Record<string, string | undefined>
 	| Promise<Record<string, string | undefined>>;
 
+export type GuidedWidgetSelection = Pick<GuidedWidgetItem, 'id' | 'label' | 'prompt'>;
+
 export type CallbacksConfig = {
 	onClose?: () => void;
 	getExternalHeaders?: ExternalHeadersCallback;
+	onGuidedWelcomeConfirm?: () => void;
+	onGuidedWidgetSelect?: ( selection: GuidedWidgetSelection ) => void;
 };
 
 export type LoadSidebarV2Options = {

--- a/src/load-sidebar-v2/guided-screens-bridge.test.ts
+++ b/src/load-sidebar-v2/guided-screens-bridge.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+	GUIDED_WELCOME_CONFIRM_MESSAGE_TYPE,
+	GUIDED_WIDGET_SELECT_MESSAGE_TYPE,
+	initGuidedScreensBridge,
+	resetGuidedScreensBridgeForTests,
+} from './guided-screens-bridge';
+import { resetHostMessageRouterForTests } from './host-message-router';
+
+const IFRAME_ORIGIN = 'http://localhost:4000';
+
+const dispatchMessage = ( data: unknown, origin: string = IFRAME_ORIGIN ): void => {
+	window.dispatchEvent( new MessageEvent( 'message', { data, origin } ) );
+};
+
+describe( 'load-sidebar-v2/guided-screens-bridge', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetGuidedScreensBridgeForTests();
+		resetHostMessageRouterForTests();
+	} );
+
+	it( 'should invoke onGuidedWelcomeConfirm on a welcome-confirm message', () => {
+		const onGuidedWelcomeConfirm = jest.fn();
+		initGuidedScreensBridge( { iframeOrigin: IFRAME_ORIGIN, callbacks: { onGuidedWelcomeConfirm } } );
+
+		dispatchMessage( { type: GUIDED_WELCOME_CONFIRM_MESSAGE_TYPE } );
+
+		expect( onGuidedWelcomeConfirm ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should invoke onGuidedWidgetSelect with the selection payload', () => {
+		const onGuidedWidgetSelect = jest.fn();
+		initGuidedScreensBridge( { iframeOrigin: IFRAME_ORIGIN, callbacks: { onGuidedWidgetSelect } } );
+
+		const selection = { id: 'hero', label: 'Hero', prompt: 'Create a hero section' };
+		dispatchMessage( { type: GUIDED_WIDGET_SELECT_MESSAGE_TYPE, payload: selection } );
+
+		expect( onGuidedWidgetSelect ).toHaveBeenCalledTimes( 1 );
+		expect( onGuidedWidgetSelect ).toHaveBeenCalledWith( selection );
+	} );
+
+	it( 'should ignore messages from other origins', () => {
+		const onGuidedWelcomeConfirm = jest.fn();
+		initGuidedScreensBridge( { iframeOrigin: IFRAME_ORIGIN, callbacks: { onGuidedWelcomeConfirm } } );
+
+		dispatchMessage( { type: GUIDED_WELCOME_CONFIRM_MESSAGE_TYPE }, 'https://evil.example.com' );
+
+		expect( onGuidedWelcomeConfirm ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should ignore unknown message types', () => {
+		const onGuidedWelcomeConfirm = jest.fn();
+		const onGuidedWidgetSelect = jest.fn();
+		initGuidedScreensBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			callbacks: { onGuidedWelcomeConfirm, onGuidedWidgetSelect },
+		} );
+
+		dispatchMessage( { type: 'angie/guided-screens/unknown' } );
+
+		expect( onGuidedWelcomeConfirm ).not.toHaveBeenCalled();
+		expect( onGuidedWidgetSelect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should not register a listener when no callbacks are provided', () => {
+		const addEventListenerSpy = jest.spyOn( window, 'addEventListener' );
+
+		initGuidedScreensBridge( { iframeOrigin: IFRAME_ORIGIN, callbacks: {} } );
+		dispatchMessage( { type: GUIDED_WELCOME_CONFIRM_MESSAGE_TYPE } );
+
+		expect( addEventListenerSpy ).not.toHaveBeenCalledWith( 'message', expect.any( Function ) );
+		addEventListenerSpy.mockRestore();
+	} );
+} );

--- a/src/load-sidebar-v2/guided-screens-bridge.ts
+++ b/src/load-sidebar-v2/guided-screens-bridge.ts
@@ -1,0 +1,50 @@
+import { addHostMessageHandler } from './host-message-router';
+import type { CallbacksConfig, GuidedWidgetSelection } from './config';
+
+export const GUIDED_WELCOME_CONFIRM_MESSAGE_TYPE = 'angie/guided-screens/welcome-confirm';
+
+export const GUIDED_WIDGET_SELECT_MESSAGE_TYPE = 'angie/guided-screens/widget-select';
+
+type GuidedScreensCallbacks = Pick<
+	CallbacksConfig,
+	'onGuidedWelcomeConfirm' | 'onGuidedWidgetSelect'
+>;
+
+type InitGuidedScreensBridgeArgs = {
+	iframeOrigin: string;
+	callbacks: GuidedScreensCallbacks;
+};
+
+let removeHandler: ( () => void ) | null = null;
+
+export const initGuidedScreensBridge = ( args: InitGuidedScreensBridgeArgs ): void => {
+	const { onGuidedWelcomeConfirm, onGuidedWidgetSelect } = args.callbacks;
+
+	if ( ! onGuidedWelcomeConfirm && ! onGuidedWidgetSelect ) {
+		return;
+	}
+
+	removeHandler?.();
+	removeHandler = addHostMessageHandler( ( event: MessageEvent ) => {
+		if ( event.origin !== args.iframeOrigin ) {
+			return;
+		}
+
+		const { type, payload } = event.data || {};
+
+		switch ( type ) {
+			case GUIDED_WELCOME_CONFIRM_MESSAGE_TYPE:
+				onGuidedWelcomeConfirm?.();
+				break;
+
+			case GUIDED_WIDGET_SELECT_MESSAGE_TYPE:
+				onGuidedWidgetSelect?.( payload as GuidedWidgetSelection );
+				break;
+		}
+	} );
+};
+
+export const resetGuidedScreensBridgeForTests = (): void => {
+	removeHandler?.();
+	removeHandler = null;
+};

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import type { FirstTimeExperienceConfig } from '../angie-mcp-sdk';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
 import type { Env } from './env';
 import { resolveConfig, shouldBoot } from './resolve-config';
@@ -95,6 +96,44 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 
 		expect( config.iframe.isRTL ).toBe( true );
 		expect( config.iframe.uiTheme ).toBe( 'dark' );
+	} );
+
+	it( 'should preserve widgetConfig.firstTimeExperience', () => {
+		const firstTimeExperience: FirstTimeExperienceConfig = {
+			screens: [
+				{
+					type: 'welcome',
+					title: 'Meet Angie',
+					subtitle: 'An active experiment.',
+					highlights: [
+						{ title: 'Angie is in beta', description: 'Features evolve quickly.' },
+						{ title: 'You stay in control' },
+					],
+					ctaLabel: 'I understand',
+				},
+				{
+					type: 'widget-picker',
+					title: 'Create your first widget',
+					subtitle: 'Start with an example or describe what you need.',
+					items: [
+						{
+							id: 'hero',
+							label: 'Hero',
+							prompt: 'Create a hero section',
+							description: 'A bold above-the-fold section.',
+							image: 'https://example.com/hero.png',
+						},
+					],
+				},
+			],
+		};
+		const config = resolveConfig(
+			{ host: { appId: 'editor-lite' }, widgetConfig: { firstTimeExperience } },
+			DEFAULT_ENV,
+		);
+
+		expect( config.widgetConfig?.firstTimeExperience ).toEqual( firstTimeExperience );
+		expect( config.widgetConfig?.closeButton ).toBe( 'collapse' );
 	} );
 
 	it( 'should skip boot when embedded in iframe by default', () => {

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -112,7 +112,7 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 					ctaLabel: 'I understand',
 				},
 				{
-					type: 'widget-picker',
+					type: 'prompts-picker',
 					title: 'Create your first widget',
 					subtitle: 'Start with an example or describe what you need.',
 					items: [

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest } from '@jest/globals';
-import type { FirstTimeExperienceConfig } from '../angie-mcp-sdk';
+import type { GuidedScreensConfig } from '../angie-mcp-sdk';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
 import type { Env } from './env';
 import { resolveConfig, shouldBoot } from './resolve-config';
@@ -98,8 +98,8 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		expect( config.iframe.uiTheme ).toBe( 'dark' );
 	} );
 
-	it( 'should preserve widgetConfig.firstTimeExperience', () => {
-		const firstTimeExperience: FirstTimeExperienceConfig = {
+	it( 'should preserve widgetConfig.guidedScreens', () => {
+		const guidedScreens: GuidedScreensConfig = {
 			screens: [
 				{
 					type: 'welcome',
@@ -128,11 +128,11 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 			],
 		};
 		const config = resolveConfig(
-			{ host: { appId: 'editor-lite' }, widgetConfig: { firstTimeExperience } },
+			{ host: { appId: 'editor-lite' }, widgetConfig: { guidedScreens } },
 			DEFAULT_ENV,
 		);
 
-		expect( config.widgetConfig?.firstTimeExperience ).toEqual( firstTimeExperience );
+		expect( config.widgetConfig?.guidedScreens ).toEqual( guidedScreens );
 		expect( config.widgetConfig?.closeButton ).toBe( 'collapse' );
 	} );
 

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -61,6 +61,8 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		callbacks: {
 			onClose: callbacks.onClose,
 			getExternalHeaders: callbacks.getExternalHeaders,
+			onGuidedWelcomeConfirm: callbacks.onGuidedWelcomeConfirm,
+			onGuidedWidgetSelect: callbacks.onGuidedWidgetSelect,
 		},
 		widgetConfig: resolveWidgetConfig( layout, options.widgetConfig ),
 	};

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -170,6 +170,29 @@ Live demo: [`demo/load-sidebar-v2-widget-config/?preset=guided`](../../demo/load
 
 `GuidedScreensConfig`, `GuidedScreen`, `GuidedHighlight`, and `GuidedWidgetItem` are exported from `@elementor/angie-sdk`.
 
+#### Events
+
+To react to what the user does inside the guided screens, pass callbacks in `loadSidebarV2({ callbacks })`. The SDK invokes them when the embedded app emits the matching event; the **callback bodies run in your code** (analytics, persisting "already seen", etc.) — the SDK only forwards the event.
+
+| Callback | Fires when | Argument |
+|----------|------------|----------|
+| `onGuidedWelcomeConfirm` | User clicks the welcome CTA (e.g. "I understand") | — |
+| `onGuidedWidgetSelect` | User picks a widget / prompt suggestion (its prompt is injected into the chat) | `{ id, label, prompt }` (`GuidedWidgetSelection`) |
+
+```typescript
+await sdk.loadSidebarV2( {
+  host: { appId: 'my-app' },
+  widgetConfig: { guidedScreens: { screens: [ /* ... */ ] } },
+  callbacks: {
+    onGuidedWelcomeConfirm: () => track( 'guided_welcome_ack' ),
+    onGuidedWidgetSelect: ( { id, prompt } ) => {
+      track( 'guided_widget_select', { id } );
+      markGuidedScreensSeen( 'my-app' ); // your persistence
+    },
+  },
+} );
+```
+
 ## Patterns from production hosts
 
 These mirror [`ai-remote-integration`](https://github.com/elementor/elementor-ai/tree/main/editor-saas-services/packages/ai-remote-integration) (Elementor my.elementor sidebar and visitor floating widget).

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -95,7 +95,7 @@ Each toggle uses `{ enabled: boolean }`.
 
 ### Guided screens
 
-An ordered set of guided intro screens (a welcome step and a widget picker) that the host supplies as content. The SDK only **forwards** this config to the embedded app — the host/app decides *when* and *how* to render them (e.g. on first open, after install, behind a "Get started" action). Rendering and any "show once" bookkeeping live in the app, not the SDK.
+An ordered set of guided intro screens (a welcome step and a prompts picker) that the host supplies as content. The SDK only **forwards** this config to the embedded app — the host/app decides *when* and *how* to render them (e.g. on first open, after install, behind a "Get started" action). Rendering and any "show once" bookkeeping live in the app, not the SDK.
 
 | Field | Type | Purpose |
 |-------|------|---------|
@@ -111,7 +111,7 @@ type GuidedScreen =
       ctaLabel: string;
     }
   | {
-      type: 'widget-picker';
+      type: 'prompts-picker';
       title: string;
       subtitle?: string;
       items: GuidedWidgetItem[];
@@ -146,7 +146,7 @@ widgetConfig: {
         ctaLabel: 'I understand',
       },
       {
-        type: 'widget-picker',
+        type: 'prompts-picker',
         title: 'Create your first widget',
         subtitle: 'Start with an example or describe what you need.',
         items: [

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -93,6 +93,83 @@ Each toggle uses `{ enabled: boolean }`.
 |-------|------|--------|
 | `closeButton` | `'collapse' \| 'close'` | `collapse` — hide panel, keep session; `close` — dismiss widget |
 
+### First-time experience
+
+A one-time guided onboarding shown inside the chat the first time a user opens Angie for a given host. The SDK only **forwards** this config to the embedded app — eligibility, rendering, and one-time persistence all live in the app.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `firstTimeExperience` | `{ screens: FteScreen[] }` | Ordered onboarding screens shown before the regular chat |
+
+```typescript
+type FteScreen =
+  | {
+      type: 'welcome';
+      title: string;
+      subtitle?: string;
+      highlights?: FteHighlight[]; // info list (e.g. beta notes), title + optional description each
+      ctaLabel: string;
+    }
+  | {
+      type: 'widget-picker';
+      title: string;
+      subtitle?: string;
+      items: FteWidgetItem[];
+    };
+
+type FteHighlight = {
+  title: string;
+  description?: string;
+};
+
+type FteWidgetItem = {
+  id: string;           // stable identifier
+  label: string;        // card title
+  prompt: string;       // injected into the chat input when picked
+  description?: string; // card body line
+  image?: string;       // preview thumbnail url
+};
+```
+
+```typescript
+widgetConfig: {
+  firstTimeExperience: {
+    screens: [
+      {
+        type: 'welcome',
+        title: 'Meet Angie',
+        subtitle: "Angie is an active experiment. We're exploring new ways to build WordPress sites.",
+        highlights: [
+          { title: 'Angie is in beta', description: 'Features evolve quickly, and your feedback helps shape what comes next.' },
+          { title: 'You stay in control', description: 'Review and edit every change before publishing to your live site.' },
+        ],
+        ctaLabel: 'I understand',
+      },
+      {
+        type: 'widget-picker',
+        title: 'Create your first widget',
+        subtitle: 'Start with an example or describe what you need.',
+        items: [
+          {
+            id: 'hero',
+            label: 'Hero section',
+            prompt: 'Create a hero section with a headline, subtext, and a CTA button.',
+            description: 'A bold above-the-fold section.',
+            image: 'https://cdn.example.com/fte/hero.png',
+          },
+        ],
+      },
+    ],
+  },
+}
+```
+
+**Requires `loadSidebarV2` + `host.appId`.** The embedded app scopes one-time completion per `appId` (it tracks completed apps server-side), so FTE only functions end-to-end through `loadSidebarV2`, which carries `host.appId`. `loadSidebar` (v1) forwards the field but has no `appId` to scope completion.
+
+Live demo: [`demo/load-sidebar-v2-widget-config/?preset=firstTime`](../../demo/load-sidebar-v2-widget-config/).
+
+`FirstTimeExperienceConfig`, `FteScreen`, `FteHighlight`, and `FteWidgetItem` are exported from `@elementor/angie-sdk`.
+
 ## Patterns from production hosts
 
 These mirror [`ai-remote-integration`](https://github.com/elementor/elementor-ai/tree/main/editor-saas-services/packages/ai-remote-integration) (Elementor my.elementor sidebar and visitor floating widget).

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -184,10 +184,11 @@ await sdk.loadSidebarV2( {
   host: { appId: 'my-app' },
   widgetConfig: { guidedScreens: { screens: [ /* ... */ ] } },
   callbacks: {
-    onGuidedWelcomeConfirm: () => track( 'guided_welcome_ack' ),
-    onGuidedWidgetSelect: ( { id, prompt } ) => {
-      track( 'guided_widget_select', { id } );
-      markGuidedScreensSeen( 'my-app' ); // your persistence
+    onGuidedWelcomeConfirm: () => {
+      // here your functionality (e.g. analytics)...
+    },
+    onGuidedWidgetSelect: ( { id, label, prompt } ) => {
+      // here your functionality (e.g. analytics, persist "already seen")...
     },
   },
 } );

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -93,36 +93,36 @@ Each toggle uses `{ enabled: boolean }`.
 |-------|------|--------|
 | `closeButton` | `'collapse' \| 'close'` | `collapse` — hide panel, keep session; `close` — dismiss widget |
 
-### First-time experience
+### Guided screens
 
-A one-time guided onboarding shown inside the chat the first time a user opens Angie for a given host. The SDK only **forwards** this config to the embedded app — eligibility, rendering, and one-time persistence all live in the app.
+An ordered set of guided intro screens (a welcome step and a widget picker) that the host supplies as content. The SDK only **forwards** this config to the embedded app — the host/app decides *when* and *how* to render them (e.g. on first open, after install, behind a "Get started" action). Rendering and any "show once" bookkeeping live in the app, not the SDK.
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `firstTimeExperience` | `{ screens: FteScreen[] }` | Ordered onboarding screens shown before the regular chat |
+| `guidedScreens` | `{ screens: GuidedScreen[] }` | Ordered guided screens the host can have the app render |
 
 ```typescript
-type FteScreen =
+type GuidedScreen =
   | {
       type: 'welcome';
       title: string;
       subtitle?: string;
-      highlights?: FteHighlight[]; // info list (e.g. beta notes), title + optional description each
+      highlights?: GuidedHighlight[]; // info list (e.g. beta notes), title + optional description each
       ctaLabel: string;
     }
   | {
       type: 'widget-picker';
       title: string;
       subtitle?: string;
-      items: FteWidgetItem[];
+      items: GuidedWidgetItem[];
     };
 
-type FteHighlight = {
+type GuidedHighlight = {
   title: string;
   description?: string;
 };
 
-type FteWidgetItem = {
+type GuidedWidgetItem = {
   id: string;           // stable identifier
   label: string;        // card title
   prompt: string;       // injected into the chat input when picked
@@ -133,7 +133,7 @@ type FteWidgetItem = {
 
 ```typescript
 widgetConfig: {
-  firstTimeExperience: {
+  guidedScreens: {
     screens: [
       {
         type: 'welcome',
@@ -155,7 +155,7 @@ widgetConfig: {
             label: 'Hero section',
             prompt: 'Create a hero section with a headline, subtext, and a CTA button.',
             description: 'A bold above-the-fold section.',
-            image: 'https://cdn.example.com/fte/hero.png',
+            image: 'https://cdn.example.com/guided/hero.png',
           },
         ],
       },
@@ -164,11 +164,11 @@ widgetConfig: {
 }
 ```
 
-**Requires `loadSidebarV2` + `host.appId`.** The embedded app scopes one-time completion per `appId` (it tracks completed apps server-side), so FTE only functions end-to-end through `loadSidebarV2`, which carries `host.appId`. `loadSidebar` (v1) forwards the field but has no `appId` to scope completion.
+**Pair with `host.appId` via `loadSidebarV2`.** Use cases like "show these once per user" need a stable identity to track against — the app uses `host.appId` for that, which only `loadSidebarV2` carries. `loadSidebar` (v1) forwards the field but has no `appId`, so the app can't scope per-host rendering.
 
-Live demo: [`demo/load-sidebar-v2-widget-config/?preset=firstTime`](../../demo/load-sidebar-v2-widget-config/).
+Live demo: [`demo/load-sidebar-v2-widget-config/?preset=guided`](../../demo/load-sidebar-v2-widget-config/).
 
-`FirstTimeExperienceConfig`, `FteScreen`, `FteHighlight`, and `FteWidgetItem` are exported from `@elementor/angie-sdk`.
+`GuidedScreensConfig`, `GuidedScreen`, `GuidedHighlight`, and `GuidedWidgetItem` are exported from `@elementor/angie-sdk`.
 
 ## Patterns from production hosts
 

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -185,10 +185,10 @@ await sdk.loadSidebarV2( {
   widgetConfig: { guidedScreens: { screens: [ /* ... */ ] } },
   callbacks: {
     onGuidedWelcomeConfirm: () => {
-      // here your functionality (e.g. analytics)...
+      // here your functionality
     },
     onGuidedWidgetSelect: ( { id, label, prompt } ) => {
-      // here your functionality (e.g. analytics, persist "already seen")...
+      // here your functionality
     },
   },
 } );


### PR DESCRIPTION
## Overview

Adds two capabilities to `WidgetConfig` / `loadSidebarV2` for presenting a host-driven, guided introduction inside the embedded Angie chat: a declarative screen configuration (`guidedScreens`) and host callbacks for user interactions within those screens.

The SDK exposes configuration and event hooks only. Screen content, the decision of when to display the flow, and the callback implementations are owned by the consuming integration — the SDK contains no integration-specific logic.

## Changes

### `guidedScreens` configuration (`WidgetConfig`)

- New optional `guidedScreens` field. The consumer provides the screen content; the SDK forwards it to the embedded application through the existing `sdk-widget-config` message. No additional transport is introduced — `resolveWidgetConfig` already spreads the full `widgetConfig`.
- Public types: `GuidedScreensConfig`, `GuidedScreen` (a discriminated union of `welcome` and `prompts-picker`), `GuidedHighlight`, and `GuidedWidgetItem`.

### Guided-screen event callbacks (`callbacks`)

- `onGuidedWelcomeConfirm(): void` — invoked when the user confirms the welcome screen.
- `onGuidedWidgetSelect(selection: GuidedWidgetSelection): void` — invoked when the user selects a prompt; `selection` is `{ id, label, prompt }`.
- A dedicated listener (`guided-screens-bridge`) subscribes — via the existing host message router — to origin-validated `postMessage` notifications from the embedded application and invokes the corresponding callback. These are one-way notifications (no `MessagePort` response channel). The listener is initialized in `bootSidebar` after the host API bridge, and the callbacks are preserved through `resolveConfig`. No listener is registered when neither callback is provided.
- Inbound message contract (embedded app → host): `angie/guided-screens/welcome-confirm` and `angie/guided-screens/widget-select`.

### Documentation and demo

- `widget-config.md`: guided-screens reference — types, configuration example, and the events table.
- `loadSidebarV2` `README.md`: the new callbacks, the updated boot flow, and the inbound message contract.
- A `guided` demo preset illustrating both the configuration and callback wiring.

## Scope and boundaries

- **SDK responsibility:** expose the `guidedScreens` configuration and the event hooks; validate message origin; route events to the provided callbacks.
- **Consumer responsibility:** supply the screen content, decide when to display the flow, and implement the callback bodies (for example, analytics or persisting completion state). When completion must be scoped per host, pair with `host.appId`, which is carried by `loadSidebarV2`.
- **End-to-end dependency:** the embedded application must emit the two events listed above for the callbacks to fire. Until then the hooks are wired but inactive.

## Testing

- `npm test` — 177 tests pass, including new coverage for the guided-screens listener (origin validation, both event types and payload, unknown-type handling, and the no-callback no-op) and `guidedScreens` configuration pass-through.
- `npm run build` — type declarations and bundle compile; the generated `.d.ts` files expose `guidedScreens`, the screen types, the callbacks, and `GuidedWidgetSelection`.
- Demo — `?preset=guided` renders the configured screens in the resolved-config inspector.

## Notes

- No version change in this PR; releases are versioned separately.
- Demo copy and assets are illustrative; production content is defined by the consuming integration.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds guided onboarding flow (welcome screen + prompts picker) to the Angie SDK. Host supplies screen config; embedded app renders on demand and emits events back to host for analytics/persistence.

## 2. What Changed (Where)

- **Type definitions** (`angie-mcp-sdk.ts`): `GuidedScreen`, `GuidedHighlight`, `GuidedWidgetItem`, `GuidedScreensConfig` types + `guidedScreens` field on `WidgetConfig`
- **Event bridge** (`guided-screens-bridge.ts`): New module listens for iframe messages, origin-checks, invokes host callbacks (`onGuidedWelcomeConfirm`, `onGuidedWidgetSelect`)
- **Config plumbing** (`config.ts`, `resolve-config.ts`, `boot-sidebar.ts`): Thread callbacks through to bridge; add `GuidedWidgetSelection` type
- **Demo + docs**: Example preset, widget config guide, README updates, full test suite

## 3. How It Works

Host passes `widgetConfig.guidedScreens` (screens array) + callbacks in `loadSidebarV2()`. Boot sequence initializes `guidedScreensBridge` which registers a single origin-checked `message` listener. Embedded app fires `angie/guided-screens/{welcome-confirm|widget-select}` events; bridge routes to matching callback. No listener registered if both callbacks undefined (optimization).

## 4. Risks

**Message routing collision**: Bridge adds to global `message` listener pool. Mitigated by hardcoded message type prefixes and origin check. **Callback cleanup**: `removeHandler` stored to support reinit; ensure cleanup runs on unmount (test coverage present). Minor: No validation of `GuidedScreen` structure—type safety relies on static typing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
