### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.4.10",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.4.10",
+      "version": "1.5.0",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",


### PR DESCRIPTION
## Problem
`package.json` was bumped to 1.5.0 but `package-lock.json` still reported 1.4.10, leaving the lockfile out of sync with the published package version.

## Solution
Updated the root and `packages[""]` version fields in `package-lock.json` to 1.5.0 to match `package.json`.


Made with [Cursor](https://cursor.com)