### PR TITLE
[AI-9135] Fix: MCP clients re-register on every SDK initialization

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -61,7 +61,7 @@ export const listenToSDK = ( appState: AppState ) => {
 						payload: {
 							success: true,
 							...payload,
-							clientId: `dynamic-client-${ payload.serverName }-${ payload.serverVersion }-${ Date.now() }`,
+							clientId: `dynamic-client-${ payload.serverName }-${ payload.serverVersion }`,
 							requestId: event.data.payload.requestId,
 						},
 						timestamp: Date.now(),


### PR DESCRIPTION
## Problem

When an MCP server connects through the Angie SDK, the host assigns it a client ID during registration. The SDK was appending a timestamp to that ID, which meant every page reload or hot reload produced a new identifier for the same server. The host treated each reload as a brand-new client and re-registered the server, leading to duplicate registrations and inconsistent client state.

## Solution

Use a stable client ID derived from the MCP server name and version instead of including a timestamp. The same server is now recognized across reloads, so existing clients are not re-registered unnecessarily.

Jira: https://elementor.atlassian.net/browse/AI-9135

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

MCP clients were re-registering on every SDK initialization because `clientId` included `Date.now()`, making it non-deterministic. Removing the timestamp ensures clients are identified consistently by server name and version, preventing duplicate registrations.

## 2. What Changed (Where)

- **src/sdk.ts**: Removed `Date.now()` from `clientId` generation—now deterministic based on server metadata only.
- **package.json**: Version bump 1.5.0 → 1.5.1.

## 3. How It Works

When SDK initializes, it sends `SDK_REQUEST_CLIENT_CREATION` with a `clientId` payload. The old code appended current timestamp, forcing unique IDs on every call. New code generates stable IDs from `serverName` and `serverVersion` alone, allowing idempotent client registration.

## 4. Risks

Low. Only affects client identity determinism. Verify existing clients with timestamp-based IDs don't conflict with new deterministic ones during transition—ideally test with mixed SDK versions.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
