### PR TITLE
[AI-8887] Add planning toggle to WidgetConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -48,6 +48,7 @@ export type WidgetConfig = {
   aiContextGuidance?: FeatureToggle;
   userProfileMenu?: FeatureToggle;
   localServers?: LocalServersConfig;
+  planning?: FeatureToggle;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -78,6 +78,7 @@ Each toggle uses `{ enabled: boolean }`.
 | `betaBanner` | Hide beta messaging in stable product surfaces |
 | `aiContextGuidance` | Show users that `host.aiContext` is available — pair with `host.aiContext` in `loadSidebarV2` |
 | `userProfileMenu` | Hide account/profile menu when the host owns auth UI |
+| `planning` | Opt out of Angie planning (`{ enabled: false }`). Omitted or `{ enabled: true }` keeps planning enabled when supported |
 
 ### Mode and MCP
 


### PR DESCRIPTION
## Overview

Adds an optional `planning` feature toggle to `WidgetConfig` so embed hosts can opt out of Angie's planning stage when initializing the sidebar.

The SDK exposes configuration only. The field is forwarded to the embedded application through the existing `sdk-widget-config` postMessage — no new transport or runtime logic in the SDK.

## Changes

### `planning` configuration (`WidgetConfig`)

- New optional `planning?: { enabled?: boolean }` field, consistent with other feature toggles (`promptLibrary`, `fileUpload`, etc.).
- `{ enabled: false }` signals the embedded app to skip planning. Omitted or `{ enabled: true }` preserves default behavior.
- Documented in `widget-config.md` under Feature toggles.
- Version bump to `1.5.0`.

## Test plan

- [ ] `npm test` passes
- [ ] `npm run build` produces dist types including `planning` on `WidgetConfig`

Made with [Cursor](https://cursor.com)