### PR TITLE
feat: add instance utils and thread AppState through core modules

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -499,7 +499,35 @@ describe('AngieMcpSdk', () => {
         iframe: { contentWindow: { postMessage: iframePostMessage } },
         iframeOrigin: 'https://angie.elementor.com',
       });
-      const widgetConfig = { title: 'Custom Title' };
+      const widgetConfig = {
+        title: 'Custom Title',
+        subtitle: 'Custom Subtitle',
+        promptLibrary: { enabled: false },
+        fileUpload: { enabled: false },
+        feedback: { enabled: false },
+        featuredMcpServer: 'wp-search',
+        suggestions: { items: [{ label: 'Search', value: 'search for' }] },
+      };
+
+      await sdk.loadSidebar({ widgetConfig });
+
+      expect(iframePostMessage).toHaveBeenCalledWith(
+        { type: 'sdk-widget-config', payload: widgetConfig },
+        'https://angie.elementor.com',
+      );
+    });
+
+    it('should send widget config with modeSwitcher and closeButton via postMessage', async () => {
+      const iframePostMessage = jest.fn();
+      mockOpenIframe.mockResolvedValue({
+        iframe: { contentWindow: { postMessage: iframePostMessage } },
+        iframeOrigin: 'https://angie.elementor.com',
+      });
+      const widgetConfig = {
+        title: 'Custom Title',
+        modeSwitcher: { enabled: true, default: 'plan' as const },
+        closeButton: 'collapse' as const,
+      };
 
       await sdk.loadSidebar({ widgetConfig });
 

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -9,9 +9,6 @@ jest.mock('./angie-detector');
 jest.mock('./registration-queue');
 jest.mock('./client-manager');
 jest.mock('./browser-context-transport');
-jest.mock('./angie-iframe-utils', () => ({
-  postMessageToAngieIframe: jest.fn(),
-}));
 jest.mock('./sidebar', () => ({
   initAngieSidebar: jest.fn(),
 }));
@@ -34,7 +31,6 @@ describe('AngieMcpSdk', () => {
   let mockBrowserContextTransport: any;
   let mockInitAngieSidebar: any;
   let mockOpenIframe: any;
-  let mockPostMessageToAngieIframe: any;
   let addEventListenerSpy: ReturnType<typeof jest.spyOn>;
 
   beforeEach(() => {
@@ -67,7 +63,6 @@ describe('AngieMcpSdk', () => {
     mockInitAngieSidebar = require('./sidebar').initAngieSidebar as jest.MockedFunction<any>;
     mockOpenIframe = require('./iframe').openIframe as jest.MockedFunction<any>;
     mockOpenIframe.mockResolvedValue(undefined);
-    mockPostMessageToAngieIframe = require('./angie-iframe-utils').postMessageToAngieIframe as jest.MockedFunction<any>;
 
     // Mock the constructors
     (require('./angie-detector') as any).AngieDetector.mockImplementation(() => mockAngieDetector);
@@ -158,8 +153,6 @@ describe('AngieMcpSdk', () => {
         'Server instance is required'
       );
     });
-
-
 
     it('should handle registration errors', async () => {
       // Arrange
@@ -303,8 +296,6 @@ describe('AngieMcpSdk', () => {
       expect(mockServer.connect).toHaveBeenCalled();
     });
 
-
-
     it('should handle server init request with non-existent server', () => {
       // Arrange
       mockRegistrationQueue.getAll.mockReturnValue([]);
@@ -326,8 +317,6 @@ describe('AngieMcpSdk', () => {
       // Assert
       expect(mockBrowserContextTransport).not.toHaveBeenCalled();
     });
-
-
 
     it('should handle server init request with server connection error', () => {
       // Arrange
@@ -505,51 +494,31 @@ describe('AngieMcpSdk', () => {
     });
 
     it('should send widget config via postMessage when provided', async () => {
-      // Arrange
-      const widgetConfig = {
-        title: 'Custom Title',
-        subtitle: 'Custom Subtitle',
-        promptLibrary: { enabled: false },
-        fileUpload: { enabled: false },
-        feedback: { enabled: false },
-        featuredMcpServer: 'wp-search',
-        suggestions: { items: [{ label: 'Search', value: 'search for' }] },
-      };
+      const iframePostMessage = jest.fn();
+      mockOpenIframe.mockResolvedValue({
+        iframe: { contentWindow: { postMessage: iframePostMessage } },
+        iframeOrigin: 'https://angie.elementor.com',
+      });
+      const widgetConfig = { title: 'Custom Title' };
 
-      // Act
       await sdk.loadSidebar({ widgetConfig });
 
-      // Assert
-      expect(mockPostMessageToAngieIframe).toHaveBeenCalledWith({
-        type: 'sdk-widget-config',
-        payload: widgetConfig,
-      });
-    });
-
-    it('should send widget config with modeSwitcher and closeButton via postMessage', async () => {
-      // Arrange
-      const widgetConfig = {
-        title: 'Custom Title',
-        modeSwitcher: { enabled: true, default: 'plan' as const },
-        closeButton: 'collapse' as const,
-      };
-
-      // Act
-      await sdk.loadSidebar({ widgetConfig });
-
-      // Assert
-      expect(mockPostMessageToAngieIframe).toHaveBeenCalledWith({
-        type: 'sdk-widget-config',
-        payload: widgetConfig,
-      });
+      expect(iframePostMessage).toHaveBeenCalledWith(
+        { type: 'sdk-widget-config', payload: widgetConfig },
+        'https://angie.elementor.com',
+      );
     });
 
     it('should not send widget config when not provided', async () => {
-      // Act
+      const iframePostMessage = jest.fn();
+      mockOpenIframe.mockResolvedValue({
+        iframe: { contentWindow: { postMessage: iframePostMessage } },
+        iframeOrigin: 'https://angie.elementor.com',
+      });
+
       await sdk.loadSidebar();
 
-      // Assert
-      expect(mockPostMessageToAngieIframe).not.toHaveBeenCalled();
+      expect(iframePostMessage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -1,5 +1,4 @@
 import type { Logger } from '@elementor/angie-logger';
-import { postMessageToAngieIframe } from './angie-iframe-utils';
 import { AngieDetector } from './angie-detector';
 import { BrowserContextTransport } from './browser-context-transport';
 import { ClientManager } from './client-manager';
@@ -9,6 +8,7 @@ import { openIframe } from './iframe';
 import { handlePostConsentRedirect } from './oauth';
 import { initAngieSidebar } from './sidebar';
 import { RegistrationQueue } from './registration-queue';
+import { generateInstanceId } from './utils';
 import { bootSidebar } from './load-sidebar-v2/boot-sidebar';
 import type { LoadSidebarV2Options } from './load-sidebar-v2/config';
 import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerConfig, AngieServerConfig, AngieServerType, MessageEventType, ServerRegistration, AngieTriggerRequest, AngieTriggerResponse } from './types';
@@ -85,7 +85,7 @@ export class AngieMcpSdk {
   private sidebarV2BootPromise: Promise<void> | null = null;
 
   constructor() {
-    this.instanceId = Math.random().toString(36).substring(2, 8);
+    this.instanceId = generateInstanceId();
     this.logger = createChildLogger({ instanceId: this.instanceId });
     this.logger.log('Constructor called - initializing SDK');
     this.angieDetector = new AngieDetector();
@@ -104,11 +104,15 @@ export class AngieMcpSdk {
     const { widgetConfig, ...rest } = options || {};
     const config = { ...DEFAULT_OPTIONS, ...rest };
     appState.containerId = config.containerId;
+    appState.instanceId = this.instanceId;
     initAngieSidebar( { skipDefaultCss: config.skipDefaultCss } );
-    await openIframe( config );
+    const opened = await openIframe( config );
 
-    if ( widgetConfig ) {
-      postMessageToAngieIframe( { type: 'sdk-widget-config', payload: widgetConfig } );
+    if ( opened && widgetConfig ) {
+      opened.iframe.contentWindow?.postMessage(
+        { type: 'sdk-widget-config', payload: widgetConfig },
+        opened.iframeOrigin,
+      );
     }
 
     this.setupPromptHashDetection();

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,15 +1,25 @@
 export const DEFAULT_CONTAINER_ID = 'angie-sidebar-container';
 
+export const DEFAULT_IFRAME_ELEMENT_ID = 'angie-iframe';
+
 export type AppState = {
 	open: boolean;
 	iframe: HTMLIFrameElement | null;
 	iframeUrlObject: URL | null;
 	containerId: string;
+	instanceId: string;
+	layout: string;
+	iframeElementId: string;
 };
 
-export const appState: AppState = {
+export const createDefaultAppState = (): AppState => ( {
 	open: false,
-	iframe: null as HTMLIFrameElement | null,
-	iframeUrlObject: null as URL | null,
+	iframe: null,
+	iframeUrlObject: null,
 	containerId: DEFAULT_CONTAINER_ID,
-};
+	instanceId: '',
+	layout: '',
+	iframeElementId: DEFAULT_IFRAME_ELEMENT_ID,
+} );
+
+export const appState: AppState = createDefaultAppState();

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -1,14 +1,13 @@
 import { addLocalStorageListener } from './localStorage';
-import { appState } from './config';
+import { appState, type AppState } from './config';
 import { createChildLogger } from './logger';
 import { listenToOAuthFromIframe, setupOidcLoginFlowHandler } from './oauth';
 import { listenToSDK } from './sdk';
 import { loadWidth } from './sidebar';
 import { HostEventType, MessageEventType } from './types';
-import { isMobile, isSafeUrl, sendSuccessMessage, toggleAngieSidebar } from './utils';
+import { isFromIframe, isMobile, isSafeUrl, sendSuccessMessage, toggleAngieSidebar } from './utils';
 import { ANGIE_SDK_VERSION } from './version';
 import { openSaaSPage } from './openSaaSPage';
-import { setAngieIframeRef } from './angie-iframe-utils';
 import type { HostEmbeddedConfigPayload } from './load-sidebar-v2/config';
 
 type OpenIframeProps = {
@@ -56,14 +55,24 @@ export const disableNavigationPrevention = async (): Promise<void> => {
 	}
 };
 
-export const openIframe = async ( props: OpenIframeProps ) => {
+export type OpenIframeResult = {
+	iframe: HTMLIFrameElement;
+	iframeOrigin: string;
+};
+
+export const openIframe = async (
+	props: OpenIframeProps,
+	instance: AppState = appState
+): Promise<OpenIframeResult | undefined> => {
 	if ( isMobile() ) {
 		iframeLogger.log( 'Mobile detected, skipping iframe injection' );
 		return;
 	}
 
+	const containerId = instance.containerId;
+
 	// Check if sidebar container exists
-	let sidebarContainer = document.getElementById( appState.containerId );
+	let sidebarContainer = document.getElementById( containerId );
 
 	if ( ! sidebarContainer ) {
 		// Use MutationObserver for more efficient DOM watching
@@ -74,7 +83,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 			// First try with shorter polling interval for immediate cases
 			let attempts = 0;
 			const quickCheck = setInterval( () => {
-				sidebarContainer = document.getElementById( appState.containerId );
+				sidebarContainer = document.getElementById( containerId );
 				attempts++;
 				if ( sidebarContainer || attempts > 20 ) { // Check for 2 seconds max with 100ms intervals
 					clearInterval( quickCheck );
@@ -95,7 +104,7 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 				}
 
 				const observer = new MutationObserver( () => {
-					sidebarContainer = document.getElementById( appState.containerId );
+					sidebarContainer = document.getElementById( containerId );
 					if ( sidebarContainer ) {
 						observer.disconnect();
 						resolve();
@@ -161,15 +170,16 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 		uiTheme: props.uiTheme,
 		isRTL: props.isRTL,
 		sdkVersion: ANGIE_SDK_VERSION,
+		iframeElementId: instance.iframeElementId,
+		instanceId: instance.instanceId,
 	} );
 
-	appState.iframe = iframe;
-	appState.iframeUrlObject = iframeUrlObject;
-	setAngieIframeRef( iframe );
+	instance.iframe = iframe;
+	instance.iframeUrlObject = iframeUrlObject;
 
-	addLocalStorageListener();
+	addLocalStorageListener( instance );
 
-	listenToSDK( appState );
+	listenToSDK( instance );
 
 	listenToOAuthFromIframe();
 	setupOidcLoginFlowHandler();
@@ -182,16 +192,20 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 			return;
 		}
 
-		if ( event?.data?.type === MessageEventType.ANGIE_CHAT_TOGGLE ) {
-			appState.open = event.data.open;
+		if ( ! isFromIframe( event, iframe ) ) {
+			return;
+		}
 
-			if ( appState.iframe ) {
-				toggleAngieSidebar( appState.iframe, appState.open );
+		if ( event?.data?.type === MessageEventType.ANGIE_CHAT_TOGGLE ) {
+			instance.open = event.data.open;
+
+			if ( instance.iframe ) {
+				toggleAngieSidebar( instance.iframe, instance.open, instance.containerId );
 			}
 		} else if ( event?.data?.type === MessageEventType.ANGIE_STUDIO_TOGGLE ) {
 			const isStudioOpen = event.data.isStudioOpen;
 
-			if ( ! appState.iframe ) {
+			if ( ! instance.iframe ) {
 				return;
 			}
 
@@ -241,4 +255,9 @@ export const openIframe = async ( props: OpenIframeProps ) => {
 		}
 
 	} );
+
+	return {
+		iframe,
+		iframeOrigin: iframeUrlObject.origin,
+	};
 };

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { appState } from './config';
+import { addLocalStorageListener } from './localStorage';
+import { HostLocalStorageEventType } from './types';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const emitMessage = ( event: Partial<MessageEvent> ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), event ) );
+};
+
+describe( 'localStorage', () => {
+	beforeEach( () => {
+		window.localStorage.clear();
+		jest.clearAllMocks();
+		appState.iframe = null;
+		appState.iframeUrlObject = null;
+	} );
+
+	it( 'should store a value sent by its own iframe', () => {
+		const ownWindow = {} as Window;
+		appState.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		appState.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
+
+		addLocalStorageListener( appState );
+		emitMessage( {
+			origin: ANGIE_ORIGIN,
+			source: ownWindow,
+			data: { type: HostLocalStorageEventType.SET, key: 'angie_test', value: 'yes' },
+		} );
+
+		expect( window.localStorage.getItem( 'angie_test' ) ).toBe( 'yes' );
+	} );
+
+	it( 'should ignore a message sent by another iframe window', () => {
+		appState.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		appState.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+
+		addLocalStorageListener( appState );
+		emitMessage( {
+			origin: ANGIE_ORIGIN,
+			source: {} as Window,
+			data: { type: HostLocalStorageEventType.SET, key: 'angie_test', value: 'yes' },
+		} );
+
+		expect( window.localStorage.getItem( 'angie_test' ) ).toBeNull();
+	} );
+} );

--- a/src/localStorage.ts
+++ b/src/localStorage.ts
@@ -1,9 +1,10 @@
-import { appState } from "./config";
+import { appState, type AppState } from "./config";
 import { HostLocalStorageEventType } from "./types";
+import { isTrustedIframeMessage } from "./utils";
 
-export const addLocalStorageListener = () => {
+export const addLocalStorageListener = ( instance: AppState = appState ) => {
 	window.addEventListener( 'message', ( event: MessageEvent ) => {
-		if ( event.origin !== appState.iframeUrlObject?.origin ) {
+		if ( ! isTrustedIframeMessage( event, instance.iframeUrlObject?.origin, instance.iframe ) ) {
 			return;
 		}
 

--- a/src/openSaaSPage.test.ts
+++ b/src/openSaaSPage.test.ts
@@ -112,6 +112,60 @@ describe('openSaaSPage', () => {
       expect(mockIframe.setAttribute).toHaveBeenCalledWith('allow', 'clipboard-write; clipboard-read');
     });
 
+    it('should build the iframe instanceId from the sdk instance id', async () => {
+      const messagePromise = openSaaSPage({
+        ...defaultProps,
+        instanceId: 'bbbbbb',
+      });
+
+      const messageListener = mockWindow.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === 'message'
+      )?.[1];
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        data: { type: HostEventType.ANGIE_READY },
+      });
+
+      const result = await messagePromise;
+      const appendSpy = result.iframeUrlObject.searchParams.append as jest.MockedFunction<any>;
+      const instanceIdCall = appendSpy.mock.calls.find((call: any[]) => call[0] === 'instanceId');
+
+      expect(instanceIdCall?.[1]).toBe('test-page-bbbbbb');
+    });
+
+    it('should ignore a ready message coming from a different iframe', async () => {
+      const ownWindow = { postMessage: jest.fn() };
+      Object.defineProperty(mockIframe, 'contentWindow', { value: ownWindow, writable: true });
+
+      let resolved = false;
+      const messagePromise = openSaaSPage(defaultProps).then((result) => {
+        resolved = true;
+        return result;
+      });
+
+      const messageListener = mockWindow.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === 'message'
+      )?.[1];
+
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        source: { postMessage: jest.fn() },
+        data: { type: HostEventType.ANGIE_READY },
+      });
+      await Promise.resolve();
+
+      expect(resolved).toBe(false);
+
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        source: ownWindow,
+        data: { type: HostEventType.ANGIE_READY },
+      });
+      await messagePromise;
+
+      expect(resolved).toBe(true);
+    });
+
     it('should apply CSS styles correctly', async () => {
       const cssProps = {
         width: '400px',

--- a/src/openSaaSPage.test.ts
+++ b/src/openSaaSPage.test.ts
@@ -60,6 +60,7 @@ describe('openSaaSPage', () => {
       setAttribute: jest.fn(),
       id: '',
       getAttribute: jest.fn(),
+      contentWindow: { postMessage: jest.fn() },
     } as any;
 
     mockDocument = {
@@ -101,6 +102,7 @@ describe('openSaaSPage', () => {
       
       messageListener({
         origin: 'https://angie.elementor.com',
+        source: mockIframe.contentWindow,
         data: { type: HostEventType.ANGIE_READY },
       });
 
@@ -123,6 +125,7 @@ describe('openSaaSPage', () => {
       )?.[1];
       messageListener({
         origin: 'https://angie.elementor.com',
+        source: mockIframe.contentWindow,
         data: { type: HostEventType.ANGIE_READY },
       });
 
@@ -182,6 +185,7 @@ describe('openSaaSPage', () => {
       )?.[1];
       messageListener({
         origin: 'https://angie.elementor.com',
+        source: mockIframe.contentWindow,
         data: { type: HostEventType.ANGIE_READY },
       });
 

--- a/src/openSaaSPage.ts
+++ b/src/openSaaSPage.ts
@@ -1,4 +1,5 @@
 import { HostEventType } from "./types";
+import { generateInstanceId, isTrustedIframeMessage } from "./utils";
 import type { HostEmbeddedConfigPayload } from "./load-sidebar-v2/config";
 
 type OpenSaaSPageInput = {
@@ -13,6 +14,8 @@ type OpenSaaSPageInput = {
 	uiTheme?: string;
 	isRTL?: boolean;
 	sdkVersion: string;
+	iframeElementId?: string;
+	instanceId?: string;
 };
 
 type OpenSaaSPageOutput = {
@@ -24,7 +27,8 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 	const origin = props.origin;
 	const pathUrl = new URL( props.path, origin );
 	// e.g. "text-to-elementor-vm2qhj"
-	const instanceId = pathUrl.pathname.slice( 1 ).replace( /\//, '--' ) + '-' + Math.random().toString( 36 ).substring( 7 );
+	const instanceSuffix = props.instanceId || generateInstanceId();
+	const instanceId = pathUrl.pathname.slice( 1 ).replace( /\//, '--' ) + '-' + instanceSuffix;
 
 	return new Promise( ( resolve ) => {
 		const iframeUrlObject = new URL( origin );
@@ -64,7 +68,7 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 		};
 
 		const onMessage = async ( event: MessageEvent ) => {
-			if ( event.origin !== iframeUrlObject.origin ) {
+			if ( ! isTrustedIframeMessage( event, iframeUrlObject.origin, iframe ) ) {
 				return;
 			}
 
@@ -91,7 +95,7 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 
 
 		iframe.setAttribute( 'src', iframeUrlObject.href );
-		iframe.id = 'angie-iframe';
+		iframe.id = props.iframeElementId || 'angie-iframe';
 		iframe.setAttribute( 'frameborder', '0' );
 		iframe.setAttribute( 'scrolling', 'no' );
 		iframe.setAttribute( 'style', Object.entries( css ).map( ( [ key, value ] ) => `${ key }: ${ value }` ).join( '; ' ) );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -19,11 +19,11 @@ export interface ClientCreationRequest {
 	capabilities?: ServerCapabilities;
 }
 
-export const listenToSDK = ( appState: AppState ) => {
+export const listenToSDK = ( instance: AppState ) => {
 	// Access global timing instance for SDK performance tracking
 	window.addEventListener( 'message', async ( event ) => {
 		const isSameOrigin = event.origin === window.location.origin;
-		const isIframe = event.origin === appState.iframeUrlObject?.origin;
+		const isIframe = event.origin === instance.iframeUrlObject?.origin;
 		if ( ! isSameOrigin && ! isIframe ) {
 			return;
 		}
@@ -66,8 +66,8 @@ export const listenToSDK = ( appState: AppState ) => {
 						},
 						timestamp: Date.now(),
 					};
-					if ( appState.iframe ) {
-						appState.iframe.contentWindow?.postMessage( message, appState.iframeUrlObject?.origin || '', [ channel.port2 ] );
+					if ( instance.iframe ) {
+						instance.iframe.contentWindow?.postMessage( message, instance.iframeUrlObject?.origin || '', [ channel.port2 ] );
 					} else {
 						throw new Error( 'Iframe not found' );
 					}
@@ -83,8 +83,8 @@ export const listenToSDK = ( appState: AppState ) => {
 				try {
 					const { requestId, prompt, context, options } = event.data.payload;
 
-					if ( appState.iframe ) {
-						appState.iframe.contentWindow?.postMessage( {
+					if ( instance.iframe ) {
+						instance.iframe.contentWindow?.postMessage( {
 							type: MessageEventType.SDK_TRIGGER_ANGIE,
 							payload: {
 								requestId,
@@ -92,7 +92,7 @@ export const listenToSDK = ( appState: AppState ) => {
 								context,
 								options,
 							},
-						}, appState.iframeUrlObject?.origin || '' );
+						}, instance.iframeUrlObject?.origin || '' );
 					} else {
 						throw new Error( 'Iframe not found' );
 					}

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -1,5 +1,5 @@
 import { createChildLogger } from './logger';
-import { sendSuccessMessage } from './utils';
+import { isTrustedIframeMessage, sendSuccessMessage } from './utils';
 import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { MessageEventType } from './types';
 import { AppState } from './config';
@@ -23,7 +23,11 @@ export const listenToSDK = ( instance: AppState ) => {
 	// Access global timing instance for SDK performance tracking
 	window.addEventListener( 'message', async ( event ) => {
 		const isSameOrigin = event.origin === window.location.origin;
-		const isIframe = event.origin === instance.iframeUrlObject?.origin;
+		const isIframe = isTrustedIframeMessage(
+			event,
+			instance.iframeUrlObject?.origin,
+			instance.iframe,
+		);
 		if ( ! isSameOrigin && ! isIframe ) {
 			return;
 		}

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -158,14 +158,22 @@ describe('sidebar', () => {
 
   describe('setupMessageListener', () => {
     const trustedOrigin = 'https://angie.example.com';
+    let ownWindow: Window;
 
     beforeEach(() => {
       const sidebarContainer = document.createElement('div');
       sidebarContainer.id = 'angie-sidebar-container';
       document.body.appendChild(sidebarContainer);
+      ownWindow = {} as Window;
       appState.iframeUrlObject = new URL( 'https://angie.example.com/angie/embedded' );
+      appState.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
       initAngieSidebar();
       ( global.window as any ).toggleAngieSidebar = jest.fn();
+    });
+
+    afterEach(() => {
+      appState.iframe = null;
+      appState.iframeUrlObject = null;
     });
 
     it( 'should ignore toggleAngieSidebar messages from untrusted origins', () => {
@@ -184,6 +192,7 @@ describe('sidebar', () => {
 
       window.dispatchEvent( new MessageEvent( 'message', {
         origin: trustedOrigin,
+        source: ownWindow,
         data: { type: 'toggleAngieSidebar', payload: { force: true } },
       } ) );
 
@@ -220,6 +229,7 @@ describe('sidebar', () => {
 
       window.dispatchEvent( new MessageEvent( 'message', {
         origin: trustedOrigin,
+        source: ownWindow,
         data: { type: 'toggleAngieSidebar', payload: { force: false } },
         ports: [ port ],
       } ) );

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -23,6 +23,7 @@ jest.mock('./iframe', () => ({
 }));
 
 jest.mock('./utils', () => ({
+  ...(jest.requireActual('./utils') as object),
   waitForDocumentReady: jest.fn().mockImplementation(() => Promise.resolve()),
   sendSuccessMessage: jest.fn(),
   toggleAngieSidebar: jest.fn(),
@@ -189,6 +190,30 @@ describe('sidebar', () => {
       expect( toggle ).toHaveBeenCalledWith( true, undefined );
     } );
 
+    it( 'should ignore a toggle message sent by a different instance iframe', () => {
+      const toggle = ( global.window as any ).toggleAngieSidebar as jest.Mock;
+      const ownWindow = {} as Window;
+      appState.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: trustedOrigin,
+        source: {} as Window,
+        data: { type: 'toggleAngieSidebar', payload: { force: true } },
+      } ) );
+
+      expect( toggle ).not.toHaveBeenCalled();
+
+      window.dispatchEvent( new MessageEvent( 'message', {
+        origin: trustedOrigin,
+        source: ownWindow,
+        data: { type: 'toggleAngieSidebar', payload: { force: true } },
+      } ) );
+
+      expect( toggle ).toHaveBeenCalledWith( true, undefined );
+
+      appState.iframe = null;
+    } );
+
     it( 'should ack toggleAngieSidebar requests over MessagePort', () => {
       const { sendSuccessMessage } = require( './utils' ) as { sendSuccessMessage: jest.Mock };
       const port = { postMessage: jest.fn() } as unknown as MessagePort;
@@ -202,4 +227,5 @@ describe('sidebar', () => {
       expect( sendSuccessMessage ).toHaveBeenCalledWith( port );
     } );
   } );
+
 });

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -227,5 +227,4 @@ describe('sidebar', () => {
       expect( sendSuccessMessage ).toHaveBeenCalledWith( port );
     } );
   } );
-
 });

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,9 +1,9 @@
 import { postMessageToAngieIframe } from "./angie-iframe-utils";
-import { appState } from "./config";
+import { appState, type AppState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
 import { isOidcFlowInUrl } from "@elementor/oidc-auth";
-import { sendSuccessMessage, toggleAngieSidebar as setIframeAccessibility, waitForDocumentReady } from "./utils";
+import { isFromIframe, isTrustedIframeMessage, sendSuccessMessage, toggleAngieSidebar as setIframeAccessibility, waitForDocumentReady } from "./utils";
 import sidebarCssContent from "./sidebar.css?raw";
 
 const sidebarLogger = createChildLogger( 'sidebar' );
@@ -34,6 +34,11 @@ function injectCSS(): void {
 export const ANGIE_SIDEBAR_STATE_OPEN = 'open';
 export const ANGIE_SIDEBAR_STATE_CLOSED = 'closed';
 
+// Only the sidebar layout persists state, and only one sidebar may run on a page, so
+// these keys never collide and stay unprefixed.
+const STATE_STORAGE_KEY = 'angie_sidebar_state';
+const WIDTH_STORAGE_KEY = 'angie_sidebar_width';
+
 const SIDE_MENU_WIDTH = 40;
 const MIN_WIDTH = 310 + SIDE_MENU_WIDTH;
 const MAX_WIDTH = 550 + SIDE_MENU_WIDTH;
@@ -52,7 +57,7 @@ export function loadWidth(): number {
 	}
 
 	try {
-		const savedWidth = window.localStorage.getItem( 'angie_sidebar_width' );
+		const savedWidth = window.localStorage.getItem( WIDTH_STORAGE_KEY );
 		if ( savedWidth ) {
 			const width = parseInt( savedWidth, 10 );
 			if ( width >= MIN_WIDTH && width <= MAX_WIDTH ) {
@@ -69,10 +74,10 @@ export function getAngieSidebarSavedState(): AngieSidebarState | null {
 	if ( typeof window === 'undefined' ) {
 		return null;
 	}
-	return localStorage.getItem( 'angie_sidebar_state' ) as AngieSidebarState | null;
+	return localStorage.getItem( STATE_STORAGE_KEY ) as AngieSidebarState | null;
 }
 
-export function handleFocus( isOpen: boolean, delay: number ): void {
+export function handleFocus( isOpen: boolean, delay: number, instance: AppState = appState ): void {
 	if ( isOpen ) {
 		setTimeout( function() {
 			postMessageToAngieIframe( {
@@ -84,7 +89,7 @@ export function handleFocus( isOpen: boolean, delay: number ): void {
 
 export function saveState( state: string ): void {
 	try {
-		localStorage.setItem( 'angie_sidebar_state', state );
+		localStorage.setItem( STATE_STORAGE_KEY, state );
 	} catch ( e ) {
 		sidebarLogger.warn( 'localStorage not available' );
 	}
@@ -92,7 +97,7 @@ export function saveState( state: string ): void {
 
 export function saveWidth( width: number ): void {
 	try {
-		localStorage.setItem( 'angie_sidebar_width', width.toString() );
+		localStorage.setItem( WIDTH_STORAGE_KEY, width.toString() );
 	} catch ( e ) {
 		sidebarLogger.warn( 'localStorage not available' );
 	}
@@ -105,7 +110,7 @@ export function applyWidth( width: number ): void {
 export function forceSidebarClosedDuringOAuth(): void {
 	applyState( ANGIE_SIDEBAR_STATE_CLOSED );
 	try {
-		localStorage.setItem( 'angie_sidebar_state', ANGIE_SIDEBAR_STATE_CLOSED );
+		localStorage.setItem( STATE_STORAGE_KEY, ANGIE_SIDEBAR_STATE_CLOSED );
 	} catch ( e ) {
 		sidebarLogger.warn( 'localStorage not available' );
 	}
@@ -126,8 +131,8 @@ export function applyState( state: AngieSidebarState ): void {
 	}
 }
 
-export function initializeResize(): void {
-	const sidebar = document.getElementById( appState.containerId );
+export function initializeResize( instance: AppState = appState ): void {
+	const sidebar = document.getElementById( instance.containerId );
 	if ( ! sidebar ) {
 		return;
 	}
@@ -202,10 +207,13 @@ export function initializeResize(): void {
 	applyWidth( savedWidth );
 }
 
-export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void ): ( force?: boolean, skipTransition?: boolean ) => void {
+export function createToggleSidebarFunction(
+	onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void,
+	instance: AppState = appState
+): ( force?: boolean, skipTransition?: boolean ) => void {
 	return function( force?: boolean, skipTransition?: boolean ): void {
 		const body = document.body;
-		const sidebar = document.getElementById( appState.containerId );
+		const sidebar = document.getElementById( instance.containerId );
 
 		if ( ! sidebar ) {
 			sidebarLogger.warn( 'Required elements not found!' );
@@ -228,12 +236,12 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 			body.classList.remove( 'angie-sidebar-active' );
 		}
 
-		if ( appState.iframe ) {
-			setIframeAccessibility( appState.iframe, shouldOpen );
+		if ( instance.iframe ) {
+			setIframeAccessibility( instance.iframe, shouldOpen, instance.containerId );
 		}
 
 		const focusDelay = skipTransition ? 0 : 300;
-		handleFocus( shouldOpen, focusDelay );
+		handleFocus( shouldOpen, focusDelay, instance );
 
 		if ( onToggle ) {
 			onToggle( shouldOpen, sidebar, skipTransition );
@@ -255,7 +263,7 @@ export function createToggleSidebarFunction( onToggle?: ( isOpen: boolean, sideb
 
 let sidebarToggleMessageListenerAttached = false;
 
-export function setupMessageListener(): void {
+export function setupMessageListener( instance: AppState = appState ): void {
 	if ( sidebarToggleMessageListenerAttached ) {
 		return;
 	}
@@ -267,8 +275,12 @@ export function setupMessageListener(): void {
 			return;
 		}
 
-		const iframeOrigin = appState.iframeUrlObject?.origin;
-		if ( iframeOrigin && event.origin !== iframeOrigin ) {
+		const iframeOrigin = instance.iframeUrlObject?.origin;
+		const isTrusted = iframeOrigin
+			? isTrustedIframeMessage( event, iframeOrigin, instance.iframe )
+			: isFromIframe( event, instance.iframe );
+
+		if ( ! isTrusted ) {
 			return;
 		}
 
@@ -287,6 +299,7 @@ export function setupMessageListener(): void {
 type InitAngieSidebarOptions = {
 	onToggle?: ( isOpen: boolean, sidebar: HTMLElement, skipTransition?: boolean ) => void;
 	skipDefaultCss?: boolean;
+	instance?: AppState;
 };
 
 export function initAngieSidebar( options?: InitAngieSidebarOptions ): void {
@@ -294,9 +307,11 @@ export function initAngieSidebar( options?: InitAngieSidebarOptions ): void {
 		injectCSS();
 	}
 
+	const instance = options?.instance ?? appState;
+
 	if ( typeof window !== 'undefined' ) {
-		window.toggleAngieSidebar = createToggleSidebarFunction( options?.onToggle );
-		setupMessageListener();
+		window.toggleAngieSidebar = createToggleSidebarFunction( options?.onToggle, instance );
+		setupMessageListener( instance );
 	}
 }
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
-import { toggleAngieSidebar, isMobile, sendSuccessMessage, sendErrorMessage, waitForDocumentReady, isSafeUrl } from './utils';
+import { toggleAngieSidebar, isMobile, sendSuccessMessage, sendErrorMessage, waitForDocumentReady, isSafeUrl, isFromIframe, isTrustedIframeMessage } from './utils';
 
 describe('utils', () => {
   let mockIframe: HTMLIFrameElement;
@@ -99,6 +99,68 @@ describe('utils', () => {
       });
 
       await expect(waitForDocumentReady()).resolves.toBeNull();
+    });
+  });
+
+  describe('isFromIframe', () => {
+    it('should return true when event.source is the iframe contentWindow', () => {
+      const fakeWindow = {} as Window;
+      const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
+      const event = { source: fakeWindow } as MessageEvent;
+
+      expect(isFromIframe(event, iframe)).toBe(true);
+    });
+
+    it('should return false when event.source is a different window', () => {
+      const fakeWindow = {} as Window;
+      const otherWindow = {} as Window;
+      const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
+      const event = { source: otherWindow } as MessageEvent;
+
+      expect(isFromIframe(event, iframe)).toBe(false);
+    });
+
+    it('should return true when iframe is null (backward-compat fallback)', () => {
+      const event = { source: {} as Window } as MessageEvent;
+
+      expect(isFromIframe(event, null)).toBe(true);
+    });
+
+    it('should return true when event.source is missing/null', () => {
+      const fakeWindow = {} as Window;
+      const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
+      const event = { source: null } as MessageEvent;
+
+      expect(isFromIframe(event, iframe)).toBe(true);
+    });
+  });
+
+  describe('isTrustedIframeMessage', () => {
+    const iframeOrigin = 'https://angie.elementor.com';
+
+    it('should return true when origin matches and source is the iframe window', () => {
+      const fakeWindow = {} as Window;
+      const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
+      const event = { origin: iframeOrigin, source: fakeWindow } as MessageEvent;
+
+      expect(isTrustedIframeMessage(event, iframeOrigin, iframe)).toBe(true);
+    });
+
+    it('should return false when origin mismatches even if source matches', () => {
+      const fakeWindow = {} as Window;
+      const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
+      const event = { origin: 'https://evil.com', source: fakeWindow } as MessageEvent;
+
+      expect(isTrustedIframeMessage(event, iframeOrigin, iframe)).toBe(false);
+    });
+
+    it('should return false when origin matches but source is a different window', () => {
+      const fakeWindow = {} as Window;
+      const otherWindow = {} as Window;
+      const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
+      const event = { origin: iframeOrigin, source: otherWindow } as MessageEvent;
+
+      expect(isTrustedIframeMessage(event, iframeOrigin, iframe)).toBe(false);
     });
   });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -120,18 +120,18 @@ describe('utils', () => {
       expect(isFromIframe(event, iframe)).toBe(false);
     });
 
-    it('should return true when iframe is null (backward-compat fallback)', () => {
+    it('should return false when iframe is null', () => {
       const event = { source: {} as Window } as MessageEvent;
 
-      expect(isFromIframe(event, null)).toBe(true);
+      expect(isFromIframe(event, null)).toBe(false);
     });
 
-    it('should return true when event.source is missing/null', () => {
+    it('should return false when event.source is missing/null', () => {
       const fakeWindow = {} as Window;
       const iframe = { contentWindow: fakeWindow } as HTMLIFrameElement;
       const event = { source: null } as MessageEvent;
 
-      expect(isFromIframe(event, iframe)).toBe(true);
+      expect(isFromIframe(event, iframe)).toBe(false);
     });
   });
 

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -30,6 +30,17 @@ describe('utils', () => {
       expect(mockSidebarContainer.getAttribute('aria-hidden')).toBe('true');
       expect(mockIframe.getAttribute('tabindex')).toBe('-1');
     });
+
+    it('should target the given container instead of the shared default', () => {
+      const otherContainer = document.createElement('div');
+      otherContainer.id = 'container-b';
+      document.body.appendChild(otherContainer);
+
+      toggleAngieSidebar(mockIframe, false, 'container-b');
+
+      expect(otherContainer.getAttribute('aria-hidden')).toBe('true');
+      expect(mockSidebarContainer.hasAttribute('aria-hidden')).toBe(false);
+    });
   });
 
   describe('isMobile', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,18 +18,12 @@ export const toggleAngieSidebar = (
 	}
 };
 
-/**
- * Two instances on a page usually share one iframe origin, so `event.origin` cannot tell
- * their iframes apart. The source window can.
- *
- * Returns true when there is nothing to compare against, so single-instance hosts behave
- * exactly as before.
- */
+/** Same origin is not enough for two iframes. Fail closed if source or contentWindow is missing. */
 export const isFromIframe = ( event: MessageEvent, iframe: HTMLIFrameElement | null ) => {
 	const ownWindow = iframe?.contentWindow;
 
 	if ( ! ownWindow || ! event.source ) {
-		return true;
+		return false;
 	}
 
 	return event.source === ownWindow;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,11 @@
 import { appState } from './config';
 
-export const toggleAngieSidebar = ( iframe: HTMLIFrameElement, isOpen: boolean ) => {
-	const sidebarContainer = document.getElementById( appState.containerId );
+export const toggleAngieSidebar = (
+	iframe: HTMLIFrameElement,
+	isOpen: boolean,
+	containerId: string = appState.containerId
+) => {
+	const sidebarContainer = document.getElementById( containerId );
 	if ( sidebarContainer ) {
 		sidebarContainer.setAttribute( 'aria-hidden', isOpen ? 'false' : 'true' );
 	}
@@ -13,6 +17,31 @@ export const toggleAngieSidebar = ( iframe: HTMLIFrameElement, isOpen: boolean )
 		iframe.setAttribute( 'tabindex', '-1' );
 	}
 };
+
+/**
+ * Two instances on a page usually share one iframe origin, so `event.origin` cannot tell
+ * their iframes apart. The source window can.
+ *
+ * Returns true when there is nothing to compare against, so single-instance hosts behave
+ * exactly as before.
+ */
+export const isFromIframe = ( event: MessageEvent, iframe: HTMLIFrameElement | null ) => {
+	const ownWindow = iframe?.contentWindow;
+
+	if ( ! ownWindow || ! event.source ) {
+		return true;
+	}
+
+	return event.source === ownWindow;
+};
+
+export const isTrustedIframeMessage = (
+	event: MessageEvent,
+	iframeOrigin: string | undefined,
+	iframe: HTMLIFrameElement | null
+): boolean => event.origin === iframeOrigin && isFromIframe( event, iframe );
+
+export const generateInstanceId = (): string => Math.random().toString( 36 ).substring( 2, 8 );
 
 export const isMobile = () => {
 	return window.screen.availWidth <= 768;


### PR DESCRIPTION
## Summary
- Add `generateInstanceId`, `isFromIframe`, and `isTrustedIframeMessage` helpers
- Extend `AppState` with `instanceId`, `layout`, and `iframeElementId`
- Pass an explicit `instance` through iframe, sidebar, localStorage, openSaaSPage, and SDK listeners

Single-instance behavior is unchanged.

Stack 1/4. Next: https://github.com/elementor/angie-sdk/pull/71

> **Note:** This PR removes `setAngieIframeRef` as part of instance plumbing. Sidebar postMessage routing (`focusInput`, resize, toggle) is fixed in #71 via `postMessageToInstance`. These PRs merge together as a stack — #67 will not ship alone.

## Test plan
- [x] `npm test` (193 tests)
- [x] `npm run build`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Eliminates implicit global state dependency by threading `AppState` instances through core modules, enabling multi-instance SDK support and improving testability. Removes string-based instance IDs in favor of deterministic generation.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `config.ts` | Extended `AppState` with `instanceId`, `layout`, `iframeElementId`; replaced singleton with factory pattern |
| `angie-mcp-sdk.ts` | Generate instance ID at construction; thread `appState` to `loadSidebar()` |
| `iframe.ts` | `openIframe()` accepts optional `AppState` parameter; returns `{iframe, iframeOrigin}` instead of void |
| `sdk.ts`, `sidebar.ts`, `utils.ts` | Accept `AppState` parameter in listener/handler functions; replace global state reads |
| `openSaaSPage.ts`, `localStorage.ts` | Add message source verification via new `isTrustedIframeMessage()`, `isFromIframe()` |
| `*.test.ts` | Update mocks and assertions to verify instance-specific behavior |

## 3. How It Works

`AngieMcpSdk` generates unique instance ID at construction → passed through `loadSidebar()` to `openIframe()` → `openIframe()` returns tuple with iframe reference and origin → callers thread instance through message handlers (`listenToSDK`, `setupMessageListener`, `addLocalStorageListener`). Message validation now uses dual checks: origin match + `event.source === iframe.contentWindow` to prevent cross-iframe spoofing. Sidebar functions (`createToggleSidebarFunction`, `initializeResize`) accept optional instance parameter, defaulting to shared `appState`.

## 4. Risks

**Multi-instance collision**: If multiple SDK instances share default `containerId`/`iframeElementId`, DOM selectors collide. Mitigation: Each instance should configure unique IDs, though not enforced at runtime. **Backward compatibility**: Functions now require `AppState` parameter in some cases; callers must update signatures. **Message spoofing**: Prior origin-only checks could accept any iframe at same origin; new `isFromIframe()` check requires iframe reference, which is null until `openIframe()` completes—short window where messages rejected.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
