### PR TITLE
Support multiple loadSidebarV2 instances on one page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -120,6 +120,10 @@
         <strong>loadSidebarV2 — floating chat</strong>
         <span>Minimal floating chat widget layout.</span>
       </a>
+      <a class="card" href="./load-sidebar-v2-multi-instance/">
+        <strong>loadSidebarV2 — three instances</strong>
+        <span>A sidebar and two floating chats on one page, each with its own iframe and widget config.</span>
+      </a>
       <a class="card" href="./load-sidebar-v1-demo/">
         <strong>loadSidebar (v1)</strong>
         <span>Legacy sidebar embedding API.</span>

--- a/demo/load-sidebar-v2-multi-instance/host.js
+++ b/demo/load-sidebar-v2-multi-instance/host.js
@@ -1,0 +1,66 @@
+import { AngieMcpSdk, LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from '../../dist/index.js';
+
+const sidebarSdk = new AngieMcpSdk();
+const chatSdk = new AngieMcpSdk();
+const chatSdk2 = new AngieMcpSdk();
+
+await sidebarSdk.loadSidebarV2( {
+	host: { appId: 'demo-sidebar', instanceId: 'demo-sidebar' },
+	container: {
+		layout: LAYOUT_SIDEBAR,
+		chatToggleButton: { enabled: true, selector: '#sidebar-toggle' },
+	},
+	widgetConfig: { title: 'Sidebar instance' },
+} );
+
+await chatSdk.loadSidebarV2( {
+	host: { appId: 'demo-chat', instanceId: 'demo-chat' },
+	container: { id: 'angie-chat-container', layout: LAYOUT_FLOATING_CHAT },
+	widgetConfig: { title: 'Chat A instance' },
+} );
+
+await chatSdk2.loadSidebarV2( {
+	host: { appId: 'demo-chat-2', instanceId: 'demo-chat-2' },
+	container: { id: 'angie-chat-container-2', layout: LAYOUT_FLOATING_CHAT },
+	widgetConfig: { title: 'Chat B instance' },
+} );
+
+const iframes = () => [ ...document.querySelectorAll( 'iframe[src*="angie/"]' ) ].map(
+	( frame ) => ( {
+		elementId: frame.id,
+		container: frame.closest( 'div[id]' )?.id,
+		urlInstanceId: new URL( frame.src ).searchParams.get( 'instanceId' ),
+	} ),
+);
+
+const toggles = () => [ ...document.querySelectorAll( '[id^="angie-widget-toggle"], #sidebar-toggle' ) ]
+	.map( ( button ) => ( { id: button.id, expanded: button.getAttribute( 'aria-expanded' ) } ) );
+
+const openContainers = () => [ ...document.querySelectorAll( 'div[id^="angie-"]' ) ]
+	.filter( ( element ) => element.querySelector( 'iframe' ) )
+	.map( ( element ) => ( {
+		container: element.id,
+		open: ! element.classList.contains( 'angie-widget-hidden' ),
+	} ) );
+
+const styleTags = () => [ ...document.querySelectorAll( 'style[id]' ) ].map( ( tag ) => tag.id );
+
+const storage = () => Object.fromEntries(
+	Object.keys( localStorage )
+		.filter( ( key ) => key.startsWith( 'angie' ) )
+		.map( ( key ) => [ key, localStorage.getItem( key ) ] ),
+);
+
+window.angieDemo = {
+	AngieMcpSdk,
+	LAYOUT_FLOATING_CHAT,
+	LAYOUT_SIDEBAR,
+	sidebarSdk,
+	chatSdk,
+	chatSdk2,
+	iframes,
+	toggles,
+	openContainers,
+	styleTags,
+	storage,
+};

--- a/demo/load-sidebar-v2-multi-instance/index.html
+++ b/demo/load-sidebar-v2-multi-instance/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>loadSidebarV2 — three instances</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/types.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod/v4": "../../node_modules/zod/v4/index.js"
+    }
+  }
+  </script>
+  <style>
+    body { margin: 0; padding: 1rem 1rem 8rem; font-family: system-ui, sans-serif; }
+    h2 { margin-block: 1.5rem 0.5rem; font-size: 1rem; }
+    code { background: #f2f2f2; padding: 0.1em 0.35em; border-radius: 3px; }
+    ul { line-height: 1.7; }
+
+    /* Move the second chat aside so both floating widgets stay visible.
+       `body #id.class` outranks the SDK's `#id.class` rules whatever the order. */
+    body #angie-chat-container-2.angie-widget-container {
+      inset-inline-end: 440px !important;
+    }
+    body #angie-widget-toggle-demo-chat-2 {
+      inset-inline-end: 96px !important;
+      background: #6366f1 !important;
+    }
+  </style>
+</head>
+<body>
+  <p><a href="../">← All demos</a></p>
+
+  <h2>Three Angie instances on one page</h2>
+  <p>
+    One <code>sidebar</code> and two <code>floatingChat</code> instances. Each has its own
+    container, iframe, and widget config.
+  </p>
+
+  <ul>
+    <li><strong>Sidebar</strong> — <code>demo-sidebar</code>, opens with the button below.</li>
+    <li><strong>Chat A</strong> — <code>demo-chat</code>, pink toggle at the bottom right.</li>
+    <li><strong>Chat B</strong> — <code>demo-chat-2</code>, indigo toggle beside it.</li>
+  </ul>
+
+  <p>
+    <button type="button" id="sidebar-toggle">Open the sidebar instance</button>
+  </p>
+
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <div id="angie-chat-container" aria-hidden="true"></div>
+  <div id="angie-chat-container-2" aria-hidden="true"></div>
+
+  <script type="module" src="./host.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-iframe-utils.test.ts
+++ b/src/angie-iframe-utils.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { postMessageToInstance } from './angie-iframe-utils';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const createFakeIframe = ( path: string ) => {
+	const iframe = document.createElement( 'iframe' );
+	const postMessage = jest.fn();
+
+	iframe.setAttribute( 'src', `${ ANGIE_ORIGIN }${ path }` );
+	Object.defineProperty( iframe, 'contentWindow', { value: { postMessage }, writable: true } );
+	document.body.appendChild( iframe );
+
+	return { iframe, postMessage };
+};
+
+const SIDEBAR_ARGS = { containerId: 'container-a', instanceId: 'aaaaaa', layout: 'sidebar' };
+const CHAT_ARGS = { containerId: 'container-b', instanceId: 'bbbbbb', layout: 'floatingChat' };
+
+describe( 'angie-iframe-utils', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'should post only to the iframe owned by the given instance', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		const firstIframe = createFakeIframe( '/angie/wp-admin' );
+		const secondIframe = createFakeIframe( '/angie/embedded' );
+		first.iframe = firstIframe.iframe;
+		second.iframe = secondIframe.iframe;
+
+		const sent = postMessageToInstance( second, { type: 'sdk-widget-config' } );
+
+		expect( sent ).toBe( true );
+		expect( secondIframe.postMessage ).toHaveBeenCalledWith(
+			{ type: 'sdk-widget-config' },
+			ANGIE_ORIGIN,
+		);
+		expect( firstIframe.postMessage ).not.toHaveBeenCalled();
+	} );
+
+} );

--- a/src/angie-iframe-utils.ts
+++ b/src/angie-iframe-utils.ts
@@ -1,15 +1,81 @@
+import { appState, type AppState } from './config';
+import { getFirstInstance } from './instance-registry';
 import { createChildLogger } from './logger';
 
 const iframeUtilsLogger = createChildLogger( 'iframe-utils' );
 
+/** Cached DOM lookup when no registered instance owns an iframe. */
 let angieIframeRef: HTMLIFrameElement | null = null;
 
