### PR TITLE
Fix GitHub Pages right-click demo 404 for zod-to-json-schema

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -40,9 +40,10 @@ jobs:
         run: |
           mkdir -p _site
           cp -R demo dist _site/
-          mkdir -p _site/node_modules/@modelcontextprotocol _site/node_modules/zod
+          mkdir -p _site/node_modules/@modelcontextprotocol _site/node_modules/zod _site/node_modules/zod-to-json-schema
           cp -R node_modules/@modelcontextprotocol/sdk _site/node_modules/@modelcontextprotocol/
           cp -R node_modules/zod _site/node_modules/
+          cp -R node_modules/zod-to-json-schema _site/node_modules/
           cat > _site/index.html <<'EOF'
           <!DOCTYPE html>
           <html lang="en">


### PR DESCRIPTION
## Summary
- The right-click floating demo loads a browser MCP server that imports `zod-to-json-schema`.
- GitHub Pages already shipped `@modelcontextprotocol/sdk` and `zod`, but not this package, so the live demo 404ed.
- Copy `zod-to-json-schema` into the Pages `_site/node_modules` during deploy.

## Test plan
- [ ] Merge and confirm Deploy demo to GitHub Pages succeeds
- [ ] Open https://elementor.github.io/angie-sdk/demo/load-sidebar-v2-right-click-floating/
- [ ] Confirm `zod-to-json-schema` no longer 404s in the network tab
- [ ] Right-click a textarea and confirm the floating chat opens
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
GitHub Pages demo was returning 404 errors on right-click due to missing `zod-to-json-schema` module in the deployed artifact. The fix ensures all runtime dependencies are included in the site bundle.

## 2. What Changed (Where)
`.github/workflows/deploy-demo.yml`: Updated site preparation step to create parent directories for all three node_modules paths upfront and explicitly copy the `zod-to-json-schema` package.

## 3. How It Works
Restructured mkdir command to pre-create all required directories in one call, then copy the previously omitted `zod-to-json-schema` module alongside existing SDK and zod dependencies. This ensures the demo has complete module resolution at runtime.

## 4. Risks
None—additive change that mirrors existing dependency patterns. Deployment footprint increases marginally with additional module inclusion.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
