### PR TITLE
AI-8812 -  Editor does not return to same page after Angie OAuth consent

### DIFF
--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -6,6 +6,7 @@ import { ClientManager } from './client-manager';
 import { appState, DEFAULT_CONTAINER_ID } from './config';
 import { createChildLogger } from './logger';
 import { openIframe } from './iframe';
+import { handlePostConsentRedirect } from './oauth';
 import { initAngieSidebar } from './sidebar';
 import { RegistrationQueue } from './registration-queue';
 import { bootSidebar } from './load-sidebar-v2/boot-sidebar';
@@ -92,6 +93,8 @@ export class AngieMcpSdk {
   }
 
   public async loadSidebar( options?: AngieMcpSdkOptions ): Promise<void> {
+    handlePostConsentRedirect();
+
     const { widgetConfig, ...rest } = options || {};
     const config = { ...DEFAULT_OPTIONS, ...rest };
     appState.containerId = config.containerId;

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,7 +1,7 @@
 import { addLocalStorageListener } from './localStorage';
 import { appState } from './config';
 import { createChildLogger } from './logger';
-import { handlePostConsentRedirect, listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
+import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
 import { listenToSDK } from './sdk';
 import { loadWidth } from './sidebar';
 import { HostEventType, MessageEventType } from './types';
@@ -173,7 +173,6 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 
 	listenToOAuthFromIframe();
 	setupOidcLoginFlowHandler();
-	handlePostConsentRedirect();
 
 	window.addEventListener( 'message', async ( event ) => {
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,3 +28,4 @@ export * from './types';
 export * from './angie-annotations';
 export { BrowserContextTransport } from './browser-context-transport';
 export { setReferrerRedirect, getReferrerRedirect, clearReferrerRedirect, executeReferrerRedirect, type ReferrerRedirectData } from './referrer-redirect';
+export { handlePostConsentRedirect } from './oauth';

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -6,9 +6,12 @@ import { readEnv } from './env';
 import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
+import { handlePostConsentRedirect } from '../oauth';
 import { resolveConfig, shouldBoot } from './resolve-config';
 
 export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
+	handlePostConsentRedirect();
+
 	const env = readEnv();
 	const config = resolveConfig( options, env );
 

--- a/src/oauth.test.ts
+++ b/src/oauth.test.ts
@@ -13,9 +13,9 @@ const mockClearReferrerRedirect = jest.fn();
 const mockExecuteReferrerRedirect = jest.fn();
 
 jest.mock( './referrer-redirect', () => ( {
-	getReferrerRedirect: mockGetReferrerRedirect,
-	clearReferrerRedirect: mockClearReferrerRedirect,
-	executeReferrerRedirect: mockExecuteReferrerRedirect,
+	getReferrerRedirect: () => mockGetReferrerRedirect(),
+	clearReferrerRedirect: () => mockClearReferrerRedirect(),
+	executeReferrerRedirect: () => mockExecuteReferrerRedirect(),
 	buildRedirectUrl: ( url: string, prompt?: string ) => prompt ? `${ url }#angie-prompt=${ encodeURIComponent( prompt ) }` : url,
 } ) );
 
@@ -34,7 +34,11 @@ jest.mock( './logger', () => ( {
 	} ),
 } ) );
 
-import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
+import {
+	listenToOAuthFromIframe,
+	setupOidcLoginFlowHandler,
+	shouldExecutePostConsentRedirect,
+} from './oauth';
 
 describe( 'oauth', () => {
 	beforeEach( () => {
@@ -62,6 +66,32 @@ describe( 'oauth', () => {
 		const lastIdx = mockForwardOidcLoginFlowToWindow.mock.calls.length - 1;
 		return ( mockForwardOidcLoginFlowToWindow.mock.calls[ lastIdx ][ 0 ] as any ).onSuccess;
 	}
+
+	describe( 'shouldExecutePostConsentRedirect', () => {
+		it( 'returns true on angie-app with start-oauth', () => {
+			expect(
+				shouldExecutePostConsentRedirect(
+					'http://localhost/wp-admin/admin.php?page=angie-app&start-oauth=1',
+				),
+			).toBe( true );
+		} );
+
+		it( 'returns false on the Elementor editor with start-oauth', () => {
+			expect(
+				shouldExecutePostConsentRedirect(
+					'http://localhost/wp-admin/post.php?post=123&action=elementor&start-oauth=1',
+				),
+			).toBe( false );
+		} );
+
+		it( 'returns false without start-oauth', () => {
+			expect(
+				shouldExecutePostConsentRedirect(
+					'http://localhost/wp-admin/admin.php?page=angie-app',
+				),
+			).toBe( false );
+		} );
+	} );
 
 	describe( 'listenToOAuthFromIframe', () => {
 		it( 'should setup OIDC auth parent listener', () => {

--- a/src/oauth.ts
+++ b/src/oauth.ts
@@ -15,13 +15,23 @@ declare global {
 
 const logger = createChildLogger( 'oauth' );
 
-const isPostConsentFlow = (): boolean => {
-	const urlParams = new URLSearchParams( window.location.search );
-	return urlParams.has( 'start-oauth' );
+const ANGIE_APP_PAGE_SLUG = 'angie-app';
+
+export const shouldExecutePostConsentRedirect = ( pageUrl?: string ): boolean => {
+	try {
+		const params = new URL(
+			pageUrl ?? window.location.href,
+			window.location.origin,
+		).searchParams;
+
+		return params.has( 'start-oauth' ) && params.get( 'page' ) === ANGIE_APP_PAGE_SLUG;
+	} catch {
+		return false;
+	}
 };
 
 export const handlePostConsentRedirect = (): void => {
-	if ( ! isPostConsentFlow() ) {
+	if ( ! shouldExecutePostConsentRedirect() ) {
 		return;
 	}
 


### PR DESCRIPTION
## Problem
Users open Angie from the Elementor editor and complete OAuth or install/consent, but land on a generic admin page instead of the editor URL with query params (post, action=elementor, source=angie). They expected to return to the same editor session.

## Solution
Run the stored referrer redirect only on the Angie app OAuth return page (not the editor), and execute it early when the sidebar bundle loads so localStorage is not cleared before login completes.

## Video proof demo
#skip_video
SDK-only change; redirect behavior is verified after CDN publish and elementor-ai integration PR.

Jira: pending — run `acli jira auth login` to create ticket

Made with [Cursor](https://cursor.com)