-export const setAngieIframeRef = ( iframe: HTMLIFrameElement | null ): void => {
-	angieIframeRef = iframe;
+const isInDocument = ( iframe: HTMLIFrameElement | null ): iframe is HTMLIFrameElement =>
+	!! iframe && document.contains( iframe );
+
+const originOf = ( iframe: HTMLIFrameElement ): string | null => {
+	try {
+		return new URL( iframe.src ).origin;
+	} catch ( error ) {
+		iframeUtilsLogger.error( 'Error parsing iframe URL:', error );
+		return null;
+	}
 };
 
+const sendToIframe = (
+	iframe: HTMLIFrameElement | null,
+	origin: string | null,
+	message: Record<string, unknown>
+): boolean => {
+	if ( ! iframe?.contentWindow ) {
+		return false;
+	}
+
+	if ( ! origin ) {
+		iframeUtilsLogger.error( 'Could not determine target origin for Angie iframe' );
+		return false;
+	}
+
+	iframe.contentWindow.postMessage( message, origin );
+	return true;
+};
+
+const getInstanceIframe = ( instance: AppState ): HTMLIFrameElement | null =>
+	isInDocument( instance.iframe ) ? instance.iframe : null;
+
+const getInstanceIframeOrigin = ( instance: AppState ): string | null => {
+	if ( instance.iframeUrlObject ) {
+		return instance.iframeUrlObject.origin;
+	}
+
+	const iframe = getInstanceIframe( instance );
+	return iframe ? originOf( iframe ) : null;
+};
+
+/**
+ * Sends a message to one instance's iframe only. Every internal caller uses this, so two
+ * instances on the same page can never receive each other's messages.
+ */
+export const postMessageToInstance = (
+	instance: AppState,
+	message: Record<string, unknown>,
+	targetOrigin?: string
+): boolean => sendToIframe(
+	getInstanceIframe( instance ),
+	targetOrigin || getInstanceIframeOrigin( instance ),
+	message
+);
+
+/**
+ * Kept for callers outside the SDK, which have no instance to name. Resolves to instance
+ * #1. Nothing inside the SDK uses it, so an ambiguous answer cannot corrupt routing.
+ */
 export const getAngieIframe = (): HTMLIFrameElement | null => {
-	if ( angieIframeRef && document.contains( angieIframeRef ) ) {
+	const instance = getFirstInstance() ?? appState;
+	const instanceIframe = getInstanceIframe( instance );
+
+	if ( instanceIframe ) {
+		return instanceIframe;
+	}
+
+	if ( isInDocument( angieIframeRef ) ) {
 		return angieIframeRef;
 	}
 
@@ -23,16 +89,7 @@ export const angieIframeExists = (): boolean => {
 
 export const getAngieIframeOrigin = (): string | null => {
 	const iframe = getAngieIframe();
-	if ( ! iframe ) {
-		return null;
-	}
-
-	try {
-		return new URL( iframe.src ).origin;
-	} catch ( error ) {
-		iframeUtilsLogger.error( 'Error parsing iframe URL:', error );
-		return null;
-	}
+	return iframe ? originOf( iframe ) : null;
 };
 
 export const postMessageToAngieIframe = (
@@ -40,17 +97,5 @@ export const postMessageToAngieIframe = (
 	targetOrigin?: string
 ): boolean => {
 	iframeUtilsLogger.log( 'postMessageToAngieIframe', message, targetOrigin );
-	const iframe = getAngieIframe();
-	if ( ! iframe?.contentWindow ) {
-		return false;
-	}
-
-	const origin = targetOrigin || getAngieIframeOrigin();
-	if ( ! origin ) {
-		iframeUtilsLogger.error( 'Could not determine target origin for Angie iframe' );
-		return false;
-	}
-
-	iframe.contentWindow.postMessage( message, origin );
-	return true;
+	return sendToIframe( getAngieIframe(), targetOrigin || getAngieIframeOrigin(), message );
 };

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -9,9 +9,6 @@ jest.mock('./angie-detector');
 jest.mock('./registration-queue');
 jest.mock('./client-manager');
 jest.mock('./browser-context-transport');
-jest.mock('./angie-iframe-utils', () => ({
-  postMessageToAngieIframe: jest.fn(),
-}));
 jest.mock('./sidebar', () => ({
   initAngieSidebar: jest.fn(),
 }));
@@ -34,7 +31,6 @@ describe('AngieMcpSdk', () => {
   let mockBrowserContextTransport: any;
   let mockInitAngieSidebar: any;
   let mockOpenIframe: any;
-  let mockPostMessageToAngieIframe: any;
   let addEventListenerSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
@@ -67,7 +63,6 @@ describe('AngieMcpSdk', () => {
     mockInitAngieSidebar = require('./sidebar').initAngieSidebar as jest.MockedFunction<any>;
     mockOpenIframe = require('./iframe').openIframe as jest.MockedFunction<any>;
     mockOpenIframe.mockResolvedValue(undefined);
-    mockPostMessageToAngieIframe = require('./angie-iframe-utils').postMessageToAngieIframe as jest.MockedFunction<any>;
 
     // Mock the constructors
     (require('./angie-detector') as any).AngieDetector.mockImplementation(() => mockAngieDetector);
@@ -158,8 +153,6 @@ describe('AngieMcpSdk', () => {
         'Server instance is required'
       );
     });
-
-
 
     it('should handle registration errors', async () => {
       // Arrange
@@ -303,8 +296,6 @@ describe('AngieMcpSdk', () => {
       expect(mockServer.connect).toHaveBeenCalled();
     });
 
-
-
     it('should handle server init request with non-existent server', () => {
       // Arrange
       mockRegistrationQueue.getAll.mockReturnValue([]);
@@ -326,8 +317,6 @@ describe('AngieMcpSdk', () => {
       // Assert
       expect(mockBrowserContextTransport).not.toHaveBeenCalled();
     });
-
-
 
     it('should handle server init request with server connection error', () => {
       // Arrange
@@ -505,51 +494,31 @@ describe('AngieMcpSdk', () => {
     });
 
     it('should send widget config via postMessage when provided', async () => {
-      // Arrange
-      const widgetConfig = {
-        title: 'Custom Title',
-        subtitle: 'Custom Subtitle',
-        promptLibrary: { enabled: false },
-        fileUpload: { enabled: false },
-        feedback: { enabled: false },
-        featuredMcpServer: 'wp-search',
-        suggestions: { items: [{ label: 'Search', value: 'search for' }] },
-      };
+      const iframePostMessage = jest.fn();
+      mockOpenIframe.mockResolvedValue({
+        iframe: { contentWindow: { postMessage: iframePostMessage } },
+        iframeOrigin: 'https://angie.elementor.com',
+      });
+      const widgetConfig = { title: 'Custom Title' };
 
-      // Act
       await sdk.loadSidebar({ widgetConfig });
 
-      // Assert
-      expect(mockPostMessageToAngieIframe).toHaveBeenCalledWith({
-        type: 'sdk-widget-config',
-        payload: widgetConfig,
-      });
-    });
-
-    it('should send widget config with modeSwitcher and closeButton via postMessage', async () => {
-      // Arrange
-      const widgetConfig = {
-        title: 'Custom Title',
-        modeSwitcher: { enabled: true, default: 'plan' as const },
-        closeButton: 'collapse' as const,
-      };
-
-      // Act
-      await sdk.loadSidebar({ widgetConfig });
-
-      // Assert
-      expect(mockPostMessageToAngieIframe).toHaveBeenCalledWith({
-        type: 'sdk-widget-config',
-        payload: widgetConfig,
-      });
+      expect(iframePostMessage).toHaveBeenCalledWith(
+        { type: 'sdk-widget-config', payload: widgetConfig },
+        'https://angie.elementor.com',
+      );
     });
 
     it('should not send widget config when not provided', async () => {
-      // Act
+      const iframePostMessage = jest.fn();
+      mockOpenIframe.mockResolvedValue({
+        iframe: { contentWindow: { postMessage: iframePostMessage } },
+        iframeOrigin: 'https://angie.elementor.com',
+      });
+
       await sdk.loadSidebar();
 
-      // Assert
-      expect(mockPostMessageToAngieIframe).not.toHaveBeenCalled();
+      expect(iframePostMessage).not.toHaveBeenCalled();
     });
   });
 
@@ -565,7 +534,30 @@ describe('AngieMcpSdk', () => {
       await sdk.loadSidebarV2( options );
 
       expect( mockBootSidebar ).toHaveBeenCalledTimes( 1 );
-      expect( mockBootSidebar ).toHaveBeenCalledWith( options );
+      expect( mockBootSidebar ).toHaveBeenCalledWith( options, expect.any( String ) );
+    });
+
+    it('should adopt host.instanceId so routing matches the booted instance', async () => {
+      const mockBootSidebar = require('./load-sidebar-v2/boot-sidebar').bootSidebar as jest.MockedFunction<any>;
+      const options = {
+        host: {
+          appId: 'editor-lite',
+          instanceId: 'stable-id',
+        },
+      };
+      mockAngieDetector.isReady.mockReturnValue(true);
+
+      await sdk.loadSidebarV2( options );
+
+      expect( mockBootSidebar ).toHaveBeenCalledWith( options, 'stable-id' );
+
+      const promise = sdk.triggerAngie( { prompt: 'hi', context: {}, options: { timeout: 50 } } );
+      const call = ( window.postMessage as jest.MockedFunction<any> ).mock.calls.find(
+        ( item: any[] ) => item[ 0 ]?.type === 'sdk-trigger-angie',
+      );
+
+      expect( call?.[ 0 ].payload.instanceId ).toBe( 'stable-id' );
+      await expect( promise ).rejects.toThrow( 'timed out' );
     });
   });
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -1,5 +1,4 @@
 import type { Logger } from '@elementor/angie-logger';
-import { postMessageToAngieIframe } from './angie-iframe-utils';
 import { AngieDetector } from './angie-detector';
 import { BrowserContextTransport } from './browser-context-transport';
 import { ClientManager } from './client-manager';
@@ -9,6 +8,7 @@ import { openIframe } from './iframe';
 import { handlePostConsentRedirect } from './oauth';
 import { initAngieSidebar } from './sidebar';
 import { RegistrationQueue } from './registration-queue';
+import { generateInstanceId } from './utils';
 import { bootSidebar } from './load-sidebar-v2/boot-sidebar';
 import type { LoadSidebarV2Options } from './load-sidebar-v2/config';
 import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerConfig, AngieServerConfig, AngieServerType, MessageEventType, ServerRegistration, AngieTriggerRequest, AngieTriggerResponse } from './types';
@@ -80,7 +80,7 @@ export class AngieMcpSdk {
   private sidebarV2BootPromise: Promise<void> | null = null;
 
   constructor() {
-    this.instanceId = Math.random().toString(36).substring(2, 8);
+    this.instanceId = generateInstanceId();
     this.logger = createChildLogger({ instanceId: this.instanceId });
     this.logger.log('Constructor called - initializing SDK');
     this.angieDetector = new AngieDetector();
@@ -99,18 +99,26 @@ export class AngieMcpSdk {
     const { widgetConfig, ...rest } = options || {};
     const config = { ...DEFAULT_OPTIONS, ...rest };
     appState.containerId = config.containerId;
+    appState.instanceId = this.instanceId;
     initAngieSidebar( { skipDefaultCss: config.skipDefaultCss } );
-    await openIframe( config );
+    const opened = await openIframe( config );
 
-    if ( widgetConfig ) {
-      postMessageToAngieIframe( { type: 'sdk-widget-config', payload: widgetConfig } );
+    if ( opened && widgetConfig ) {
+      opened.iframe.contentWindow?.postMessage(
+        { type: 'sdk-widget-config', payload: widgetConfig },
+        opened.iframeOrigin,
+      );
     }
 
     this.setupPromptHashDetection();
   }
 
   public loadSidebarV2( options: LoadSidebarV2Options ): Promise<void> {
-    this.sidebarV2BootPromise = bootSidebar( options );
+    if ( options.host.instanceId ) {
+      this.instanceId = options.host.instanceId;
+    }
+
+    this.sidebarV2BootPromise = bootSidebar( options, this.instanceId );
     return this.sidebarV2BootPromise;
   }
 
@@ -311,6 +319,7 @@ export class AngieMcpSdk {
         type: MessageEventType.SDK_TRIGGER_ANGIE,
         payload: {
           requestId,
+          instanceId: this.instanceId,
           prompt: request.prompt,
           options: request.options,
           context: {

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,25 @@
 export const DEFAULT_CONTAINER_ID = 'angie-sidebar-container';
 
+export const DEFAULT_IFRAME_ELEMENT_ID = 'angie-iframe';
+
 export type AppState = {
 	open: boolean;
 	iframe: HTMLIFrameElement | null;
 	iframeUrlObject: URL | null;
 	containerId: string;
+	instanceId: string;
+	layout: string;
+	iframeElementId: string;
 };
 
-export const appState: AppState = {
+export const createDefaultAppState = (): AppState => ( {
 	open: false,
-	iframe: null as HTMLIFrameElement | null,
-	iframeUrlObject: null as URL | null,
+	iframe: null,
+	iframeUrlObject: null,
 	containerId: DEFAULT_CONTAINER_ID,
-};
+	instanceId: '',
+	layout: '',
+	iframeElementId: DEFAULT_IFRAME_ELEMENT_ID,
+} );
+
+export const appState: AppState = createDefaultAppState();

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,14 +1,13 @@
 import { addLocalStorageListener } from './localStorage';
-import { appState } from './config';
+import { appState, type AppState } from './config';
 import { createChildLogger } from './logger';
 import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
 import { listenToSDK } from './sdk';
 import { loadWidth } from './sidebar';
 import { HostEventType, MessageEventType } from './types';
-import { isMobile, isSafeUrl, sendSuccessMessage, toggleAngieSidebar } from './utils';
+import { isFromIframe, isMobile, isSafeUrl, sendSuccessMessage, toggleAngieSidebar } from './utils';
 import { ANGIE_SDK_VERSION } from './version';
 import { openSaaSPage } from './openSaaSPage';
-import { setAngieIframeRef } from './angie-iframe-utils';
 import type { HostEmbeddedConfigPayload } from './load-sidebar-v2/config';
 
 type OpenIframeProps = {
@@ -56,14 +55,24 @@ export const disableNavigationPrevention = async (): Promise<void> => {
 	}
 };
 
-export const openIframe = async ( props: OpenIframeProps ) => {
+export type OpenIframeResult = {
+	iframe: HTMLIFrameElement;
+	iframeOrigin: string;
+};
+
+export const openIframe = async (
+	props: OpenIframeProps,
+	instance: AppState = appState
+): Promise<OpenIframeResult | undefined> => {
 	if ( isMobile() ) {
 		iframeLogger.log( 'Mobile detected, skipping iframe injection' );
 		return;
 	}
 
+	const containerId = instance.containerId;
+
 	// Check if sidebar container exists
-	let sidebarContainer = document.getElementById( appState.containerId );
+	let sidebarContainer = document.getElementById( containerId );
 
 	if ( ! sidebarContainer ) {
 		// Use MutationObserver for more efficient DOM watching
@@ -74,7 +83,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 			// First try with shorter polling interval for immediate cases
 			let attempts = 0;
 			const quickCheck = setInterval( () => {
-				sidebarContainer = document.getElementById( appState.containerId );
+				sidebarContainer = document.getElementById( containerId );
 				attempts++;
 				if ( sidebarContainer || attempts > 20 ) { // Check for 2 seconds max with 100ms intervals
 					clearInterval( quickCheck );
@@ -95,7 +104,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 				}
 
 				const observer = new MutationObserver( () => {
-					sidebarContainer = document.getElementById( appState.containerId );
+					sidebarContainer = document.getElementById( containerId );
 					if ( sidebarContainer ) {
 						observer.disconnect();
 						resolve();
@@ -161,15 +170,16 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 		uiTheme: props.uiTheme,
 		isRTL: props.isRTL,
 		sdkVersion: ANGIE_SDK_VERSION,
+		iframeElementId: instance.iframeElementId,
+		instanceId: instance.instanceId,
 	} );
 
-	appState.iframe = iframe;
-	appState.iframeUrlObject = iframeUrlObject;
-	setAngieIframeRef( iframe );
+	instance.iframe = iframe;
+	instance.iframeUrlObject = iframeUrlObject;
 
-	addLocalStorageListener();
+	addLocalStorageListener( instance );
 
-	listenToSDK( appState );
+	listenToSDK( instance );
 
 	listenToOAuthFromIframe();
 	setupOidcLoginFlowHandler();
@@ -182,16 +192,20 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 			return;
 		}
 
-		if ( event?.data?.type === MessageEventType.ANGIE_CHAT_TOGGLE ) {
-			appState.open = event.data.open;
+		if ( ! isFromIframe( event, iframe ) ) {
+			return;
+		}
 
-			if ( appState.iframe ) {
-				toggleAngieSidebar( appState.iframe, appState.open );
+		if ( event?.data?.type === MessageEventType.ANGIE_CHAT_TOGGLE ) {
+			instance.open = event.data.open;
+
+			if ( instance.iframe ) {
+				toggleAngieSidebar( instance.iframe, instance.open, instance.containerId );
 			}
 		} else if ( event?.data?.type === MessageEventType.ANGIE_STUDIO_TOGGLE ) {
 			const isStudioOpen = event.data.isStudioOpen;
 
-			if ( ! appState.iframe ) {
+			if ( ! instance.iframe ) {
 				return;
 			}
 
@@ -241,4 +255,9 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 		}
 
 	} );
+
+	return {
+		iframe,
+		iframeOrigin: iframeUrlObject.origin,
+	};
 };

--- a/src/instance-registry.test.ts
+++ b/src/instance-registry.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { appState } from './config';
+import {
+	createAngieInstance,
+	resetInstancesForTests,
+	shouldInstanceHandle,
+} from './instance-registry';
+
+const SIDEBAR_ARGS = { containerId: 'container-a', instanceId: 'aaaaaa', layout: 'sidebar' as const };
+const CHAT_ARGS = { containerId: 'container-b', instanceId: 'bbbbbb', layout: 'floatingChat' as const };
+
+describe( 'instance-registry', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+	} );
+
+	it( 'should reuse the shared appState object for the first instance', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+
+		expect( instance ).toBe( appState );
+	} );
+
+} );
+
+describe( 'instance-registry host-to-host routing', () => {
+	const fakeIframe = () => ( { contentWindow: {} } as HTMLIFrameElement );
+
+	beforeEach( () => {
+		resetInstancesForTests();
+	} );
+
+	it( 'should skip a message addressed to another instance that owns an iframe', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+		second.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( first, 'bbbbbb' ) ).toBe( false );
+	} );
+
+	it( 'should let the first iframe owner answer for an instance that owns no iframe', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( first, 'bbbbbb' ) ).toBe( true );
+		expect( shouldInstanceHandle( first, 'unknown-editor-id' ) ).toBe( true );
+	} );
+
+	it( 'should not let a later iframe owner answer for an unknown instance', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+		second.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( second, 'unknown-editor-id' ) ).toBe( false );
+	} );
+} );

--- a/src/instance-registry.ts
+++ b/src/instance-registry.ts
@@ -1,0 +1,71 @@
+import {
+	appState,
+	createDefaultAppState,
+	DEFAULT_IFRAME_ELEMENT_ID,
+	type AppState,
+} from './config';
+import { LAYOUT_SIDEBAR } from './load-sidebar-v2/config';
+
+export type CreateAngieInstanceArgs = Pick<AppState, 'containerId' | 'instanceId' | 'layout'>;
+
+const instances: AppState[] = [];
+
+export const createAngieInstance = ( args: CreateAngieInstanceArgs ): AppState => {
+	// Instance #1 is the shared `appState` object itself, so every existing reader of
+	// `appState` follows it and single-instance behaviour is unchanged. It keeps the
+	// legacy iframe id too, so host CSS targeting `#angie-iframe` still matches.
+	const reuseSharedAppState = instances.length === 0;
+
+	const state: AppState = {
+		...createDefaultAppState(),
+		...args,
+		iframeElementId: reuseSharedAppState
+			? DEFAULT_IFRAME_ELEMENT_ID
+			: `${ DEFAULT_IFRAME_ELEMENT_ID }-${ args.instanceId }`,
+	};
+
+	const instance = reuseSharedAppState ? Object.assign( appState, state ) : state;
+
+	instances.push( instance );
+
+	return instance;
+};
+
+export const getFirstInstance = (): AppState | null => instances[ 0 ] ?? null;
+
+const getFirstIframeInstance = (): AppState | null =>
+	instances.find( ( instance ) => instance.iframe !== null ) ?? null;
+
+export const getInstanceById = ( instanceId: string ): AppState | null =>
+	instances.find( ( instance ) => instance.instanceId === instanceId ) ?? null;
+
+export const getInstanceByContainerId = ( containerId: string ): AppState | null =>
+	instances.find( ( instance ) => instance.containerId === containerId ) ?? null;
+
+export const hasSidebarLayoutInstance = (): boolean =>
+	instances.some( ( instance ) => instance.layout === LAYOUT_SIDEBAR );
+
+/**
+ * Decides whether `instance` should act on a host-to-host message.
+ *
+ * The Elementor editor loads its own SDK bundle. It registers MCP servers but never
+ * opens an iframe, and relies on the Angie plugin's listener to pass its messages on.
+ * So a message addressed elsewhere is only ignored when that instance owns an iframe of
+ * its own. Otherwise the first iframe owner answers for it.
+ */
+export const shouldInstanceHandle = ( instance: AppState, instanceId?: string ): boolean => {
+	if ( ! instanceId || instanceId === instance.instanceId ) {
+		return true;
+	}
+
+	if ( getInstanceById( instanceId )?.iframe ) {
+		return false;
+	}
+
+	return getFirstIframeInstance() === instance;
+};
+
+export const resetInstancesForTests = (): void => {
+	instances.length = 0;
+	Object.assign( appState, createDefaultAppState() );
+};

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -53,7 +53,7 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 
 | Section | Purpose |
 |---------|---------|
-| `host` | **Required.** `appId`, optional `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
+| `host` | **Required.** `appId`, optional `instanceId` (see [multiple instances](#multiple-instances-on-one-page)), `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
 | `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
 | `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
@@ -76,6 +76,51 @@ Keep it focused on what helps the agent answer screen-level questions:
 Example: [`demo/load-sidebar-v2-full-config/host.js`](../../demo/load-sidebar-v2-full-config/host.js) reads `#demo-host-app` into `whatUserSees` and lists allowed actions in `whatUserCanDo`.
 
 Enable `widgetConfig.aiContextGuidance: { enabled: true }` so users see that host context is available. Full reference: [widget-config.md](./widget-config.md).
+
+## Multiple instances on one page
+
+You can run more than one Angie instance on the same page. Each one keeps its own
+iframe, its own config and its own messages.
+
+Two rules:
+
+1. **Give every extra instance its own `container.id`.** The default is
+   `angie-sidebar-container` for every layout, so two instances that do not set it would
+   share one `<div>`. Booting the second one throws an error that names the id.
+2. **Only one instance may use the `sidebar` layout.** That layout paints through
+   page-wide CSS (`body.angie-sidebar-active` and `#angie-sidebar-container`), so a
+   second sidebar would have no styling and would share the first one's open state.
+   Booting a second sidebar throws. Extra instances must use `floatingChat`.
+
+```js
+const sidebarSdk = new AngieMcpSdk();
+await sidebarSdk.loadSidebarV2( {
+	host: { appId: 'my-app', instanceId: 'my-app-sidebar' },
+	container: { layout: LAYOUT_SIDEBAR },
+} );
+
+const chatSdk = new AngieMcpSdk();
+await chatSdk.loadSidebarV2( {
+	host: { appId: 'my-app-help', instanceId: 'my-app-help' },
+	container: { id: 'angie-help-container', layout: LAYOUT_FLOATING_CHAT },
+} );
+```
+
+Working example: [`demo/load-sidebar-v2-multi-instance`](../../demo/load-sidebar-v2-multi-instance/).
+
+### host.instanceId
+
+Optional. Names the instance. When you leave it out, the SDK generates a new id on every
+page load.
+
+The id names the instance's iframe (`angie-iframe-<instanceId>`), appears as the
+`instanceId` query parameter in the iframe URL, and routes MCP server registrations back
+to the right instance. Pass a stable id when you want those to stay the same across page
+loads, for example to target the iframe from your own CSS or end-to-end tests.
+
+Legacy globals (`window.toggleAngieSidebar`, `getAngieIframe()`, and similar helpers)
+still target the first booted instance. Hold the `AngieMcpSdk` object if you need a
+specific instance.
 
 ### Custom CSS (toggle + sidebar panel)
 

--- a/src/load-sidebar-v2/boot-sidebar.integration.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.integration.test.ts
@@ -1,0 +1,125 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { bootSidebar } from './boot-sidebar';
+import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
+import { CHAT_WIDGET_HIDDEN_CLASS } from './chat-toggle/constants';
+import { resetHostApiBridgeForTests } from './host-api-bridge';
+import { resetHostMessageRouterForTests } from './host-message-router';
+import { resetChatShellForTests } from './chat-toggle/chat-shell';
+import { resetInstancesForTests } from '../instance-registry';
+
+jest.mock( '../openSaaSPage', () => ( { openSaaSPage: jest.fn() } ) );
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+type FakeIframe = {
+	iframe: HTMLIFrameElement;
+	postMessage: jest.Mock;
+	contentWindow: Window;
+};
+
+const openedIframes: FakeIframe[] = [];
+
+const iframeOf = ( containerId: string ): FakeIframe => {
+	const container = document.getElementById( containerId )!;
+	const found = openedIframes.find( ( item ) => container.contains( item.iframe ) );
+
+	if ( ! found ) {
+		throw new Error( `no iframe was mounted into #${ containerId }` );
+	}
+
+	return found;
+};
+
+const sentPayload = ( target: FakeIframe, type: string ): unknown =>
+	( target.postMessage.mock.calls.find(
+		( call: unknown[] ) => ( call[ 0 ] as { type: string } ).type === type,
+	)?.[ 0 ] as { payload: unknown } | undefined )?.payload;
+
+const sentTypes = ( target: FakeIframe ): string[] =>
+	target.postMessage.mock.calls.map( ( call: unknown[] ) => ( call[ 0 ] as { type: string } ).type );
+
+const emitFromIframe = ( target: FakeIframe, data: unknown ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), {
+		origin: ANGIE_ORIGIN,
+		source: target.contentWindow,
+		data,
+	} ) );
+};
+
+describe( 'load-sidebar-v2/boot-sidebar integration', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query: unknown ) => ( {
+				matches: false,
+				media: String( query ),
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} ) ),
+		} );
+		Object.defineProperty( window, 'screen', { writable: true, value: { availWidth: 1280 } } );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+		document.body.className = '';
+		openedIframes.length = 0;
+		resetInstancesForTests();
+		resetHostApiBridgeForTests();
+		resetHostMessageRouterForTests();
+		resetChatShellForTests();
+
+		( require( '../openSaaSPage' ).openSaaSPage as jest.Mock ).mockImplementation(
+			async ( props: any ) => {
+				const iframe = document.createElement( 'iframe' );
+				const postMessage = jest.fn();
+				const contentWindow = { postMessage } as unknown as Window;
+
+				Object.defineProperty( iframe, 'contentWindow', { value: contentWindow } );
+				iframe.id = props.iframeElementId;
+				iframe.setAttribute( 'src', `${ props.origin }/${ props.path }` );
+				props.insertCallback?.( iframe );
+				openedIframes.push( { iframe, postMessage, contentWindow } );
+
+				return { iframe, iframeUrlObject: new URL( ANGIE_ORIGIN ) };
+			},
+		);
+	} );
+
+	it( 'should run a sidebar and a floating chat side by side', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR },
+			host: { appId: 'app-sidebar', instanceId: 'sidebar1' },
+			widgetConfig: { title: 'Sidebar' },
+		} );
+		await bootSidebar( {
+			container: {
+				id: 'chat-b',
+				layout: LAYOUT_FLOATING_CHAT,
+				chatToggleButton: { enabled: true, selector: '#toggle-chat-b' },
+			},
+			host: { appId: 'app-b', instanceId: 'bbbbbb' },
+			widgetConfig: { title: 'Widget B' },
+		} );
+
+		const sidebarIframe = iframeOf( 'angie-sidebar-container' );
+		const chatIframe = iframeOf( 'chat-b' );
+
+		expect( sentPayload( sidebarIframe, 'sdk-widget-config' ) )
+			.toEqual( expect.objectContaining( { title: 'Sidebar' } ) );
+		expect( sentPayload( chatIframe, 'sdk-widget-config' ) )
+			.toEqual( expect.objectContaining( { title: 'Widget B' } ) );
+
+		const sidebarWasActive = document.body.classList.contains( 'angie-sidebar-active' );
+		const sidebarMessagesBefore = sentTypes( sidebarIframe ).length;
+
+		emitFromIframe( chatIframe, { type: 'toggleAngieSidebar', payload: { force: true } } );
+
+		expect( document.getElementById( 'chat-b' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( false );
+		expect( document.body.classList.contains( 'angie-sidebar-active' ) ).toBe( sidebarWasActive );
+		expect( sentTypes( sidebarIframe ) ).toHaveLength( sidebarMessagesBefore );
+	} );
+} );

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
 import { bootSidebar } from './boot-sidebar';
