### PR TITLE
[ED-24883] Add sync/async APIs to detect if Angie plugin is available and active

### DIFF
--- a/src/angie-detector.test.ts
+++ b/src/angie-detector.test.ts
@@ -189,6 +189,46 @@ describe('AngieDetector', () => {
     });
   });
 
+  describe('waitUntilReady', () => {
+    it('should resolve when Angie is detected before timeout', async () => {
+      detector = new AngieDetector();
+
+      const promise = detector.waitUntilReady( 1000 );
+
+      if ( mockPort.onmessage ) {
+        mockPort.onmessage( {
+          data: {
+            version: '1.0.0',
+            capabilities: [ 'tool1' ],
+          },
+        } );
+      }
+      jest.runAllTimers();
+
+      const result = await promise;
+
+      expect( result ).toEqual( {
+        isReady: true,
+        version: '1.0.0',
+        capabilities: [ 'tool1' ],
+      } );
+    } );
+
+    it('should resolve with timeout result within bounded wait', async () => {
+      detector = new AngieDetector();
+
+      const promise = detector.waitUntilReady( 1000 );
+
+      jest.advanceTimersByTime( 1000 );
+
+      const result = await promise;
+
+      expect( result ).toEqual( {
+        isReady: false,
+      } );
+    } );
+  } );
+
   describe('ping mechanism', () => {
     it('should send pings at correct intervals', () => {
       // Arrange

--- a/src/angie-detector.ts
+++ b/src/angie-detector.ts
@@ -82,4 +82,17 @@ export class AngieDetector {
   public async waitForReady(): Promise<AngieDetectionResult> {
     return this.readyPromise;
   }
+
+  public async waitUntilReady( timeoutMs: number ): Promise<AngieDetectionResult> {
+    if ( this.isAngieReady ) {
+      return this.readyPromise;
+    }
+
+    return Promise.race( [
+      this.readyPromise,
+      new Promise<AngieDetectionResult>( ( resolve ) => {
+        setTimeout( () => resolve( { isReady: false } ), timeoutMs );
+      } ),
+    ] );
+  }
 }

--- a/src/angie-plugin-detection.test.ts
+++ b/src/angie-plugin-detection.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it, beforeEach, jest, afterEach } from '@jest/globals';
+
+const mockPort = {
+  onmessage: null as any,
+  postMessage: jest.fn(),
+  close: jest.fn(),
+};
+
+const mockChannel = {
+  port1: mockPort,
+  port2: mockPort,
+};
+
+describe( 'angie-plugin-detection', () => {
+  let detection: typeof import( './angie-plugin-detection' );
+  let originalMessageChannel: typeof global.MessageChannel;
+
+  beforeEach( async () => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+
+    originalMessageChannel = global.MessageChannel;
+    global.MessageChannel = jest.fn( () => mockChannel ) as any;
+    mockPort.onmessage = null;
+
+    delete ( window as any ).angiePlugin;
+    ( window.postMessage as jest.Mock ).mockClear();
+
+    detection = await import( './angie-plugin-detection' );
+  } );
+
+  afterEach( () => {
+    jest.useRealTimers();
+    global.MessageChannel = originalMessageChannel;
+    delete ( window as any ).angiePlugin;
+  } );
+
+  describe( 'isAngiePluginAvailable', () => {
+    it( 'should return false when marker is absent', () => {
+      expect( detection.isAngiePluginAvailable() ).toBe( false );
+    } );
+
+    it( 'should return false when marker available is false', () => {
+      window.angiePlugin = { available: false };
+
+      expect( detection.isAngiePluginAvailable() ).toBe( false );
+    } );
+
+    it( 'should return true when marker available is true', () => {
+      window.angiePlugin = { available: true, version: '1.0.0' };
+
+      expect( detection.isAngiePluginAvailable() ).toBe( true );
+    } );
+  } );
+
+  describe( 'isAngiePluginActive', () => {
+    it( 'should return false when plugin is not available', () => {
+      expect( detection.isAngiePluginActive() ).toBe( false );
+      expect( window.postMessage ).not.toHaveBeenCalled();
+    } );
+
+    it( 'should return false when plugin is available but runtime is not ready', () => {
+      window.angiePlugin = { available: true };
+
+      expect( detection.isAngiePluginActive() ).toBe( false );
+      expect( window.postMessage ).toHaveBeenCalled();
+    } );
+
+    it( 'should return true when plugin is available and runtime responds to ping', () => {
+      window.angiePlugin = { available: true };
+      detection.isAngiePluginActive();
+
+      if ( mockPort.onmessage ) {
+        mockPort.onmessage( {
+          data: {
+            version: '1.0.0',
+            capabilities: [ 'tool1' ],
+          },
+        } );
+      }
+
+      expect( detection.isAngiePluginActive() ).toBe( true );
+    } );
+  } );
+
+  describe( 'waitForAngiePluginAvailable', () => {
+    it( 'should resolve true immediately when marker is already present', async () => {
+      window.angiePlugin = { available: true };
+
+      const promise = detection.waitForAngiePluginAvailable( 1000 );
+      await jest.runAllTimersAsync();
+
+      await expect( promise ).resolves.toBe( true );
+    } );
+
+    it( 'should resolve false when marker never appears within timeout', async () => {
+      const promise = detection.waitForAngiePluginAvailable( 1000 );
+
+      await jest.advanceTimersByTimeAsync( 1000 );
+
+      await expect( promise ).resolves.toBe( false );
+    } );
+
+    it( 'should resolve true when marker appears during polling', async () => {
+      const promise = detection.waitForAngiePluginAvailable( 1000 );
+
+      await jest.advanceTimersByTimeAsync( 100 );
+      window.angiePlugin = { available: true };
+      await jest.runAllTimersAsync();
+
+      await expect( promise ).resolves.toBe( true );
+    } );
+  } );
+
+  describe( 'waitForAngiePluginActive', () => {
+    it( 'should resolve false quickly when plugin is not available', async () => {
+      const promise = detection.waitForAngiePluginActive( 1000 );
+
+      await jest.advanceTimersByTimeAsync( 1000 );
+
+      await expect( promise ).resolves.toBe( false );
+      expect( window.postMessage ).not.toHaveBeenCalled();
+    } );
+
+    it( 'should resolve true when plugin is available and runtime responds', async () => {
+      window.angiePlugin = { available: true };
+
+      const promise = detection.waitForAngiePluginActive( 1000 );
+      await jest.advanceTimersByTimeAsync( 0 );
+
+      if ( mockPort.onmessage ) {
+        mockPort.onmessage( {
+          data: {
+            version: '1.0.0',
+            capabilities: [ 'tool1' ],
+          },
+        } );
+      }
+
+      await expect( promise ).resolves.toBe( true );
+    } );
+
+    it( 'should resolve false when plugin is available but runtime does not respond in time', async () => {
+      window.angiePlugin = { available: true };
+
+      const promise = detection.waitForAngiePluginActive( 1000 );
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync( 1000 );
+
+      await expect( promise ).resolves.toBe( false );
+    } );
+  } );
+} );

--- a/src/angie-plugin-detection.ts
+++ b/src/angie-plugin-detection.ts
@@ -1,0 +1,71 @@
+import { AngieDetector } from './angie-detector';
+
+const DEFAULT_TIMEOUT_MS = 3000;
+const POLL_INTERVAL_MS = 50;
+
+let sharedDetector: AngieDetector | null = null;
+
+const sleep = ( ms: number ) => new Promise<void>( ( resolve ) => setTimeout( resolve, ms ) );
+
+const pollUntil = async (
+  deadline: number,
+  predicate: () => boolean,
+  intervalMs = POLL_INTERVAL_MS,
+): Promise<boolean> => {
+  while ( Date.now() < deadline ) {
+    if ( predicate() ) {
+      return true;
+    }
+    await sleep( intervalMs );
+  }
+  return predicate();
+};
+
+const getSharedDetector = (): AngieDetector => {
+  if ( ! sharedDetector ) {
+    sharedDetector = new AngieDetector();
+  }
+  return sharedDetector;
+};
+
+export const isAngiePluginAvailable = (): boolean => {
+  if ( typeof window === 'undefined' ) {
+    return false;
+  }
+  return window.angiePlugin?.available === true;
+};
+
+export const isAngiePluginActive = (): boolean => {
+  if ( ! isAngiePluginAvailable() ) {
+    return false;
+  }
+  return getSharedDetector().isReady();
+};
+
+export const waitForAngiePluginAvailable = async (
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<boolean> => {
+  if ( typeof window === 'undefined' ) {
+    return false;
+  }
+  const deadline = Date.now() + timeoutMs;
+  return pollUntil( deadline, isAngiePluginAvailable );
+};
+
+export const waitForAngiePluginActive = async (
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+): Promise<boolean> => {
+  if ( typeof window === 'undefined' ) {
+    return false;
+  }
+
+  const start = Date.now();
+  const available = await waitForAngiePluginAvailable( timeoutMs );
+  if ( ! available ) {
+    return false;
+  }
+
+  const remaining = Math.max( 0, timeoutMs - ( Date.now() - start ) );
+  const result = await getSharedDetector().waitUntilReady( remaining );
+  return result.isReady;
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,12 @@ export {
 	type AngieSidebarState,
 } from './sidebar';
 export { waitForDocumentReady, toggleAngieSidebar } from './utils';
+export {
+	isAngiePluginAvailable,
+	isAngiePluginActive,
+	waitForAngiePluginAvailable,
+	waitForAngiePluginActive,
+} from './angie-plugin-detection';
 export { navigateAngieIframe } from './navigation-utils';
 export { getAngieIframe } from './angie-iframe-utils';
 export { disableNavigationPrevention } from './iframe';

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,10 +53,21 @@ export interface ServerRegistration {
   error?: string;
 }
 
+export interface AngiePluginMarker {
+  available: boolean;
+  version?: string;
+}
+
 export interface AngieDetectionResult {
   isReady: boolean;
   version?: string;
   capabilities?: string[];
+}
+
+declare global {
+  interface Window {
+    angiePlugin?: AngiePluginMarker;
+  }
 }
 
 export interface AngieMessage<T = unknown> {


### PR DESCRIPTION
## Summary
- Add standalone exports: `isAngiePluginAvailable()`, `isAngiePluginActive()`, `waitForAngiePluginAvailable()`, `waitForAngiePluginActive()`
- Read plugin presence from `window.angiePlugin` (contract from ED-24884); use lazy `AngieDetector` only when marker is present
- Add `AngieDetector.waitUntilReady(timeoutMs)` for bounded ping wait (~3s default vs ~250s `waitForReady()`)
- Keep existing `AngieMcpSdk.isAngieReady()` / `isReady()` / `waitForReady()` unchanged

## Test plan
- [x] `npm test`
- [x] `npm run build`
- [ ] After ED-24884: WP admin with Angie → `isAngiePluginAvailable()` true; without plugin → `false` within ~3s

Jira: https://elementor.atlassian.net/browse/ED-24883
Parent: https://elementor.atlassian.net/browse/ED-24509
Depends on: https://elementor.atlassian.net/browse/ED-24884 (plugin marker)

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

ED-24883: Expose sync/async plugin detection APIs to allow consumers to check if Angie plugin is available and active with timeout support. Addresses need for coordinated initialization when integrating the Angie runtime.

## 2. What Changed (Where)

- `angie-detector.ts`: Added `waitUntilReady(timeoutMs)` with Promise.race for bounded waits
- `angie-plugin-detection.ts` (new): Four exported APIs—`isAngiePluginAvailable()`, `isAngiePluginActive()`, `waitForAngiePluginAvailable()`, `waitForAngiePluginActive()`
- `types.ts`: Added `AngiePluginMarker` interface and `window.angiePlugin` global declaration
- `index.ts`: Exported detection APIs
- Tests: Full coverage for detector timeout behavior and plugin detection workflows

## 3. How It Works

Sync APIs check `window.angiePlugin.available` flag and detector readiness immediately. Async APIs poll the marker with 50ms intervals (configurable) and race detector readiness against timeout. Remaining timeout budget flows through chained waits to prevent deadline overshoot.

## 4. Risks

None identified. Defensive checks for SSR (`typeof window === 'undefined'`), sensible defaults (3s timeout), and isolated shared detector state. Tests cover both happy path and timeout scenarios.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
