### PR TITLE
Add models config to WidgetConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -32,6 +32,10 @@ export type LocalServersConfig = {
   skipLoading?: boolean;
 };
 
+export type ModelsConfig = {
+  execution: string;
+};
+
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -49,6 +53,7 @@ export type WidgetConfig = {
   userProfileMenu?: FeatureToggle;
   localServers?: LocalServersConfig;
   planning?: FeatureToggle;
+  models?: ModelsConfig;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,


### PR DESCRIPTION
## Summary
- Add optional `widgetConfig.models` with a required `execution` model id (`ModelsConfig`).
- Export `ModelsConfig` from the SDK public API.

## Test plan
- [ ] `npm test` passes
- [ ] `npm run build` produces dist types that include `models` on `WidgetConfig`
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Widget configuration needed extensibility for model execution settings. Adding a dedicated `ModelsConfig` type provides a structured interface for future model-related feature toggles.

## 2. What Changed (Where)

- `angie-mcp-sdk.ts`: New `ModelsConfig` type with `execution` string field; added `models?` optional property to `WidgetConfig`
- `index.ts`: Export `ModelsConfig` type alongside existing exports
- `package.json`: Version bump 1.5.1 → 1.5.2

## 3. How It Works

`WidgetConfig` now optionally accepts a `models` object containing an `execution` string (likely a model identifier or config key). Type is exported for external consumers to reference when constructing SDK options.

## 4. Risks

None. Purely additive with optional property—backward compatible. Verify `execution` field semantics align with runtime handler expectations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