+import { getFirstInstance, resetInstancesForTests } from '../instance-registry';
 
 jest.mock( '../sidebar', () => ( {
 	ANGIE_SIDEBAR_STATE_CLOSED: 'closed',
@@ -13,7 +14,7 @@ jest.mock( '../sidebar', () => ( {
 } ) );
 
 jest.mock( './open-embedded-iframe', () => ( {
-	openEmbeddedIframe: jest.fn( () => Promise.resolve() ),
+	openEmbeddedIframe: jest.fn( () => Promise.resolve( true ) ),
 } ) );
 
 jest.mock( './embedded-handshake', () => ( {
@@ -52,6 +53,8 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+		resetInstancesForTests();
 		mockApplyState = require( '../sidebar' ).applyState as jest.Mock;
 		mockInitAngieSidebar = require( '../sidebar' ).initAngieSidebar as jest.Mock;
 		mockLoadState = require( '../sidebar' ).loadState as jest.Mock;
@@ -77,6 +80,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		);
 		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
 			expect.objectContaining( { appId: 'editor-lite', configVersion: 2 } ),
+			expect.objectContaining( { instanceId: expect.any( String ) } ),
 		);
 		expect( mockLoadState ).toHaveBeenCalledWith( 'open' );
 		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
@@ -112,5 +116,55 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockApplyState ).toHaveBeenCalledWith( 'closed' );
 		expect( mockLoadState ).toHaveBeenCalledWith( 'closed' );
 		expect( mockInitAngieSidebar ).toHaveBeenCalled();
+	} );
+
+	it( 'should refuse a second sidebar layout instance', async () => {
+		await bootSidebar( { container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } } );
+
+		await expect( bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR, id: 'sidebar-b' },
+			host: { appId: 'app-b' },
+		} ) ).rejects.toThrow( /sidebar/i );
+	} );
+
+	it( 'should refuse a container id that another instance already uses', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-a' },
+		} );
+
+		await expect( bootSidebar( {
+			container: { layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-b' },
+		} ) ).rejects.toThrow( /angie-sidebar-container/ );
+	} );
+
+	it( 'should refuse an instance id that another instance already uses', async () => {
+		await bootSidebar( {
+			container: { id: 'chat-a', layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-a', instanceId: 'shared-id' },
+		} );
+
+		await expect( bootSidebar( {
+			container: { id: 'chat-b', layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-b', instanceId: 'shared-id' },
+		} ) ).rejects.toThrow( /shared-id/ );
+	} );
+
+	it( 'should name the instance after the sdk id, or the host id when given', async () => {
+		await bootSidebar(
+			{ container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } },
+			'sdk123',
+		);
+		expect( getFirstInstance()?.instanceId ).toBe( 'sdk123' );
+
+		resetInstancesForTests();
+		document.body.innerHTML = '';
+
+		await bootSidebar(
+			{ container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a', instanceId: 'stable' } },
+			'sdk123',
+		);
+		expect( getFirstInstance()?.instanceId ).toBe( 'stable' );
 	} );
 } );

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -1,15 +1,30 @@
-import { appState } from '../config';
 import { ensureSidebarContainer } from './container';
-import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
+import {
+	buildHostEmbeddedConfigPayload,
+	LAYOUT_SIDEBAR,
+	type LoadSidebarV2Options,
+} from './config';
+import { DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR } from './defaults';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
 import { readEnv } from './env';
 import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { handlePostConsentRedirect } from '../oauth';
+import {
+	createAngieInstance,
+	getFirstInstance,
+	getInstanceByContainerId,
+	getInstanceById,
+	hasSidebarLayoutInstance,
+} from '../instance-registry';
 import { resolveConfig, shouldBoot } from './resolve-config';
+import { generateInstanceId } from '../utils';
 
-export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
+export const bootSidebar = async (
+	options: LoadSidebarV2Options,
+	sdkInstanceId = ''
+): Promise<void> => {
 	handlePostConsentRedirect();
 
 	const env = readEnv();
@@ -19,36 +34,79 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 		return;
 	}
 
+	// Sidebar uses page-wide CSS and open state, so only one is supported.
+	if ( config.container.layout === LAYOUT_SIDEBAR && hasSidebarLayoutInstance() ) {
+		throw new Error(
+			'Angie SDK: only one sidebar layout instance is supported on a page. ' +
+			'Use container.layout "floatingChat" for the extra instance.'
+		);
+	}
+
+	if ( getInstanceByContainerId( config.container.id ) ) {
+		throw new Error(
+			`Angie SDK: container id "${ config.container.id }" is already used by another ` +
+			'Angie instance. Give this instance its own container.id.'
+		);
+	}
+
+	const instanceId = config.host.instanceId || sdkInstanceId || generateInstanceId();
+
+	if ( getInstanceById( instanceId ) ) {
+		throw new Error(
+			`Angie SDK: instance id "${ instanceId }" is already used by another ` +
+			'Angie instance. Give this instance its own host.instanceId.'
+		);
+	}
+
+	// Two instances would otherwise fight over the same default toggle button.
+	if (
+		getFirstInstance() &&
+		config.container.chatToggleButton.selector === DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR
+	) {
+		config.container.chatToggleButton.selector =
+			`${ DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR }-${ instanceId }`;
+	}
+
+	const instance = createAngieInstance( {
+		containerId: config.container.id,
+		instanceId,
+		layout: config.container.layout,
+	} );
+
 	initHostApiBridge( {
 		iframeOrigin: config.iframe.origin,
 		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
+		instance,
 	} );
-
-	appState.containerId = config.container.id;
 
 	ensureSidebarContainer( config.container.id, env.isRTL );
 
 	const strategy = LAYOUT_STRATEGIES[ config.container.layout ];
-	const bootContext = { config, env };
+	const bootContext = { config, env, instance };
 
 	strategy.initShell( bootContext );
 	strategy.beforeOpenIframe?.( bootContext );
 
 	const embeddedPayload = buildHostEmbeddedConfigPayload( config.host );
 
-	await openEmbeddedIframe( {
+	const opened = await openEmbeddedIframe( {
 		container: config.container,
 		iframe: config.iframe,
 		embeddedConfig: embeddedPayload,
+		instance,
 	} );
 
 	strategy.afterOpenIframe?.( bootContext );
 
+	if ( ! opened ) {
+		return;
+	}
+
 	// HOST_READY delivers config during iframe load; post-open message supports older embedded clients.
-	sendEmbeddedConfig( embeddedPayload );
+	sendEmbeddedConfig( embeddedPayload, instance );
 
 	if ( config.widgetConfig ) {
-		sendWidgetConfig( config.widgetConfig );
+		sendWidgetConfig( config.widgetConfig, instance );
 	}
 };

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
@@ -3,14 +3,19 @@ import { appState } from '../../config';
 import { toggleAngieSidebar } from '../../utils';
 import { syncToggleButton } from '../toggle-button';
 import { CHAT_WIDGET_HIDDEN_CLASS } from './constants';
-import { setChatWidgetOpen } from './chat-shell';
+import { initChatShell, resetChatShellForTests, setChatWidgetOpen } from './chat-shell';
+import { createAngieInstance, resetInstancesForTests } from '../../instance-registry';
+import { resetHostMessageRouterForTests } from '../host-message-router';
 
 jest.mock( '../../utils', () => ( {
+	...( jest.requireActual( '../../utils' ) as object ),
 	toggleAngieSidebar: jest.fn(),
+	sendSuccessMessage: jest.fn(),
 } ) );
 
 jest.mock( '../toggle-button', () => ( {
 	syncToggleButton: jest.fn(),
+	wireToggleButton: jest.fn(),
 } ) );
 
 const CONTAINER_ID = 'angie-sidebar-container';
@@ -32,11 +37,12 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 			containerId: CONTAINER_ID,
 			toggleButtonSelector: TOGGLE_SELECTOR,
 			isOpen: false,
+			instance: appState,
 		} );
 
 		const container = document.getElementById( CONTAINER_ID )!;
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, false );
 	} );
 
@@ -48,10 +54,106 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 			containerId: CONTAINER_ID,
 			toggleButtonSelector: TOGGLE_SELECTOR,
 			isOpen: true,
+			instance: appState,
 		} );
 
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( false );
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, true );
+	} );
+} );
+
+describe( 'load-sidebar-v2/chat-toggle/chat-shell multi-instance', () => {
+	const IFRAME_ORIGIN = 'https://angie.elementor.com';
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetChatShellForTests();
+		resetHostMessageRouterForTests();
+		resetInstancesForTests();
+		document.body.innerHTML = `
+			<div id="chat-a" class="${ CHAT_WIDGET_HIDDEN_CLASS }"></div>
+			<div id="chat-b" class="${ CHAT_WIDGET_HIDDEN_CLASS }"></div>
+			<button id="toggle-a" type="button"></button>
+			<button id="toggle-b" type="button"></button>
+		`;
+	} );
+
+	it( 'should open only the widget whose iframe sent the toggle message', () => {
+		const first = createAngieInstance( {
+			containerId: 'chat-a',
+			instanceId: 'aaaaaa',
+			layout: 'floatingChat',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'chat-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const secondWindow = {} as Window;
+		first.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+		second.iframe = { contentWindow: secondWindow } as HTMLIFrameElement;
+
+		initChatShell( {
+			containerId: 'chat-a',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-a',
+			instance: first,
+		} );
+		initChatShell( {
+			containerId: 'chat-b',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-b',
+			instance: second,
+		} );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: IFRAME_ORIGIN,
+			source: secondWindow,
+			data: { type: 'toggleAngieSidebar', payload: { force: true } },
+		} ) );
+
+		expect( document.getElementById( 'chat-b' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( false );
+		expect( document.getElementById( 'chat-a' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( true );
+	} );
+
+	it( 'should keep the first widget listening after a second one starts', () => {
+		const first = createAngieInstance( {
+			containerId: 'chat-a',
+			instanceId: 'aaaaaa',
+			layout: 'floatingChat',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'chat-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const firstWindow = {} as Window;
+		first.iframe = { contentWindow: firstWindow } as HTMLIFrameElement;
+		second.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+
+		initChatShell( {
+			containerId: 'chat-a',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-a',
+			instance: first,
+		} );
+		initChatShell( {
+			containerId: 'chat-b',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-b',
+			instance: second,
+		} );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: IFRAME_ORIGIN,
+			source: firstWindow,
+			data: { type: 'toggleAngieSidebar', payload: { force: true } },
+		} ) );
+
+		expect( document.getElementById( 'chat-a' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( false );
 	} );
 } );

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.ts
@@ -1,6 +1,7 @@
-import { appState } from '../../config';
+import type { AppState } from '../../config';
+import { hasSidebarLayoutInstance } from '../../instance-registry';
 import { MessageEventType } from '../../types';
-import { sendSuccessMessage, toggleAngieSidebar } from '../../utils';
+import { isTrustedIframeMessage, sendSuccessMessage, toggleAngieSidebar } from '../../utils';
 import { syncToggleButton, wireToggleButton } from '../toggle-button';
 import { addHostMessageHandler } from '../host-message-router';
 import {
@@ -14,17 +15,19 @@ type InitChatShellArgs = {
 	iframeOrigin: string;
 	toggleButtonSelector: string;
 	onClose?: () => void;
+	instance: AppState;
 };
 
 type SetChatWidgetOpenArgs = {
 	containerId: string;
 	toggleButtonSelector: string;
 	isOpen: boolean;
+	instance: AppState;
 };
 
 const TOGGLE_ANGIE_SIDEBAR_MESSAGE = 'toggleAngieSidebar';
 
-let removeChatShellMessageHandler: ( () => void ) | null = null;
+const removeMessageHandlers = new Map<AppState, () => void>();
 
 export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 	const container = document.getElementById( args.containerId );
@@ -39,8 +42,8 @@ export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 		container.classList.add( CHAT_WIDGET_HIDDEN_CLASS );
 	}
 
-	if ( appState.iframe ) {
-		toggleAngieSidebar( appState.iframe, args.isOpen );
+	if ( args.instance.iframe ) {
+		toggleAngieSidebar( args.instance.iframe, args.isOpen, args.containerId );
 	}
 
 	syncToggleButton( args.toggleButtonSelector, args.isOpen );
@@ -60,83 +63,54 @@ const setChatWidgetFullscreen = ( containerId: string, isFullscreen: boolean ): 
 	}
 };
 
+const setOpen = ( args: InitChatShellArgs, isOpen: boolean ): void => {
+	setChatWidgetOpen( {
+		containerId: args.containerId,
+		toggleButtonSelector: args.toggleButtonSelector,
+		isOpen,
+		instance: args.instance,
+	} );
+};
+
+const isWidgetOpen = ( containerId: string ): boolean => {
+	const container = document.getElementById( containerId );
+	return !! container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
+};
+
 const handleSidebarToggleMessage = (
 	args: InitChatShellArgs,
 	payload: { force?: boolean } | undefined,
 ): void => {
 	const force = payload?.force;
 
-	if ( force === false ) {
-		setChatWidgetOpen( {
-			containerId: args.containerId,
-			toggleButtonSelector: args.toggleButtonSelector,
-			isOpen: false,
-		} );
-		args.onClose?.();
+	if ( force !== undefined ) {
+		setOpen( args, force );
+
+		if ( ! force ) {
+			args.onClose?.();
+		}
+
 		return;
 	}
 
-	if ( force === true ) {
-		setChatWidgetOpen( {
-			containerId: args.containerId,
-			toggleButtonSelector: args.toggleButtonSelector,
-			isOpen: true,
-		} );
-		return;
-	}
+	const wasOpen = isWidgetOpen( args.containerId );
+	setOpen( args, ! wasOpen );
 
-	const container = document.getElementById( args.containerId );
-	const isCurrentlyOpen = container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
-	setChatWidgetOpen( {
-		containerId: args.containerId,
-		toggleButtonSelector: args.toggleButtonSelector,
-		isOpen: ! isCurrentlyOpen,
-	} );
-
-	if ( isCurrentlyOpen ) {
+	if ( wasOpen ) {
 		args.onClose?.();
 	}
 };
 
 const initToggleButton = ( args: InitChatShellArgs ): void => {
-	const toggleButton = findToggleButton( args.toggleButtonSelector );
-
-	if ( ! toggleButton ) {
-		wireToggleButton( {
-			toggleButtonSelector: args.toggleButtonSelector,
-			onClick: () => {
-				const toggleEl = findToggleButton( args.toggleButtonSelector );
-
-				if ( ! toggleEl ) {
-					return;
-				}
-
-				const isCurrentlyOpen = toggleEl.getAttribute( 'aria-expanded' ) === 'true';
-				setChatWidgetOpen( {
-					containerId: args.containerId,
-					toggleButtonSelector: args.toggleButtonSelector,
-					isOpen: ! isCurrentlyOpen,
-				} );
-
-				if ( isCurrentlyOpen ) {
-					args.onClose?.();
-				}
-			},
-		} );
-		return;
-	}
-
 	wireToggleButton( {
 		toggleButtonSelector: args.toggleButtonSelector,
 		onClick: () => {
-			const isCurrentlyOpen = toggleButton.getAttribute( 'aria-expanded' ) === 'true';
-			setChatWidgetOpen( {
-				containerId: args.containerId,
-				toggleButtonSelector: args.toggleButtonSelector,
-				isOpen: ! isCurrentlyOpen,
-			} );
+			const toggleEl = findToggleButton( args.toggleButtonSelector );
+			const wasOpen = toggleEl?.getAttribute( 'aria-expanded' ) === 'true';
 
-			if ( isCurrentlyOpen ) {
+			setOpen( args, ! wasOpen );
+
+			if ( wasOpen ) {
 				args.onClose?.();
 			}
 		},
@@ -144,9 +118,11 @@ const initToggleButton = ( args: InitChatShellArgs ): void => {
 };
 
 const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
-	removeChatShellMessageHandler?.();
-	removeChatShellMessageHandler = addHostMessageHandler( ( event: MessageEvent ) => {
-		if ( event.origin !== args.iframeOrigin ) {
+	const { instance } = args;
+
+	removeMessageHandlers.get( instance )?.();
+	removeMessageHandlers.set( instance, addHostMessageHandler( ( event: MessageEvent ) => {
+		if ( ! isTrustedIframeMessage( event, args.iframeOrigin, instance.iframe ) ) {
 			return;
 		}
 
@@ -167,11 +143,7 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				setChatWidgetFullscreen( args.containerId, isStudioOpen );
 
 				if ( isStudioOpen ) {
-					setChatWidgetOpen( {
-						containerId: args.containerId,
-						toggleButtonSelector: args.toggleButtonSelector,
-						isOpen: true,
-					} );
+					setOpen( args, true );
 				}
 
 				if ( port ) {
@@ -180,19 +152,22 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				break;
 			}
 		}
-	} );
+	} ) );
 };
 
 export const initChatShell = ( args: InitChatShellArgs ): void => {
 	initToggleButton( args );
 	setupChatWidgetMessageListeners( args );
 
-	window.toggleAngieSidebar = ( force?: boolean ) => {
-		handleSidebarToggleMessage( args, { force } );
-	};
+	// Preserve the sidebar's global toggle when both layouts are used.
+	if ( ! hasSidebarLayoutInstance() ) {
+		window.toggleAngieSidebar = ( force?: boolean ) => {
+			handleSidebarToggleMessage( args, { force } );
+		};
+	}
 };
 
 export const resetChatShellForTests = (): void => {
-	removeChatShellMessageHandler?.();
-	removeChatShellMessageHandler = null;
+	removeMessageHandlers.forEach( ( remove ) => remove() );
+	removeMessageHandlers.clear();
 };

--- a/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
+++ b/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
@@ -1,3 +1,4 @@
+import type { AppState } from '../../config';
 import { initChatShell } from './chat-shell';
 import {
 	injectChatToggleButton,
@@ -11,6 +12,7 @@ type InitFloatingChatLayoutArgs = {
 	toggleButtonSelector: string;
 	injectToggleButton: boolean;
 	onClose?: () => void;
+	instance: AppState;
 };
 
 export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void => {
@@ -26,5 +28,6 @@ export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void
 		iframeOrigin: args.iframeOrigin,
 		onClose: args.onClose,
 		toggleButtonSelector: args.toggleButtonSelector,
+		instance: args.instance,
 	} );
 };

--- a/src/load-sidebar-v2/chat-toggle/widget-ui.ts
+++ b/src/load-sidebar-v2/chat-toggle/widget-ui.ts
@@ -6,6 +6,7 @@ import {
 	CHAT_WIDGET_HIDDEN_CLASS,
 	CHAT_WIDGET_STYLES_ID,
 } from './constants';
+import { DEFAULT_CONTAINER_ID } from '../../config';
 import { applySelectorToToggleButton, findToggleButton } from './toggle-button-element';
 
 const ANGIE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16" fill="none">
@@ -130,13 +131,24 @@ export const injectChatToggleButtonStyles = (): void => {
 	document.head.appendChild( style );
 };
 
+/**
+ * The CSS is written against one container id, so every container needs its own tag.
+ * The default container keeps the original id, leaving single-instance pages unchanged.
+ */
+const styleIdForContainer = ( containerId: string ): string =>
+	containerId === DEFAULT_CONTAINER_ID
+		? CHAT_WIDGET_STYLES_ID
+		: `${ CHAT_WIDGET_STYLES_ID }-${ containerId }`;
+
 export const injectChatWidgetStyles = ( containerId: string ): void => {
-	if ( document.getElementById( CHAT_WIDGET_STYLES_ID ) ) {
+	const styleId = styleIdForContainer( containerId );
+
+	if ( document.getElementById( styleId ) ) {
 		return;
 	}
 
 	const style = document.createElement( 'style' );
-	style.id = CHAT_WIDGET_STYLES_ID;
+	style.id = styleId;
 	style.textContent = buildWidgetCss( containerId );
 	document.head.appendChild( style );
 };

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -12,6 +12,7 @@ export type LoadSidebarV2ContainerStyleTheme = 'wordpress' | '';
 
 export type HostConfig = {
 	appId: string;
+	instanceId?: string;
 	aiContext?: Record<string, unknown>;
 	website?: Record<string, unknown>;
 	analytics?: Record<string, unknown>;

--- a/src/load-sidebar-v2/embedded-handshake.ts
+++ b/src/load-sidebar-v2/embedded-handshake.ts
@@ -1,16 +1,23 @@
-import { postMessageToAngieIframe } from '../angie-iframe-utils';
+import { postMessageToInstance } from '../angie-iframe-utils';
+import { appState, type AppState } from '../config';
 import type { HostEmbeddedConfigPayload, ResolvedConfigV2 } from './config';
 import { EMBEDDED_CONFIG_MESSAGE_TYPE } from './defaults';
 
-export const sendEmbeddedConfig = ( payload: HostEmbeddedConfigPayload ): void => {
-	postMessageToAngieIframe( {
+export const sendEmbeddedConfig = (
+	payload: HostEmbeddedConfigPayload,
+	instance: AppState = appState
+): void => {
+	postMessageToInstance( instance, {
 		payload,
 		type: EMBEDDED_CONFIG_MESSAGE_TYPE,
 	} );
 };
 
-export const sendWidgetConfig = ( widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']> ): void => {
-	postMessageToAngieIframe( {
+export const sendWidgetConfig = (
+	widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']>,
+	instance: AppState = appState
+): void => {
+	postMessageToInstance( instance, {
 		payload: widgetConfig,
 		type: 'sdk-widget-config',
 	} );

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -8,6 +8,8 @@ import {
 	initHostApiBridge,
 	resetHostApiBridgeForTests,
 } from './host-api-bridge';
+import { appState } from '../config';
+import { createAngieInstance, resetInstancesForTests } from '../instance-registry';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -23,10 +25,53 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		resetHostApiBridgeForTests();
+		resetInstancesForTests();
+	} );
+
+	it( 'should answer each instance with its own host config', async () => {
+		const first = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const secondWindow = {} as Window;
+		first.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+		second.iframe = { contentWindow: secondWindow } as HTMLIFrameElement;
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: { appId: 'app-a', analytics: { screenPath: '/a' } },
+			instance: first,
+		} );
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: { appId: 'app-b', analytics: { screenPath: '/b' } },
+			instance: second,
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_ANALYTICS_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			source: secondWindow,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { payload: expect.objectContaining( { screenPath: '/b' } ) },
+		} );
 	} );
 
 	it( 'should respond with empty headers when no callback is provided', async () => {
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		const port = createMockPort();
 		window.dispatchEvent( new MessageEvent( 'message', {
@@ -53,6 +98,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		initHostApiBridge( {
 			iframeOrigin: IFRAME_ORIGIN,
 			getExternalHeaders,
+			instance: appState,
 		} );
 
 		const firstPort = createMockPort();
@@ -92,6 +138,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		initHostApiBridge( {
 			iframeOrigin: IFRAME_ORIGIN,
 			getExternalHeaders,
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -113,6 +160,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 			getExternalHeaders: async () => {
 				throw new Error( 'Token unavailable' );
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -137,6 +185,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 				appId: 'test-app',
 				website: { name: 'Custom Site', wpVersion: '6.4' },
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -174,6 +223,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 					plugins: { elementor: true },
 				},
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -201,7 +251,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	it( 'should handle localStorage GET', async () => {
 		window.localStorage.setItem( 'angie-test-key', 'stored-value' );
 
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		const port = createMockPort();
 		window.dispatchEvent( new MessageEvent( 'message', {
@@ -218,7 +268,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	} );
 
 	it( 'should handle localStorage SET', async () => {
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		window.dispatchEvent( new MessageEvent( 'message', {
 			data: {

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,5 +1,6 @@
 import { sendErrorMessage, sendSuccessMessage } from '../utils';
 import { HostLocalStorageEventType } from '../types';
+import type { AppState } from '../config';
 import type { ExternalHeadersCallback, HostConfig } from './config';
 
 export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
@@ -12,10 +13,26 @@ type InitHostApiBridgeArgs = {
 	iframeOrigin: string;
 	host?: HostConfig;
 	getExternalHeaders?: ExternalHeadersCallback;
+	instance: AppState;
 };
 
-let bridgeConfig: InitHostApiBridgeArgs | null = null;
+const bridges = new Map<AppState, InitHostApiBridgeArgs>();
 let bridgeListenerRegistered = false;
+
+// Disambiguate by event.source when several instances share one origin; see isFromIframe.
+const findBridge = ( event: MessageEvent ): InitHostApiBridgeArgs | null => {
+	const matching = [ ...bridges.values() ].filter(
+		( bridge ) => bridge.iframeOrigin === event.origin,
+	);
+
+	if ( matching.length <= 1 ) {
+		return matching[ 0 ] ?? null;
+	}
+
+	return matching.find(
+		( bridge ) => bridge.instance.iframe?.contentWindow === event.source,
+	) ?? null;
+};
 
 const filterDefinedHeaders = (
 	headers: Record<string, string | undefined>,
@@ -83,7 +100,9 @@ const handleHostLocalStorageSet = ( key: string, value: string ): void => {
 };
 
 const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
-	if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+	const bridgeConfig = findBridge( event );
+
+	if ( ! bridgeConfig ) {
 		return;
 	}
 
@@ -131,7 +150,7 @@ const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
 };
 
 export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
-	bridgeConfig = args;
+	bridges.set( args.instance, args );
 
 	if ( bridgeListenerRegistered ) {
 		return;
@@ -144,5 +163,5 @@ export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 };
 
 export const resetHostApiBridgeForTests = (): void => {
-	bridgeConfig = null;
+	bridges.clear();
 };

--- a/src/load-sidebar-v2/layouts/index.ts
+++ b/src/load-sidebar-v2/layouts/index.ts
@@ -1,5 +1,6 @@
 import { initFloatingChatLayout } from '../chat-toggle/init-floating-chat-layout';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR, type LoadSidebarV2Layout, type ResolvedConfigV2 } from '../config';
+import type { AppState } from '../../config';
 import type { Env } from '../env';
 import {
 	applyInitialSidebarShellState,
@@ -10,6 +11,7 @@ import {
 export type LayoutBootContext = {
 	config: ResolvedConfigV2;
 	env: Env;
+	instance: AppState;
 };
 
 export type LayoutStrategy = {
@@ -19,19 +21,19 @@ export type LayoutStrategy = {
 };
 
 const sidebarStrategy: LayoutStrategy = {
-	initShell: ( { config } ) => {
-		initSidebarShell( config.container, config.callbacks );
+	initShell: ( { config, instance } ) => {
+		initSidebarShell( config.container, config.callbacks, instance );
 	},
 	beforeOpenIframe: ( { config } ) => {
 		applyInitialSidebarShellState( config.container );
 	},
-	afterOpenIframe: ( { config } ) => {
-		finalizeSidebarShellState( config.container );
+	afterOpenIframe: ( { config, instance } ) => {
+		finalizeSidebarShellState( config.container, instance );
 	},
 };
 
 const floatingChatStrategy: LayoutStrategy = {
-	initShell: ( { config } ) => {
+	initShell: ( { config, instance } ) => {
 		const { chatToggleButton } = config.container;
 
 		initFloatingChatLayout( {
@@ -40,6 +42,7 @@ const floatingChatStrategy: LayoutStrategy = {
 			onClose: config.callbacks.onClose,
 			toggleButtonSelector: chatToggleButton.selector,
 			injectToggleButton: chatToggleButton.enabled,
+			instance,
 		} );
 	},
 };

--- a/src/load-sidebar-v2/open-embedded-iframe.test.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.test.ts
@@ -3,7 +3,10 @@ import { appState } from '../config';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 
 jest.mock( '../iframe', () => ( {
-	openIframe: jest.fn( () => Promise.resolve() ),
+	openIframe: jest.fn( () => Promise.resolve( {
+		iframe: {} as HTMLIFrameElement,
+		iframeOrigin: 'https://angie.elementor.com',
+	} ) ),
 } ) );
 
 jest.mock( '../utils', () => ( {
@@ -48,7 +51,7 @@ describe( 'load-sidebar-v2/open-embedded-iframe', () => {
 			},
 		} );
 
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false, appState.containerId );
 		expect( syncToggleButton ).toHaveBeenCalledWith( '#demo-sidebar-toggle', false );
 	} );
 } );

--- a/src/load-sidebar-v2/open-embedded-iframe.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.ts
@@ -1,4 +1,4 @@
-import { appState } from '../config';
+import { appState, type AppState } from '../config';
 import { openIframe } from '../iframe';
 import { toggleAngieSidebar } from '../utils';
 import { LAYOUT_FLOATING_CHAT, type HostEmbeddedConfigPayload, type ResolvedConfigV2 } from './config';
@@ -9,16 +9,24 @@ type OpenEmbeddedIframeArgs = {
 	container: ResolvedConfigV2['container'];
 	iframe: ResolvedConfigV2['iframe'];
 	embeddedConfig?: HostEmbeddedConfigPayload;
+	instance?: AppState;
 };
 
-export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<void> => {
-	await openIframe( {
+export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<boolean> => {
+	const instance = args.instance ?? appState;
+
+	const opened = await openIframe( {
 		isRTL: args.iframe.isRTL,
 		origin: args.iframe.origin,
 		path: args.iframe.path,
 		uiTheme: args.iframe.uiTheme,
 		embeddedConfig: args.embeddedConfig,
-	} );
+	}, instance );
+
+	// No iframe on mobile, so there is nothing to configure or toggle.
+	if ( ! opened ) {
+		return false;
+	}
 
 	if (
 		args.container.layout === LAYOUT_FLOATING_CHAT &&
@@ -28,15 +36,18 @@ export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promis
 			containerId: args.container.id,
 			toggleButtonSelector: args.container.chatToggleButton.selector,
 			isOpen: false,
+			instance,
 		} );
-		return;
+		return true;
 	}
 
-	if ( appState.iframe ) {
-		toggleAngieSidebar( appState.iframe, false );
+	if ( instance.iframe ) {
+		toggleAngieSidebar( instance.iframe, false, instance.containerId );
 	}
 
 	if ( args.container.chatToggleButton.enabled ) {
 		syncToggleButton( args.container.chatToggleButton.selector, false );
 	}
+
+	return true;
 };

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -35,8 +35,10 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 	return {
 		host: {
 			appId: options.host.appId,
+			instanceId: options.host.instanceId,
 			aiContext: options.host.aiContext,
 			website: options.host.website,
+			analytics: options.host.analytics,
 		},
 		boot: {
 			allowInIframe: boot.allowInIframe ?? DEFAULTS.boot.allowInIframe,

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -7,6 +7,7 @@ import {
 	initializeResize,
 	loadState,
 } from '../sidebar';
+import { appState, type AppState } from '../config';
 import type { ContainerConfig, ResolvedConfigV2 } from './config';
 import {
 	syncToggleButton,
@@ -17,12 +18,14 @@ import { injectStyleThemeCss } from './inject-style-theme';
 export const initSidebarShell = (
 	container: ContainerConfig,
 	callbacks: ResolvedConfigV2['callbacks'],
+	instance: AppState = appState,
 ): void => {
 	const toggleButtonSelector = container.chatToggleButton.enabled
 		? container.chatToggleButton.selector
 		: undefined;
 
 	initAngieSidebar( {
+		instance,
 		onToggle: ( isOpen ) => {
 			if ( toggleButtonSelector ) {
 				syncToggleButton( toggleButtonSelector, isOpen );
@@ -66,6 +69,7 @@ export const applyInitialSidebarShellState = (
 
 export const finalizeSidebarShellState = (
 	container: ContainerConfig,
+	instance: AppState = appState,
 ): void => {
 	if ( container.persistOpenState ) {
 		loadState(
@@ -76,6 +80,6 @@ export const finalizeSidebarShellState = (
 	}
 
 	if ( container.resizable ) {
-		initializeResize();
+		initializeResize( instance );
 	}
 };

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { addLocalStorageListener } from './localStorage';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+import { HostLocalStorageEventType } from './types';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const emitMessage = ( event: Partial<MessageEvent> ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), event ) );
+};
+
+describe( 'localStorage', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		window.localStorage.clear();
+		jest.clearAllMocks();
+	} );
+
+	it( 'should store a value sent by its own iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const ownWindow = {} as Window;
+		instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		instance.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
+
+		addLocalStorageListener( instance );
+		emitMessage( {
+			origin: ANGIE_ORIGIN,
+			source: ownWindow,
+			data: { type: HostLocalStorageEventType.SET, key: 'angie_test', value: 'yes' },
+		} );
+
+		expect( window.localStorage.getItem( 'angie_test' ) ).toBe( 'yes' );
+	} );
+
+	it( 'should ignore a message sent by another instance iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		instance.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+
+		addLocalStorageListener( instance );
+		emitMessage( {
+			origin: ANGIE_ORIGIN,
+			source: {} as Window,
+			data: { type: HostLocalStorageEventType.SET, key: 'angie_test', value: 'yes' },
+		} );
+
+		expect( window.localStorage.getItem( 'angie_test' ) ).toBeNull();
+	} );
+} );

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,9 +1,10 @@
-import { appState } from "./config";
+import { appState, type AppState } from "./config";
 import { HostLocalStorageEventType } from "./types";
+import { isTrustedIframeMessage } from "./utils";
 
-export const addLocalStorageListener = () => {
+export const addLocalStorageListener = ( instance: AppState = appState ) => {
 	window.addEventListener( 'message', ( event: MessageEvent ) => {
-		if ( event.origin !== appState.iframeUrlObject?.origin ) {
+		if ( ! isTrustedIframeMessage( event, instance.iframeUrlObject?.origin, instance.iframe ) ) {
 			return;
 		}
 

--- a/src/openSaaSPage.test.ts
+++ b/src/openSaaSPage.test.ts
@@ -112,6 +112,60 @@ describe('openSaaSPage', () => {
       expect(mockIframe.setAttribute).toHaveBeenCalledWith('allow', 'clipboard-write; clipboard-read');
     });
 
+    it('should build the iframe instanceId from the sdk instance id', async () => {
+      const messagePromise = openSaaSPage({
+        ...defaultProps,
+        instanceId: 'bbbbbb',
+      });
+
+      const messageListener = mockWindow.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === 'message'
+      )?.[1];
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        data: { type: HostEventType.ANGIE_READY },
+      });
+
+      const result = await messagePromise;
+      const appendSpy = result.iframeUrlObject.searchParams.append as jest.MockedFunction<any>;
+      const instanceIdCall = appendSpy.mock.calls.find((call: any[]) => call[0] === 'instanceId');
+
+      expect(instanceIdCall?.[1]).toBe('test-page-bbbbbb');
+    });
+
+    it('should ignore a ready message coming from a different iframe', async () => {
+      const ownWindow = { postMessage: jest.fn() };
+      Object.defineProperty(mockIframe, 'contentWindow', { value: ownWindow, writable: true });
+
+      let resolved = false;
+      const messagePromise = openSaaSPage(defaultProps).then((result) => {
+        resolved = true;
+        return result;
+      });
+
+      const messageListener = mockWindow.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === 'message'
+      )?.[1];
+
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        source: { postMessage: jest.fn() },
+        data: { type: HostEventType.ANGIE_READY },
+      });
+      await Promise.resolve();
+
+      expect(resolved).toBe(false);
+
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        source: ownWindow,
+        data: { type: HostEventType.ANGIE_READY },
+      });
+      await messagePromise;
+
+      expect(resolved).toBe(true);
+    });
+
     it('should apply CSS styles correctly', async () => {
       const cssProps = {
         width: '400px',

--- a/src/openSaaSPage.ts
+++ b/src/openSaaSPage.ts
@@ -1,4 +1,5 @@
 import { HostEventType } from "./types";
+import { generateInstanceId, isTrustedIframeMessage } from "./utils";
 import type { HostEmbeddedConfigPayload } from "./load-sidebar-v2/config";
 
 type OpenSaaSPageInput = {
@@ -13,6 +14,8 @@ type OpenSaaSPageInput = {
 	uiTheme?: string;
 	isRTL?: boolean;
 	sdkVersion: string;
+	iframeElementId?: string;
+	instanceId?: string;
 };
 
 type OpenSaaSPageOutput = {
@@ -24,7 +27,8 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 	const origin = props.origin;
 	const pathUrl = new URL( props.path, origin );
 	// e.g. "text-to-elementor-vm2qhj"
-	const instanceId = pathUrl.pathname.slice( 1 ).replace( /\//, '--' ) + '-' + Math.random().toString( 36 ).substring( 7 );
+	const instanceSuffix = props.instanceId || generateInstanceId();
+	const instanceId = pathUrl.pathname.slice( 1 ).replace( /\//, '--' ) + '-' + instanceSuffix;
 
 	return new Promise( ( resolve ) => {
 		const iframeUrlObject = new URL( origin );
@@ -64,7 +68,7 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 		};
 
 		const onMessage = async ( event: MessageEvent ) => {
-			if ( event.origin !== iframeUrlObject.origin ) {
+			if ( ! isTrustedIframeMessage( event, iframeUrlObject.origin, iframe ) ) {
 				return;
 			}
 
@@ -91,7 +95,7 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 
 
 		iframe.setAttribute( 'src', iframeUrlObject.href );
-		iframe.id = 'angie-iframe';
+		iframe.id = props.iframeElementId || 'angie-iframe';
 		iframe.setAttribute( 'frameborder', '0' );
 		iframe.setAttribute( 'scrolling', 'no' );
 		iframe.setAttribute( 'style', Object.entries( css ).map( ( [ key, value ] ) => `${ key }: ${ value }` ).join( '; ' ) );

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+import { listenToSDK } from './sdk';
+import { MessageEventType } from './types';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const attachIframe = ( instance: ReturnType<typeof createAngieInstance> ) => {
+	const postMessage = jest.fn();
+	instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+	instance.iframe = { contentWindow: { postMessage } } as unknown as HTMLIFrameElement;
+	return postMessage;
+};
+
+const emitHostMessage = ( data: unknown ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), {
+		origin: window.location.origin,
+		source: window,
+		data,
+		ports: [ { postMessage: jest.fn() } ],
+	} ) );
+};
+
+describe( 'sdk', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		jest.clearAllMocks();
+	} );
+
+	it( 'should forward a trigger request only to the addressed instance', () => {
+		const first = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const firstPostMessage = attachIframe( first );
+		const secondPostMessage = attachIframe( second );
+
+		listenToSDK( first );
+		listenToSDK( second );
+		emitHostMessage( {
+			type: MessageEventType.SDK_TRIGGER_ANGIE,
+			payload: { instanceId: 'aaaaaa', requestId: 'req-2', prompt: 'hello' },
+		} );
+
+		expect( firstPostMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: MessageEventType.SDK_TRIGGER_ANGIE } ),
+			ANGIE_ORIGIN,
+		);
+		expect( secondPostMessage ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,6 +3,7 @@ import { sendSuccessMessage } from './utils';
 import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { MessageEventType } from './types';
 import { AppState } from './config';
+import { shouldInstanceHandle } from './instance-registry';
 
 const sdkLogger = createChildLogger( 'sdk' );
 
@@ -20,13 +21,18 @@ export interface ClientCreationRequest {
 }
 
 export const listenToSDK = ( appState: AppState ) => {
-	// Access global timing instance for SDK performance tracking
 	window.addEventListener( 'message', async ( event ) => {
 		const isSameOrigin = event.origin === window.location.origin;
 		const isIframe = event.origin === appState.iframeUrlObject?.origin;
 		if ( ! isSameOrigin && ! isIframe ) {
 			return;
 		}
+
+		// Host messages share event.source, so route them by instanceId.
+		const shouldHandleMessage = shouldInstanceHandle(
+			appState,
+			event?.data?.payload?.instanceId
+		);
 
 		switch ( event?.data?.type ) {
 			case MessageEventType.SDK_ANGIE_ALL_SERVERS_REGISTERED:
@@ -43,6 +49,10 @@ export const listenToSDK = ( appState: AppState ) => {
 				break;
 			}
 			case MessageEventType.SDK_REQUEST_CLIENT_CREATION: {
+				if ( ! shouldHandleMessage ) {
+					break;
+				}
+
 				const payload = event.data.payload as ClientCreationRequest;
 
 				try {
@@ -77,6 +87,9 @@ export const listenToSDK = ( appState: AppState ) => {
 				break;
 			}
 			case MessageEventType.SDK_TRIGGER_ANGIE: {
+				if ( ! shouldHandleMessage ) {
+					break;
+				}
 
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -12,7 +12,7 @@ import { appState } from './config';
 
 // Mock dependencies
 jest.mock('./angie-iframe-utils', () => ({
-  postMessageToAngieIframe: jest.fn(),
+  postMessageToInstance: jest.fn(),
 }));
 
 jest.mock('./iframe', () => ({
@@ -23,6 +23,7 @@ jest.mock('./iframe', () => ({
 }));
 
 jest.mock('./utils', () => ({
+  ...(jest.requireActual('./utils') as object),
   waitForDocumentReady: jest.fn().mockImplementation(() => Promise.resolve()),
   sendSuccessMessage: jest.fn(),
   toggleAngieSidebar: jest.fn(),
@@ -189,6 +190,30 @@ describe('sidebar', () => {
       expect( toggle ).toHaveBeenCalledWith( true, undefined );
     } );
 
+    it( 'should ignore a toggle message sent by a different instance iframe', () => {
+      const toggle = ( global.window as any ).toggleAngieSidebar as jest.Mock;
+      const ownWindow = {} as Window;
+      appState.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: trustedOrigin,
+        source: {} as Window,
+        data: { type: 'toggleAngieSidebar', payload: { force: true } },
+      } ) );
+
+      expect( toggle ).not.toHaveBeenCalled();
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: trustedOrigin,
+        source: ownWindow,
+        data: { type: 'toggleAngieSidebar', payload: { force: true } },
+      } ) );
+
+      expect( toggle ).toHaveBeenCalledWith( true, undefined );
+
+      appState.iframe = null;
+    } );
+
     it( 'should ack toggleAngieSidebar requests over MessagePort', () => {
       const { sendSuccessMessage } = require( './utils' ) as { sendSuccessMessage: jest.Mock };
       const port = { postMessage: jest.fn() } as unknown as MessagePort;
@@ -202,4 +227,5 @@ describe('sidebar', () => {
       expect( sendSuccessMessage ).toHaveBeenCalledWith( port );
     } );
   } );
+
 });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,9 +1,9 @@
-import { postMessageToAngieIframe } from "./angie-iframe-utils";
-import { appState } from "./config";
+import { postMessageToInstance } from "./angie-iframe-utils";
+import { appState, type AppState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
 import { isOidcFlowInUrl } from "@elementor/oidc-auth";
-import { sendSuccessMessage, toggleAngieSidebar as setIframeAccessibility, waitForDocumentReady } from "./utils";
+import { isFromIframe, isTrustedIframeMessage, sendSuccessMessage, toggleAngieSidebar as setIframeAccessibility, waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
 
 const sidebarLogger = createChildLogger( 'sidebar' );
@@ -34,6 +34,11 @@ function injectCSS(): void {
 export const ANGIE_SIDEBAR_STATE_OPEN = 'open';
 export const ANGIE_SIDEBAR_STATE_CLOSED = 'closed';
 
+// Only the sidebar layout persists state, and only one sidebar may run on a page, so
+// these keys never collide and stay unprefixed.
+const STATE_STORAGE_KEY = 'angie_sidebar_state';
+const WIDTH_STORAGE_KEY = 'angie_sidebar_width';
+
 const SIDE_MENU_WIDTH = 40;
 const MIN_WIDTH = 310 + SIDE_MENU_WIDTH;
 const MAX_WIDTH = 550 + SIDE_MENU_WIDTH;
@@ -52,7 +57,7 @@ export function loadWidth(): number {
 	}
 
 	try {
-		const savedWidth = window.localStorage.getItem( 'angie_sidebar_width' );
+		const savedWidth = window.localStorage.getItem( WIDTH_STORAGE_KEY );
 		if ( savedWidth ) {
 			const width = parseInt( savedWidth, 10 );
 			if ( width >= MIN_WIDTH && width <= MAX_WIDTH ) {
@@ -69,13 +74,13 @@ export function getAngieSidebarSavedState(): AngieSidebarState | null {
 	if ( typeof window === 'undefined' ) {
 		return null;
 	}
-	return localStorage.getItem( 'angie_sidebar_state' ) as AngieSidebarState | null;
+	return localStorage.getItem( STATE_STORAGE_KEY ) as AngieSidebarState | null;
 }
 
-export function handleFocus( isOpen: boolean, delay: number ): void {
+export function handleFocus( isOpen: boolean, delay: number, instance: AppState = appState ): void {
 	if ( isOpen ) {
 		setTimeout( function() {
-			postMessageToAngieIframe( {
+			postMessageToInstance( instance, {
 				type: 'focusInput',
 			} );
 		}, delay );
@@ -84,7 +89,7 @@ export function handleFocus( isOpen: boolean, delay: number ): void {
 
 export function saveState( state: string ): void {
 	try {
-		localStorage.setItem( 'angie_sidebar_state', state );
+		localStorage.setItem( STATE_STORAGE_KEY, state );
 	} catch ( e ) {
 		sidebarLogger.warn( 'localStorage not available' );
 	}
@@ -92,7 +97,7 @@ export function saveState( state: string ): void {
 
 export function saveWidth( width: number ): void {
 	try {
-		localStorage.setItem( 'angie_sidebar_width', width.toString() );
+		localStorage.setItem( WIDTH_STORAGE_KEY, width.toString() );
 	} catch ( e ) {
 		sidebarLogger.warn( 'localStorage not available' );
 	}
@@ -105,7 +110,7 @@ export function applyWidth( width: number ): void {
 export function forceSidebarClosedDuringOAuth(): void {
 	applyState( ANGIE_SIDEBAR_STATE_CLOSED );
 	try {
-		localStorage.setItem( 'angie_sidebar_state', ANGIE_SIDEBAR_STATE_CLOSED );
+		localStorage.setItem( STATE_STORAGE_KEY, ANGIE_SIDEBAR_STATE_CLOSED );
 	} catch ( e ) {
 		sidebarLogger.warn( 'localStorage not available' );
 	}
@@ -126,8 +131,8 @@ export function applyState( state: AngieSidebarState ): void {
 	}
 }
 
-export function initializeResize(): void {
-	const sidebar = document.getElementById( appState.containerId );
+export function initializeResize( instance: AppState = appState ): void {
+	const sidebar = document.getElementById( instance.containerId );
 	if ( ! sidebar ) {
 		return;
 	}
@@ -184,7 +189,7 @@ export function initializeResize(): void {
 			const currentWidth = parseInt( getComputedStyle( document.documentElement ).getPropertyValue( '--angie-sidebar-width' ), 10 );
 			saveWidth( currentWidth );
 
-			postMessageToAngieIframe( {
+			postMessageToInstance( instance, {
 				type: MessageEventType.ANGIE_SIDEBAR_RESIZED,
 				payload: { initialWidth: startWidth, width: currentWidth },
 			} );
@@ -202,10 +207,13 @@ export function initializeResize(): void {
 	applyWidth( savedWidth );
 }
 
-export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void ): ( force?: boolean, skipTransition?: boolean ) => void {
+export function createToggleSidebarFunction(
+	onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void,
+	instance: AppState = appState
+): ( force?: boolean, skipTransition?: boolean ) => void {
 	return function( force?: boolean, skipTransition?: boolean ): void {
 		const body = document.body;
-		const sidebar = document.getElementById( appState.containerId );
+		const sidebar = document.getElementById( instance.containerId );
 
 		if ( ! sidebar ) {
 			sidebarLogger.warn( 'Required elements not found!' );
@@ -228,12 +236,12 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 			body.classList.remove( 'angie-sidebar-active' );
 		}
 
-		if ( appState.iframe ) {
-			setIframeAccessibility( appState.iframe, shouldOpen );
+		if ( instance.iframe ) {
+			setIframeAccessibility( instance.iframe, shouldOpen, instance.containerId );
 		}
 
 		const focusDelay = skipTransition ? 0 : 300;
-		handleFocus( shouldOpen, focusDelay );
+		handleFocus( shouldOpen, focusDelay, instance );
 
 		if ( onToggle ) {
 			onToggle( shouldOpen, sidebar, skipTransition );
@@ -246,7 +254,7 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 		} );
 		document.dispatchEvent( event );
 
-		postMessageToAngieIframe( {
+		postMessageToInstance( instance, {
 			type: MessageEventType.ANGIE_SIDEBAR_TOGGLED,
 			payload: { state: shouldOpen ? 'opened' : 'closed' },
 		} );
@@ -255,7 +263,7 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 
 let sidebarToggleMessageListenerAttached = false;
 
-export function setupMessageListener(): void {
+export function setupMessageListener( instance: AppState = appState ): void {
 	if ( sidebarToggleMessageListenerAttached ) {
 		return;
 	}
@@ -267,8 +275,12 @@ export function setupMessageListener(): void {
 			return;
 		}
 
-		const iframeOrigin = appState.iframeUrlObject?.origin;
-		if ( iframeOrigin && event.origin !== iframeOrigin ) {
+		const iframeOrigin = instance.iframeUrlObject?.origin;
+		const isTrusted = iframeOrigin
+			? isTrustedIframeMessage( event, iframeOrigin, instance.iframe )
+			: isFromIframe( event, instance.iframe );
+
+		if ( ! isTrusted ) {
 			return;
 		}
 
@@ -287,6 +299,7 @@ export function setupMessageListener(): void {
 type InitAngieSidebarOptions = {
 	onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void;
 	skipDefaultCss?: boolean;
+	instance?: AppState;
 };
 
 export function initAngieSidebar( options?: InitAngieSidebarOptions ): void {
@@ -294,9 +307,11 @@ export function initAngieSidebar( options?: InitAngieSidebarOptions ): void {
 		injectCSS();
 	}
 
+	const instance = options?.instance ?? appState;
+
 	if ( typeof window !== 'undefined' ) {
-		window.toggleAngieSidebar = createToggleSidebarFunction( options?.onToggle );
-		setupMessageListener();
+		window.toggleAngieSidebar = createToggleSidebarFunction( options?.onToggle, instance );
+		setupMessageListener( instance );
 	}
 }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -30,6 +30,17 @@ describe('utils', () => {
       expect(mockSidebarContainer.getAttribute('aria-hidden')).toBe('true');
       expect(mockIframe.getAttribute('tabindex')).toBe('-1');
     });
+
+    it('should target the given container instead of the shared default', () => {
+      const otherContainer = document.createElement('div');
+      otherContainer.id = 'container-b';
+      document.body.appendChild(otherContainer);
+
+      toggleAngieSidebar(mockIframe, false, 'container-b');
+
+      expect(otherContainer.getAttribute('aria-hidden')).toBe('true');
+      expect(mockSidebarContainer.hasAttribute('aria-hidden')).toBe(false);
+    });
   });
 
   describe('isMobile', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,11 @@
 import { appState } from './config';
 
-export const toggleAngieSidebar = ( iframe: HTMLIFrameElement, isOpen: boolean ) => {
-	const sidebarContainer = document.getElementById( appState.containerId );
+export const toggleAngieSidebar = (
+	iframe: HTMLIFrameElement,
+	isOpen: boolean,
+	containerId: string = appState.containerId
+) => {
+	const sidebarContainer = document.getElementById( containerId );
 	if ( sidebarContainer ) {
 		sidebarContainer.setAttribute( 'aria-hidden', isOpen ? 'false' : 'true' );
 	}
@@ -13,6 +17,31 @@ export const toggleAngieSidebar = ( iframe: HTMLIFrameElement, isOpen: boolean )
 		iframe.setAttribute( 'tabindex', '-1' );
 	}
 };
+
+/**
+ * Two instances on a page usually share one iframe origin, so `event.origin` cannot tell
+ * their iframes apart. The source window can.
+ *
+ * Returns true when there is nothing to compare against, so single-instance hosts behave
+ * exactly as before.
+ */
+export const isFromIframe = ( event: MessageEvent, iframe: HTMLIFrameElement | null ) => {
+	const ownWindow = iframe?.contentWindow;
+
+	if ( ! ownWindow || ! event.source ) {
+		return true;
+	}
+
+	return event.source === ownWindow;
+};
+
+export const isTrustedIframeMessage = (
+	event: MessageEvent,
+	iframeOrigin: string | undefined,
+	iframe: HTMLIFrameElement | null
+): boolean => event.origin === iframeOrigin && isFromIframe( event, iframe );
+
+export const generateInstanceId = (): string => Math.random().toString( 36 ).substring( 2, 8 );
 
 export const isMobile = () => {
 	return window.screen.availWidth <= 768;


### PR DESCRIPTION
## Summary
- Add `host.instanceId` and boot guards (one sidebar layout, unique container/id)
- Route `triggerAngie` by instance; auto-suffix default toggle selectors for extra instances
- Add three-instance demo, README docs, and bump version to **1.6.0**

Stacked on #PR1 — merge the base infra PR first.

## Test plan
- [x] `npm test` (208 tests, includes integration test)
- [x] `npm run build`
- [ ] Open `demo/load-sidebar-v2-multi-instance/` — sidebar + two floating chats side by side
- [ ] Verify boot throws on duplicate container id or second sidebar layout
- [ ] Verify stable `host.instanceId` appears in iframe URL and element id


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Enable multiple independent Angie SDK instances on one page—each with separate iframes, config, and message routing. Prior design assumed singleton; now supporting sidebar + floating chat combos or multi-chat layouts.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `src/instance-registry.ts` | New registry; tracks instances, routes messages by `instanceId`, prevents conflicts (duplicate container/layout ids) |
| `src/angie-iframe-utils.ts` | Refactored to `postMessageToInstance(instance, msg)` instead of global `postMessageToAngieIframe()`; added origin/iframe validation |
| `src/config.ts` | `AppState` now holds `instanceId`, `layout`, `iframeElementId`; factory fn replaces object literal |
| `src/load-sidebar-v2/boot-sidebar.ts` | Creates instances via registry, validates no duplicate sidebar layouts, passes instance through pipeline |
| `src/load-sidebar-v2/{chat-toggle,layouts,shell}.ts` | Accept instance param, route iframe messages by `event.source` not just origin |
| `src/sidebar.ts`, `src/iframe.ts` | Thread instance through storage keys, resize handlers, toggle listeners; legacy globals still target first instance |
| `demo/load-sidebar-v2-multi-instance/` | New demo: 1 sidebar + 2 floating chats on one page |
| Tests | Added integration + unit tests for multi-instance routing, message disambiguation |

## 3. How It Works

1. **Instance creation**: `bootSidebar()` calls `createAngieInstance(args)`, which reuses shared `appState` for first instance (backward-compat), creates new state objects for extras. Registers in module-level `instances[]` array.

2. **Message routing**: 
   - Host→SDK: `event.origin` + `event.source` (iframe contentWindow) disambiguate when multiple iframes share same origin.
   - Host→Host: `event.data.payload.instanceId` routes requests; if target instance has no iframe, first iframe owner answers (editor use case).
   - SDK→Host: Each instance calls `postMessageToInstance(instance, msg)` which looks up its iframe + origin, not global singleton.

3. **Isolation**: Each instance gets unique `iframeElementId` (default `angie-iframe-<uuid>`), `containerId`, `layout`. CSS style tags scoped per container. Toggle buttons have unique selectors. Storage keys (sidebar state/width) shared only because only one sidebar allowed.

4. **Validation**: Boot throws if (a) second sidebar layout, (b) duplicate container id, (c) duplicate instanceId. Prevents configuration accidents.

5. **Backward compat**: `window.toggleAngieSidebar`, `getAngieIframe()` still target first instance. Legacy code unaffected.

## 4. Risks

**Message misrouting in dense multi-iframe scenarios**: Two instances at same origin but different content windows; if `event.source` validation fails (malformed messages, cross-origin frames), messages could reach wrong instance. *Mitigation*: `isTrustedIframeMessage()` + `isFromIframe()` helpers validate both origin and source; tests cover cross-iframe rejection.

**Storage pollution**: Sidebar state keys unprefixed (design doc says only one sidebar per page). If constraint violated, open state collides. *Mitigation*: Boot-time validation prevents second sidebar; tests enforce.

**Legacy caller confusion**: Code outside SDK using `getAngieIframe()` or `postMessageToAngieIframe()` (removed) gets first instance. Silent wrong-instance bug if not first. *Mitigation*: JSDoc warns; functions only removed from exports when internal callers migrated; demo shows multi-instance pattern.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
