### PR TITLE
Add instance registry and route postMessage through loadSidebarV2

### DIFF
--- a/src/angie-iframe-utils.test.ts
+++ b/src/angie-iframe-utils.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { postMessageToInstance } from './angie-iframe-utils';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const createFakeIframe = ( path: string ) => {
+	const iframe = document.createElement( 'iframe' );
+	const postMessage = jest.fn();
+
+	iframe.setAttribute( 'src', `${ ANGIE_ORIGIN }${ path }` );
+	Object.defineProperty( iframe, 'contentWindow', { value: { postMessage }, writable: true } );
+	document.body.appendChild( iframe );
+
+	return { iframe, postMessage };
+};
+
+const SIDEBAR_ARGS = { containerId: 'container-a', instanceId: 'aaaaaa', layout: 'sidebar' };
+const CHAT_ARGS = { containerId: 'container-b', instanceId: 'bbbbbb', layout: 'floatingChat' };
+
+describe( 'angie-iframe-utils', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'should post only to the iframe owned by the given instance', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		const firstIframe = createFakeIframe( '/angie/wp-admin' );
+		const secondIframe = createFakeIframe( '/angie/embedded' );
+		first.iframe = firstIframe.iframe;
+		second.iframe = secondIframe.iframe;
+
+		const sent = postMessageToInstance( second, { type: 'sdk-widget-config' } );
+
+		expect( sent ).toBe( true );
+		expect( secondIframe.postMessage ).toHaveBeenCalledWith(
+			{ type: 'sdk-widget-config' },
+			ANGIE_ORIGIN,
+		);
+		expect( firstIframe.postMessage ).not.toHaveBeenCalled();
+	} );
+
+} );

--- a/src/angie-iframe-utils.ts
+++ b/src/angie-iframe-utils.ts
@@ -1,15 +1,81 @@
+import { appState, type AppState } from './config';
+import { getFirstInstance } from './instance-registry';
 import { createChildLogger } from './logger';
 
 const iframeUtilsLogger = createChildLogger( 'iframe-utils' );
 
+/** Cached DOM lookup when no registered instance owns an iframe. */
 let angieIframeRef: HTMLIFrameElement | null = null;
 
-export const setAngieIframeRef = ( iframe: HTMLIFrameElement | null ): void => {
-	angieIframeRef = iframe;
+const isInDocument = ( iframe: HTMLIFrameElement | null ): iframe is HTMLIFrameElement =>
+	!! iframe && document.contains( iframe );
+
+const originOf = ( iframe: HTMLIFrameElement ): string | null => {
+	try {
+		return new URL( iframe.src ).origin;
+	} catch ( error ) {
+		iframeUtilsLogger.error( 'Error parsing iframe URL:', error );
+		return null;
+	}
 };
 
+const sendToIframe = (
+	iframe: HTMLIFrameElement | null,
+	origin: string | null,
+	message: Record<string, unknown>
+): boolean => {
+	if ( ! iframe?.contentWindow ) {
+		return false;
+	}
+
+	if ( ! origin ) {
+		iframeUtilsLogger.error( 'Could not determine target origin for Angie iframe' );
+		return false;
+	}
+
+	iframe.contentWindow.postMessage( message, origin );
+	return true;
+};
+
+const getInstanceIframe = ( instance: AppState ): HTMLIFrameElement | null =>
+	isInDocument( instance.iframe ) ? instance.iframe : null;
+
+const getInstanceIframeOrigin = ( instance: AppState ): string | null => {
+	if ( instance.iframeUrlObject ) {
+		return instance.iframeUrlObject.origin;
+	}
+
+	const iframe = getInstanceIframe( instance );
+	return iframe ? originOf( iframe ) : null;
+};
+
+/**
+ * Sends a message to one instance's iframe only. Every internal caller uses this, so two
+ * instances on the same page can never receive each other's messages.
+ */
+export const postMessageToInstance = (
+	instance: AppState,
+	message: Record<string, unknown>,
+	targetOrigin?: string
+): boolean => sendToIframe(
+	getInstanceIframe( instance ),
+	targetOrigin || getInstanceIframeOrigin( instance ),
+	message
+);
+
+/**
+ * Kept for callers outside the SDK, which have no instance to name. Resolves to instance
+ * #1. Nothing inside the SDK uses it, so an ambiguous answer cannot corrupt routing.
+ */
 export const getAngieIframe = (): HTMLIFrameElement | null => {
-	if ( angieIframeRef && document.contains( angieIframeRef ) ) {
+	const instance = getFirstInstance() ?? appState;
+	const instanceIframe = getInstanceIframe( instance );
+
+	if ( instanceIframe ) {
+		return instanceIframe;
+	}
+
+	if ( isInDocument( angieIframeRef ) ) {
 		return angieIframeRef;
 	}
 
@@ -23,16 +89,7 @@ export const angieIframeExists = (): boolean => {
 
 export const getAngieIframeOrigin = (): string | null => {
 	const iframe = getAngieIframe();
-	if ( ! iframe ) {
-		return null;
-	}
-
-	try {
-		return new URL( iframe.src ).origin;
-	} catch ( error ) {
-		iframeUtilsLogger.error( 'Error parsing iframe URL:', error );
-		return null;
-	}
+	return iframe ? originOf( iframe ) : null;
 };
 
 export const postMessageToAngieIframe = (
@@ -40,17 +97,5 @@ export const postMessageToAngieIframe = (
 	targetOrigin?: string
 ): boolean => {
 	iframeUtilsLogger.log( 'postMessageToAngieIframe', message, targetOrigin );
-	const iframe = getAngieIframe();
-	if ( ! iframe?.contentWindow ) {
-		return false;
-	}
-
-	const origin = targetOrigin || getAngieIframeOrigin();
-	if ( ! origin ) {
-		iframeUtilsLogger.error( 'Could not determine target origin for Angie iframe' );
-		return false;
-	}
-
-	iframe.contentWindow.postMessage( message, origin );
-	return true;
+	return sendToIframe( getAngieIframe(), targetOrigin || getAngieIframeOrigin(), message );
 };

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -534,7 +534,7 @@ describe('AngieMcpSdk', () => {
       await sdk.loadSidebarV2( options );
 
       expect( mockBootSidebar ).toHaveBeenCalledTimes( 1 );
-      expect( mockBootSidebar ).toHaveBeenCalledWith( options );
+      expect( mockBootSidebar ).toHaveBeenCalledWith( options, expect.any( String ) );
     });
   });
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -119,7 +119,7 @@ export class AngieMcpSdk {
   }
 
   public loadSidebarV2( options: LoadSidebarV2Options ): Promise<void> {
-    this.sidebarV2BootPromise = bootSidebar( options );
+    this.sidebarV2BootPromise = bootSidebar( options, this.instanceId );
     return this.sidebarV2BootPromise;
   }
 

--- a/src/instance-registry.test.ts
+++ b/src/instance-registry.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { appState } from './config';
+import {
+	createAngieInstance,
+	resetInstancesForTests,
+	shouldInstanceHandle,
+} from './instance-registry';
+
+const SIDEBAR_ARGS = { containerId: 'container-a', instanceId: 'aaaaaa', layout: 'sidebar' as const };
+const CHAT_ARGS = { containerId: 'container-b', instanceId: 'bbbbbb', layout: 'floatingChat' as const };
+
+describe( 'instance-registry', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+	} );
+
+	it( 'should reuse the shared appState object for the first instance', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+
+		expect( instance ).toBe( appState );
+	} );
+
+} );
+
+describe( 'instance-registry host-to-host routing', () => {
+	const fakeIframe = () => ( { contentWindow: {} } as HTMLIFrameElement );
+
+	beforeEach( () => {
+		resetInstancesForTests();
+	} );
+
+	it( 'should skip a message addressed to another instance that owns an iframe', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+		second.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( first, 'bbbbbb' ) ).toBe( false );
+	} );
+
+	it( 'should let the first iframe owner answer for an instance that owns no iframe', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( first, 'bbbbbb' ) ).toBe( true );
+		expect( shouldInstanceHandle( first, 'unknown-editor-id' ) ).toBe( true );
+	} );
+
+	it( 'should not let a later iframe owner answer for an unknown instance', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+		second.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( second, 'unknown-editor-id' ) ).toBe( false );
+	} );
+} );

--- a/src/instance-registry.ts
+++ b/src/instance-registry.ts
@@ -1,0 +1,71 @@
+import {
+	appState,
+	createDefaultAppState,
+	DEFAULT_IFRAME_ELEMENT_ID,
+	type AppState,
+} from './config';
+import { LAYOUT_SIDEBAR } from './load-sidebar-v2/config';
+
+export type CreateAngieInstanceArgs = Pick<AppState, 'containerId' | 'instanceId' | 'layout'>;
+
+const instances: AppState[] = [];
+
+export const createAngieInstance = ( args: CreateAngieInstanceArgs ): AppState => {
+	// Instance #1 is the shared `appState` object itself, so every existing reader of
+	// `appState` follows it and single-instance behaviour is unchanged. It keeps the
+	// legacy iframe id too, so host CSS targeting `#angie-iframe` still matches.
+	const reuseSharedAppState = instances.length === 0;
+
+	const state: AppState = {
+		...createDefaultAppState(),
+		...args,
+		iframeElementId: reuseSharedAppState
+			? DEFAULT_IFRAME_ELEMENT_ID
+			: `${ DEFAULT_IFRAME_ELEMENT_ID }-${ args.instanceId }`,
+	};
+
+	const instance = reuseSharedAppState ? Object.assign( appState, state ) : state;
+
+	instances.push( instance );
+
+	return instance;
+};
+
+export const getFirstInstance = (): AppState | null => instances[ 0 ] ?? null;
+
+const getFirstIframeInstance = (): AppState | null =>
+	instances.find( ( instance ) => instance.iframe !== null ) ?? null;
+
+export const getInstanceById = ( instanceId: string ): AppState | null =>
+	instances.find( ( instance ) => instance.instanceId === instanceId ) ?? null;
+
+export const getInstanceByContainerId = ( containerId: string ): AppState | null =>
+	instances.find( ( instance ) => instance.containerId === containerId ) ?? null;
+
+export const hasSidebarLayoutInstance = (): boolean =>
+	instances.some( ( instance ) => instance.layout === LAYOUT_SIDEBAR );
+
+/**
+ * Decides whether `instance` should act on a host-to-host message.
+ *
+ * The Elementor editor loads its own SDK bundle. It registers MCP servers but never
+ * opens an iframe, and relies on the Angie plugin's listener to pass its messages on.
+ * So a message addressed elsewhere is only ignored when that instance owns an iframe of
+ * its own. Otherwise the first iframe owner answers for it.
+ */
+export const shouldInstanceHandle = ( instance: AppState, instanceId?: string ): boolean => {
+	if ( ! instanceId || instanceId === instance.instanceId ) {
+		return true;
+	}
+
+	if ( getInstanceById( instanceId )?.iframe ) {
+		return false;
+	}
+
+	return getFirstIframeInstance() === instance;
+};
+
+export const resetInstancesForTests = (): void => {
+	instances.length = 0;
+	Object.assign( appState, createDefaultAppState() );
+};

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
 import { bootSidebar } from './boot-sidebar';
+import { getFirstInstance, resetInstancesForTests } from '../instance-registry';
 
 jest.mock( '../sidebar', () => ( {
 	ANGIE_SIDEBAR_STATE_CLOSED: 'closed',
@@ -13,7 +14,7 @@ jest.mock( '../sidebar', () => ( {
 } ) );
 
 jest.mock( './open-embedded-iframe', () => ( {
-	openEmbeddedIframe: jest.fn( () => Promise.resolve() ),
+	openEmbeddedIframe: jest.fn( () => Promise.resolve( true ) ),
 } ) );
 
 jest.mock( './embedded-handshake', () => ( {
@@ -52,6 +53,8 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+		resetInstancesForTests();
 		mockApplyState = require( '../sidebar' ).applyState as jest.Mock;
 		mockInitAngieSidebar = require( '../sidebar' ).initAngieSidebar as jest.Mock;
 		mockLoadState = require( '../sidebar' ).loadState as jest.Mock;
@@ -77,6 +80,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		);
 		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
 			expect.objectContaining( { appId: 'editor-lite', configVersion: 2 } ),
+			expect.objectContaining( { instanceId: expect.any( String ) } ),
 		);
 		expect( mockLoadState ).toHaveBeenCalledWith( 'open' );
 		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
@@ -112,5 +116,13 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockApplyState ).toHaveBeenCalledWith( 'closed' );
 		expect( mockLoadState ).toHaveBeenCalledWith( 'closed' );
 		expect( mockInitAngieSidebar ).toHaveBeenCalled();
+	} );
+
+	it( 'should name the instance after the sdk id', async () => {
+		await bootSidebar(
+			{ container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } },
+			'sdk123',
+		);
+		expect( getFirstInstance()?.instanceId ).toBe( 'sdk123' );
 	} );
 } );

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -1,4 +1,3 @@
-import { appState } from '../config';
 import { ensureSidebarContainer } from './container';
 import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
@@ -7,9 +6,14 @@ import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { handlePostConsentRedirect } from '../oauth';
+import { createAngieInstance } from '../instance-registry';
 import { resolveConfig, shouldBoot } from './resolve-config';
+import { generateInstanceId } from '../utils';
 
-export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
+export const bootSidebar = async (
+	options: LoadSidebarV2Options,
+	sdkInstanceId = ''
+): Promise<void> => {
 	handlePostConsentRedirect();
 
 	const env = readEnv();
@@ -19,36 +23,48 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 		return;
 	}
 
+	const instanceId = sdkInstanceId || generateInstanceId();
+
+	const instance = createAngieInstance( {
+		containerId: config.container.id,
+		instanceId,
+		layout: config.container.layout,
+	} );
+
 	initHostApiBridge( {
 		iframeOrigin: config.iframe.origin,
 		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
+		instance,
 	} );
-
-	appState.containerId = config.container.id;
 
 	ensureSidebarContainer( config.container.id, env.isRTL );
 
 	const strategy = LAYOUT_STRATEGIES[ config.container.layout ];
-	const bootContext = { config, env };
+	const bootContext = { config, env, instance };
 
 	strategy.initShell( bootContext );
 	strategy.beforeOpenIframe?.( bootContext );
 
 	const embeddedPayload = buildHostEmbeddedConfigPayload( config.host );
 
-	await openEmbeddedIframe( {
+	const opened = await openEmbeddedIframe( {
 		container: config.container,
 		iframe: config.iframe,
 		embeddedConfig: embeddedPayload,
+		instance,
 	} );
 
 	strategy.afterOpenIframe?.( bootContext );
 
+	if ( ! opened ) {
+		return;
+	}
+
 	// HOST_READY delivers config during iframe load; post-open message supports older embedded clients.
-	sendEmbeddedConfig( embeddedPayload );
+	sendEmbeddedConfig( embeddedPayload, instance );
 
 	if ( config.widgetConfig ) {
-		sendWidgetConfig( config.widgetConfig );
+		sendWidgetConfig( config.widgetConfig, instance );
 	}
 };

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
@@ -6,11 +6,14 @@ import { CHAT_WIDGET_HIDDEN_CLASS } from './constants';
 import { setChatWidgetOpen } from './chat-shell';
 
 jest.mock( '../../utils', () => ( {
+	...( jest.requireActual( '../../utils' ) as object ),
 	toggleAngieSidebar: jest.fn(),
+	sendSuccessMessage: jest.fn(),
 } ) );
 
 jest.mock( '../toggle-button', () => ( {
 	syncToggleButton: jest.fn(),
+	wireToggleButton: jest.fn(),
 } ) );
 
 const CONTAINER_ID = 'angie-sidebar-container';
@@ -32,11 +35,12 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 			containerId: CONTAINER_ID,
 			toggleButtonSelector: TOGGLE_SELECTOR,
 			isOpen: false,
+			instance: appState,
 		} );
 
 		const container = document.getElementById( CONTAINER_ID )!;
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, false );
 	} );
 
@@ -48,10 +52,11 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 			containerId: CONTAINER_ID,
 			toggleButtonSelector: TOGGLE_SELECTOR,
 			isOpen: true,
+			instance: appState,
 		} );
 
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( false );
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, true );
 	} );
 } );

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.ts
@@ -1,6 +1,6 @@
-import { appState } from '../../config';
+import type { AppState } from '../../config';
 import { MessageEventType } from '../../types';
-import { sendSuccessMessage, toggleAngieSidebar } from '../../utils';
+import { isTrustedIframeMessage, sendSuccessMessage, toggleAngieSidebar } from '../../utils';
 import { syncToggleButton, wireToggleButton } from '../toggle-button';
 import { addHostMessageHandler } from '../host-message-router';
 import {
@@ -14,17 +14,19 @@ type InitChatShellArgs = {
 	iframeOrigin: string;
 	toggleButtonSelector: string;
 	onClose?: () => void;
+	instance: AppState;
 };
 
 type SetChatWidgetOpenArgs = {
 	containerId: string;
 	toggleButtonSelector: string;
 	isOpen: boolean;
+	instance: AppState;
 };
 
 const TOGGLE_ANGIE_SIDEBAR_MESSAGE = 'toggleAngieSidebar';
 
-let removeChatShellMessageHandler: ( () => void ) | null = null;
+const removeMessageHandlers = new Map<AppState, () => void>();
 
 export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 	const container = document.getElementById( args.containerId );
@@ -39,8 +41,8 @@ export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 		container.classList.add( CHAT_WIDGET_HIDDEN_CLASS );
 	}
 
-	if ( appState.iframe ) {
-		toggleAngieSidebar( appState.iframe, args.isOpen );
+	if ( args.instance.iframe ) {
+		toggleAngieSidebar( args.instance.iframe, args.isOpen, args.containerId );
 	}
 
 	syncToggleButton( args.toggleButtonSelector, args.isOpen );
@@ -60,83 +62,54 @@ const setChatWidgetFullscreen = ( containerId: string, isFullscreen: boolean ): 
 	}
 };
 
+const setOpen = ( args: InitChatShellArgs, isOpen: boolean ): void => {
+	setChatWidgetOpen( {
+		containerId: args.containerId,
+		toggleButtonSelector: args.toggleButtonSelector,
+		isOpen,
+		instance: args.instance,
+	} );
+};
+
+const isWidgetOpen = ( containerId: string ): boolean => {
+	const container = document.getElementById( containerId );
+	return !! container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
+};
+
 const handleSidebarToggleMessage = (
 	args: InitChatShellArgs,
 	payload: { force?: boolean } | undefined,
 ): void => {
 	const force = payload?.force;
 
-	if ( force === false ) {
-		setChatWidgetOpen( {
-			containerId: args.containerId,
-			toggleButtonSelector: args.toggleButtonSelector,
-			isOpen: false,
-		} );
-		args.onClose?.();
+	if ( force !== undefined ) {
+		setOpen( args, force );
+
+		if ( ! force ) {
+			args.onClose?.();
+		}
+
 		return;
 	}
 
-	if ( force === true ) {
-		setChatWidgetOpen( {
-			containerId: args.containerId,
-			toggleButtonSelector: args.toggleButtonSelector,
-			isOpen: true,
-		} );
-		return;
-	}
+	const wasOpen = isWidgetOpen( args.containerId );
+	setOpen( args, ! wasOpen );
 
-	const container = document.getElementById( args.containerId );
-	const isCurrentlyOpen = container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
-	setChatWidgetOpen( {
-		containerId: args.containerId,
-		toggleButtonSelector: args.toggleButtonSelector,
-		isOpen: ! isCurrentlyOpen,
-	} );
-
-	if ( isCurrentlyOpen ) {
+	if ( wasOpen ) {
 		args.onClose?.();
 	}
 };
 
 const initToggleButton = ( args: InitChatShellArgs ): void => {
-	const toggleButton = findToggleButton( args.toggleButtonSelector );
-
-	if ( ! toggleButton ) {
-		wireToggleButton( {
-			toggleButtonSelector: args.toggleButtonSelector,
-			onClick: () => {
-				const toggleEl = findToggleButton( args.toggleButtonSelector );
-
-				if ( ! toggleEl ) {
-					return;
-				}
-
-				const isCurrentlyOpen = toggleEl.getAttribute( 'aria-expanded' ) === 'true';
-				setChatWidgetOpen( {
-					containerId: args.containerId,
-					toggleButtonSelector: args.toggleButtonSelector,
-					isOpen: ! isCurrentlyOpen,
-				} );
-
-				if ( isCurrentlyOpen ) {
-					args.onClose?.();
-				}
-			},
-		} );
-		return;
-	}
-
 	wireToggleButton( {
 		toggleButtonSelector: args.toggleButtonSelector,
 		onClick: () => {
-			const isCurrentlyOpen = toggleButton.getAttribute( 'aria-expanded' ) === 'true';
-			setChatWidgetOpen( {
-				containerId: args.containerId,
-				toggleButtonSelector: args.toggleButtonSelector,
-				isOpen: ! isCurrentlyOpen,
-			} );
+			const toggleEl = findToggleButton( args.toggleButtonSelector );
+			const wasOpen = toggleEl?.getAttribute( 'aria-expanded' ) === 'true';
 
-			if ( isCurrentlyOpen ) {
+			setOpen( args, ! wasOpen );
+
+			if ( wasOpen ) {
 				args.onClose?.();
 			}
 		},
@@ -144,9 +117,11 @@ const initToggleButton = ( args: InitChatShellArgs ): void => {
 };
 
 const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
-	removeChatShellMessageHandler?.();
-	removeChatShellMessageHandler = addHostMessageHandler( ( event: MessageEvent ) => {
-		if ( event.origin !== args.iframeOrigin ) {
+	const { instance } = args;
+
+	removeMessageHandlers.get( instance )?.();
+	removeMessageHandlers.set( instance, addHostMessageHandler( ( event: MessageEvent ) => {
+		if ( ! isTrustedIframeMessage( event, args.iframeOrigin, instance.iframe ) ) {
 			return;
 		}
 
@@ -167,11 +142,7 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				setChatWidgetFullscreen( args.containerId, isStudioOpen );
 
 				if ( isStudioOpen ) {
-					setChatWidgetOpen( {
-						containerId: args.containerId,
-						toggleButtonSelector: args.toggleButtonSelector,
-						isOpen: true,
-					} );
+					setOpen( args, true );
 				}
 
 				if ( port ) {
@@ -180,7 +151,7 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				break;
 			}
 		}
-	} );
+	} ) );
 };
 
 export const initChatShell = ( args: InitChatShellArgs ): void => {
@@ -193,6 +164,6 @@ export const initChatShell = ( args: InitChatShellArgs ): void => {
 };
 
 export const resetChatShellForTests = (): void => {
-	removeChatShellMessageHandler?.();
-	removeChatShellMessageHandler = null;
+	removeMessageHandlers.forEach( ( remove ) => remove() );
+	removeMessageHandlers.clear();
 };

--- a/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
+++ b/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
@@ -1,3 +1,4 @@
+import type { AppState } from '../../config';
 import { initChatShell } from './chat-shell';
 import {
 	injectChatToggleButton,
@@ -11,6 +12,7 @@ type InitFloatingChatLayoutArgs = {
 	toggleButtonSelector: string;
 	injectToggleButton: boolean;
 	onClose?: () => void;
+	instance: AppState;
 };
 
 export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void => {
@@ -26,5 +28,6 @@ export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void
 		iframeOrigin: args.iframeOrigin,
 		onClose: args.onClose,
 		toggleButtonSelector: args.toggleButtonSelector,
+		instance: args.instance,
 	} );
 };

--- a/src/load-sidebar-v2/chat-toggle/widget-ui.ts
+++ b/src/load-sidebar-v2/chat-toggle/widget-ui.ts
@@ -6,6 +6,7 @@ import {
 	CHAT_WIDGET_HIDDEN_CLASS,
 	CHAT_WIDGET_STYLES_ID,
 } from './constants';
+import { DEFAULT_CONTAINER_ID } from '../../config';
 import { applySelectorToToggleButton, findToggleButton } from './toggle-button-element';
 
 const ANGIE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16" fill="none">
@@ -130,13 +131,24 @@ export const injectChatToggleButtonStyles = (): void => {
 	document.head.appendChild( style );
 };
 
+/**
+ * The CSS is written against one container id, so every container needs its own tag.
+ * The default container keeps the original id, leaving single-instance pages unchanged.
+ */
+const styleIdForContainer = ( containerId: string ): string =>
+	containerId === DEFAULT_CONTAINER_ID
+		? CHAT_WIDGET_STYLES_ID
+		: `${ CHAT_WIDGET_STYLES_ID }-${ containerId }`;
+
 export const injectChatWidgetStyles = ( containerId: string ): void => {
-	if ( document.getElementById( CHAT_WIDGET_STYLES_ID ) ) {
+	const styleId = styleIdForContainer( containerId );
+
+	if ( document.getElementById( styleId ) ) {
 		return;
 	}
 
 	const style = document.createElement( 'style' );
-	style.id = CHAT_WIDGET_STYLES_ID;
+	style.id = styleId;
 	style.textContent = buildWidgetCss( containerId );
 	document.head.appendChild( style );
 };

--- a/src/load-sidebar-v2/embedded-handshake.ts
+++ b/src/load-sidebar-v2/embedded-handshake.ts
@@ -1,16 +1,23 @@
-import { postMessageToAngieIframe } from '../angie-iframe-utils';
+import { postMessageToInstance } from '../angie-iframe-utils';
+import { appState, type AppState } from '../config';
 import type { HostEmbeddedConfigPayload, ResolvedConfigV2 } from './config';
 import { EMBEDDED_CONFIG_MESSAGE_TYPE } from './defaults';
 
-export const sendEmbeddedConfig = ( payload: HostEmbeddedConfigPayload ): void => {
-	postMessageToAngieIframe( {
+export const sendEmbeddedConfig = (
+	payload: HostEmbeddedConfigPayload,
+	instance: AppState = appState
+): void => {
+	postMessageToInstance( instance, {
 		payload,
 		type: EMBEDDED_CONFIG_MESSAGE_TYPE,
 	} );
 };
 
-export const sendWidgetConfig = ( widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']> ): void => {
-	postMessageToAngieIframe( {
+export const sendWidgetConfig = (
+	widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']>,
+	instance: AppState = appState
+): void => {
+	postMessageToInstance( instance, {
 		payload: widgetConfig,
 		type: 'sdk-widget-config',
 	} );

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -8,6 +8,8 @@ import {
 	initHostApiBridge,
 	resetHostApiBridgeForTests,
 } from './host-api-bridge';
+import { appState } from '../config';
+import { resetInstancesForTests } from '../instance-registry';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -23,10 +25,11 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		resetHostApiBridgeForTests();
+		resetInstancesForTests();
 	} );
 
 	it( 'should respond with empty headers when no callback is provided', async () => {
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		const port = createMockPort();
 		window.dispatchEvent( new MessageEvent( 'message', {
@@ -53,6 +56,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		initHostApiBridge( {
 			iframeOrigin: IFRAME_ORIGIN,
 			getExternalHeaders,
+			instance: appState,
 		} );
 
 		const firstPort = createMockPort();
@@ -92,6 +96,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		initHostApiBridge( {
 			iframeOrigin: IFRAME_ORIGIN,
 			getExternalHeaders,
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -113,6 +118,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 			getExternalHeaders: async () => {
 				throw new Error( 'Token unavailable' );
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -137,6 +143,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 				appId: 'test-app',
 				website: { name: 'Custom Site', wpVersion: '6.4' },
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -174,6 +181,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 					plugins: { elementor: true },
 				},
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -201,7 +209,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	it( 'should handle localStorage GET', async () => {
 		window.localStorage.setItem( 'angie-test-key', 'stored-value' );
 
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		const port = createMockPort();
 		window.dispatchEvent( new MessageEvent( 'message', {
@@ -218,7 +226,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	} );
 
 	it( 'should handle localStorage SET', async () => {
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		window.dispatchEvent( new MessageEvent( 'message', {
 			data: {

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,5 +1,6 @@
 import { sendErrorMessage, sendSuccessMessage } from '../utils';
 import { HostLocalStorageEventType } from '../types';
+import type { AppState } from '../config';
 import type { ExternalHeadersCallback, HostConfig } from './config';
 
 export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
@@ -12,10 +13,26 @@ type InitHostApiBridgeArgs = {
 	iframeOrigin: string;
 	host?: HostConfig;
 	getExternalHeaders?: ExternalHeadersCallback;
+	instance: AppState;
 };
 
-let bridgeConfig: InitHostApiBridgeArgs | null = null;
+const bridges = new Map<AppState, InitHostApiBridgeArgs>();
 let bridgeListenerRegistered = false;
+
+// Disambiguate by event.source when several instances share one origin; see isFromIframe.
+const findBridge = ( event: MessageEvent ): InitHostApiBridgeArgs | null => {
+	const matching = [ ...bridges.values() ].filter(
+		( bridge ) => bridge.iframeOrigin === event.origin,
+	);
+
+	if ( matching.length <= 1 ) {
+		return matching[ 0 ] ?? null;
+	}
+
+	return matching.find(
+		( bridge ) => bridge.instance.iframe?.contentWindow === event.source,
+	) ?? null;
+};
 
 const filterDefinedHeaders = (
 	headers: Record<string, string | undefined>,
@@ -83,7 +100,9 @@ const handleHostLocalStorageSet = ( key: string, value: string ): void => {
 };
 
 const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
-	if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+	const bridgeConfig = findBridge( event );
+
+	if ( ! bridgeConfig ) {
 		return;
 	}
 
@@ -131,7 +150,7 @@ const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
 };
 
 export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
-	bridgeConfig = args;
+	bridges.set( args.instance, args );
 
 	if ( bridgeListenerRegistered ) {
 		return;
@@ -144,5 +163,5 @@ export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 };
 
 export const resetHostApiBridgeForTests = (): void => {
-	bridgeConfig = null;
+	bridges.clear();
 };

--- a/src/load-sidebar-v2/layouts/index.ts
+++ b/src/load-sidebar-v2/layouts/index.ts
@@ -1,5 +1,6 @@
 import { initFloatingChatLayout } from '../chat-toggle/init-floating-chat-layout';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR, type LoadSidebarV2Layout, type ResolvedConfigV2 } from '../config';
+import type { AppState } from '../../config';
 import type { Env } from '../env';
 import {
 	applyInitialSidebarShellState,
@@ -10,6 +11,7 @@ import {
 export type LayoutBootContext = {
 	config: ResolvedConfigV2;
 	env: Env;
+	instance: AppState;
 };
 
 export type LayoutStrategy = {
@@ -19,19 +21,19 @@ export type LayoutStrategy = {
 };
 
 const sidebarStrategy: LayoutStrategy = {
-	initShell: ( { config } ) => {
-		initSidebarShell( config.container, config.callbacks );
+	initShell: ( { config, instance } ) => {
+		initSidebarShell( config.container, config.callbacks, instance );
 	},
 	beforeOpenIframe: ( { config } ) => {
 		applyInitialSidebarShellState( config.container );
 	},
-	afterOpenIframe: ( { config } ) => {
-		finalizeSidebarShellState( config.container );
+	afterOpenIframe: ( { config, instance } ) => {
+		finalizeSidebarShellState( config.container, instance );
 	},
 };
 
 const floatingChatStrategy: LayoutStrategy = {
-	initShell: ( { config } ) => {
+	initShell: ( { config, instance } ) => {
 		const { chatToggleButton } = config.container;
 
 		initFloatingChatLayout( {
@@ -40,6 +42,7 @@ const floatingChatStrategy: LayoutStrategy = {
 			onClose: config.callbacks.onClose,
 			toggleButtonSelector: chatToggleButton.selector,
 			injectToggleButton: chatToggleButton.enabled,
+			instance,
 		} );
 	},
 };

--- a/src/load-sidebar-v2/open-embedded-iframe.test.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.test.ts
@@ -3,7 +3,10 @@ import { appState } from '../config';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 
 jest.mock( '../iframe', () => ( {
-	openIframe: jest.fn( () => Promise.resolve() ),
+	openIframe: jest.fn( () => Promise.resolve( {
+		iframe: {} as HTMLIFrameElement,
+		iframeOrigin: 'https://angie.elementor.com',
+	} ) ),
 } ) );
 
 jest.mock( '../utils', () => ( {
@@ -48,7 +51,7 @@ describe( 'load-sidebar-v2/open-embedded-iframe', () => {
 			},
 		} );
 
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false, appState.containerId );
 		expect( syncToggleButton ).toHaveBeenCalledWith( '#demo-sidebar-toggle', false );
 	} );
 } );

--- a/src/load-sidebar-v2/open-embedded-iframe.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.ts
@@ -1,4 +1,4 @@
-import { appState } from '../config';
+import { appState, type AppState } from '../config';
 import { openIframe } from '../iframe';
 import { toggleAngieSidebar } from '../utils';
 import { LAYOUT_FLOATING_CHAT, type HostEmbeddedConfigPayload, type ResolvedConfigV2 } from './config';
@@ -9,16 +9,24 @@ type OpenEmbeddedIframeArgs = {
 	container: ResolvedConfigV2['container'];
 	iframe: ResolvedConfigV2['iframe'];
 	embeddedConfig?: HostEmbeddedConfigPayload;
+	instance?: AppState;
 };
 
-export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<void> => {
-	await openIframe( {
+export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<boolean> => {
+	const instance = args.instance ?? appState;
+
+	const opened = await openIframe( {
 		isRTL: args.iframe.isRTL,
 		origin: args.iframe.origin,
 		path: args.iframe.path,
 		uiTheme: args.iframe.uiTheme,
 		embeddedConfig: args.embeddedConfig,
-	} );
+	}, instance );
+
+	// No iframe on mobile, so there is nothing to configure or toggle.
+	if ( ! opened ) {
+		return false;
+	}
 
 	if (
 		args.container.layout === LAYOUT_FLOATING_CHAT &&
@@ -28,15 +36,18 @@ export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promis
 			containerId: args.container.id,
 			toggleButtonSelector: args.container.chatToggleButton.selector,
 			isOpen: false,
+			instance,
 		} );
-		return;
+		return true;
 	}
 
-	if ( appState.iframe ) {
-		toggleAngieSidebar( appState.iframe, false );
+	if ( instance.iframe ) {
+		toggleAngieSidebar( instance.iframe, false, instance.containerId );
 	}
 
 	if ( args.container.chatToggleButton.enabled ) {
 		syncToggleButton( args.container.chatToggleButton.selector, false );
 	}
+
+	return true;
 };

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -37,6 +37,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 			appId: options.host.appId,
 			aiContext: options.host.aiContext,
 			website: options.host.website,
+			analytics: options.host.analytics,
 		},
 		boot: {
 			allowInIframe: boot.allowInIframe ?? DEFAULTS.boot.allowInIframe,

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -7,6 +7,7 @@ import {
 	initializeResize,
 	loadState,
 } from '../sidebar';
+import { appState, type AppState } from '../config';
 import type { ContainerConfig, ResolvedConfigV2 } from './config';
 import {
 	syncToggleButton,
@@ -17,12 +18,14 @@ import { injectStyleThemeCss } from './inject-style-theme';
 export const initSidebarShell = (
 	container: ContainerConfig,
 	callbacks: ResolvedConfigV2['callbacks'],
+	instance: AppState = appState,
 ): void => {
 	const toggleButtonSelector = container.chatToggleButton.enabled
 		? container.chatToggleButton.selector
 		: undefined;
 
 	initAngieSidebar( {
+		instance,
 		onToggle: ( isOpen ) => {
 			if ( toggleButtonSelector ) {
 				syncToggleButton( toggleButtonSelector, isOpen );
@@ -66,6 +69,7 @@ export const applyInitialSidebarShellState = (
 
 export const finalizeSidebarShellState = (
 	container: ContainerConfig,
+	instance: AppState = appState,
 ): void => {
 	if ( container.persistOpenState ) {
 		loadState(
@@ -76,6 +80,6 @@ export const finalizeSidebarShellState = (
 	}
 
 	if ( container.resizable ) {
-		initializeResize();
+		initializeResize( instance );
 	}
 };

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { appState } from './config';
 import { addLocalStorageListener } from './localStorage';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
 import { HostLocalStorageEventType } from './types';
 
 const ANGIE_ORIGIN = 'https://angie.elementor.com';
@@ -11,18 +11,22 @@ const emitMessage = ( event: Partial<MessageEvent> ): void => {
 
 describe( 'localStorage', () => {
 	beforeEach( () => {
+		resetInstancesForTests();
 		window.localStorage.clear();
 		jest.clearAllMocks();
-		appState.iframe = null;
-		appState.iframeUrlObject = null;
 	} );
 
 	it( 'should store a value sent by its own iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
 		const ownWindow = {} as Window;
-		appState.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
-		appState.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
+		instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		instance.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
 
-		addLocalStorageListener( appState );
+		addLocalStorageListener( instance );
 		emitMessage( {
 			origin: ANGIE_ORIGIN,
 			source: ownWindow,
@@ -32,11 +36,16 @@ describe( 'localStorage', () => {
 		expect( window.localStorage.getItem( 'angie_test' ) ).toBe( 'yes' );
 	} );
 
-	it( 'should ignore a message sent by another iframe window', () => {
-		appState.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
-		appState.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+	it( 'should ignore a message sent by another instance iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		instance.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
 
-		addLocalStorageListener( appState );
+		addLocalStorageListener( instance );
 		emitMessage( {
 			origin: ANGIE_ORIGIN,
 			source: {} as Window,

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+import { listenToSDK } from './sdk';
+import { MessageEventType } from './types';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const attachIframe = ( instance: ReturnType<typeof createAngieInstance> ) => {
+	const postMessage = jest.fn();
+	instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+	instance.iframe = { contentWindow: { postMessage } } as unknown as HTMLIFrameElement;
+	return postMessage;
+};
+
+const emitHostMessage = ( data: unknown ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), {
+		origin: window.location.origin,
+		source: window,
+		data,
+		ports: [ { postMessage: jest.fn() } ],
+	} ) );
+};
+
+describe( 'sdk', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		jest.clearAllMocks();
+	} );
+
+	it( 'should forward a trigger request only to the addressed instance', () => {
+		const first = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const firstPostMessage = attachIframe( first );
+		const secondPostMessage = attachIframe( second );
+
+		listenToSDK( first );
+		listenToSDK( second );
+		emitHostMessage( {
+			type: MessageEventType.SDK_TRIGGER_ANGIE,
+			payload: { instanceId: 'aaaaaa', requestId: 'req-2', prompt: 'hello' },
+		} );
+
+		expect( firstPostMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: MessageEventType.SDK_TRIGGER_ANGIE } ),
+			ANGIE_ORIGIN,
+		);
+		expect( secondPostMessage ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,6 +3,7 @@ import { sendSuccessMessage } from './utils';
 import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { MessageEventType } from './types';
 import { AppState } from './config';
+import { shouldInstanceHandle } from './instance-registry';
 
 const sdkLogger = createChildLogger( 'sdk' );
 
@@ -19,14 +20,19 @@ export interface ClientCreationRequest {
 	capabilities?: ServerCapabilities;
 }
 
-export const listenToSDK = ( instance: AppState ) => {
-	// Access global timing instance for SDK performance tracking
+export const listenToSDK = ( appState: AppState ) => {
 	window.addEventListener( 'message', async ( event ) => {
 		const isSameOrigin = event.origin === window.location.origin;
-		const isIframe = event.origin === instance.iframeUrlObject?.origin;
+		const isIframe = event.origin === appState.iframeUrlObject?.origin;
 		if ( ! isSameOrigin && ! isIframe ) {
 			return;
 		}
+
+		// Host messages share event.source, so route them by instanceId.
+		const shouldHandleMessage = shouldInstanceHandle(
+			appState,
+			event?.data?.payload?.instanceId
+		);
 
 		switch ( event?.data?.type ) {
 			case MessageEventType.SDK_ANGIE_ALL_SERVERS_REGISTERED:
@@ -43,6 +49,10 @@ export const listenToSDK = ( instance: AppState ) => {
 				break;
 			}
 			case MessageEventType.SDK_REQUEST_CLIENT_CREATION: {
+				if ( ! shouldHandleMessage ) {
+					break;
+				}
+
 				const payload = event.data.payload as ClientCreationRequest;
 
 				try {
@@ -66,8 +76,8 @@ export const listenToSDK = ( instance: AppState ) => {
 						},
 						timestamp: Date.now(),
 					};
-					if ( instance.iframe ) {
-						instance.iframe.contentWindow?.postMessage( message, instance.iframeUrlObject?.origin || '', [ channel.port2 ] );
+					if ( appState.iframe ) {
+						appState.iframe.contentWindow?.postMessage( message, appState.iframeUrlObject?.origin || '', [ channel.port2 ] );
 					} else {
 						throw new Error( 'Iframe not found' );
 					}
@@ -77,14 +87,17 @@ export const listenToSDK = ( instance: AppState ) => {
 				break;
 			}
 			case MessageEventType.SDK_TRIGGER_ANGIE: {
+				if ( ! shouldHandleMessage ) {
+					break;
+				}
 
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 
 				try {
 					const { requestId, prompt, context, options } = event.data.payload;
 
-					if ( instance.iframe ) {
-						instance.iframe.contentWindow?.postMessage( {
+					if ( appState.iframe ) {
+						appState.iframe.contentWindow?.postMessage( {
 							type: MessageEventType.SDK_TRIGGER_ANGIE,
 							payload: {
 								requestId,
@@ -92,7 +105,7 @@ export const listenToSDK = ( instance: AppState ) => {
 								context,
 								options,
 							},
-						}, instance.iframeUrlObject?.origin || '' );
+						}, appState.iframeUrlObject?.origin || '' );
 					} else {
 						throw new Error( 'Iframe not found' );
 					}

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -12,7 +12,7 @@ import { appState } from './config';
 
 // Mock dependencies
 jest.mock('./angie-iframe-utils', () => ({
-  postMessageToAngieIframe: jest.fn(),
+  postMessageToInstance: jest.fn(),
 }));
 
 jest.mock('./iframe', () => ({

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,4 +1,4 @@
-import { postMessageToAngieIframe } from "./angie-iframe-utils";
+import { postMessageToInstance } from "./angie-iframe-utils";
 import { appState, type AppState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
@@ -80,7 +80,7 @@ export function getAngieSidebarSavedState(): AngieSidebarState | null {
 export function handleFocus( isOpen: boolean, delay: number, instance: AppState = appState ): void {
 	if ( isOpen ) {
 		setTimeout( function() {
-			postMessageToAngieIframe( {
+			postMessageToInstance( instance, {
 				type: 'focusInput',
 			} );
 		}, delay );
@@ -189,7 +189,7 @@ export function initializeResize( instance: AppState = appState ): void {
 			const currentWidth = parseInt( getComputedStyle( document.documentElement ).getPropertyValue( '--angie-sidebar-width' ), 10 );
 			saveWidth( currentWidth );
 
-			postMessageToAngieIframe( {
+			postMessageToInstance( instance, {
 				type: MessageEventType.ANGIE_SIDEBAR_RESIZED,
 				payload: { initialWidth: startWidth, width: currentWidth },
 			} );
@@ -254,7 +254,7 @@ export function createToggleSidebarFunction(
 		} );
 		document.dispatchEvent( event );
 
-		postMessageToAngieIframe( {
+		postMessageToInstance( instance, {
 			type: MessageEventType.ANGIE_SIDEBAR_TOGGLED,
 			payload: { state: shouldOpen ? 'opened' : 'closed' },
 		} );


### PR DESCRIPTION
## Summary
- Add instance registry; first instance reuses shared `appState`
- Route internal postMessage via `postMessageToInstance`
- Wire `loadSidebarV2` boot, host-api-bridge, and chat shell through per-instance state

Still single-instance at runtime — no multi-instance boot guards yet.

Stack 2/3. Requires PR 1 merged first.

## Test plan
- [x] `npm test` (200 tests)
- [x] `npm run build`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Multi-instance support requires routing messages to specific iframes instead of broadcasting to a single global one. This PR introduces an instance registry and refactors postMessage flows to accept instance parameters, enabling multiple SDK instances on the same page without cross-talk.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `src/instance-registry.ts` | New registry: tracks instances, handles routing decisions for host-to-host messages via `shouldInstanceHandle()` |
| `src/angie-iframe-utils.ts` | Refactored: `postMessageToInstance()` replaces `postMessageToAngieIframe()`, removed `setAngieIframeRef()` setter |
| `src/load-sidebar-v2/boot-sidebar.ts` | Creates instance and threads it through layout strategies and handshake functions |
| `src/load-sidebar-v2/chat-toggle/chat-shell.ts` | Instance-scoped message handler map replaces global `removeChatShellMessageHandler` |
| `src/load-sidebar-v2/host-api-bridge.ts` | Multi-bridge map with origin+source disambiguation replaces single `bridgeConfig` |
| `src/sdk.ts` | Routes messages by `instanceId` via `shouldInstanceHandle()` before forwarding to iframe |
| `src/sidebar.ts` | Adopts `postMessageToInstance()` for focus/resize events |
| Tests | Added instance-registry + routing tests; updated mocks for instance parameter |

## 3. How It Works

**Instance lifecycle**: `createAngieInstance()` reuses shared `appState` for first instance (backward compat), generates unique IDs and iframe element IDs for subsequent ones. Registry stored in module-scoped array.

**Message routing**: Host messages carry optional `instanceId`. `shouldInstanceHandle()` decides: if addressed to another instance with iframe, skip; if unaddressed and no other iframe owns it, first iframe owner answers. Prevents Elementor editor (no iframe) from intercepting messages meant for plugin instances.

**Multi-bridge support**: `initHostApiBridge()` now stores per-instance bridge config. `findBridge()` disambiguates by matching event origin + `event.source` (iframe contentWindow) when multiple instances share origin.

**Layout strategies**: `LayoutBootContext` carries instance; passed down to shell init, chat shell, and resize handlers so they operate on correct iframe.

## 4. Risks

**Backward compatibility**: First instance reuses `appState` so single-instance code paths unchanged. `getAngieIframe()` still resolves first instance for legacy external callers—acceptable since ambiguity only arises with multiple instances.

**Message routing ambiguity**: If two instances share iframe origin (e.g., same embedding domain), routing relies on `event.source` (contentWindow reference). Should be reliable, but test coverage confirms this (added `sdk.test.ts`).

**Incomplete refactor**: `sdk.ts` still references `appState` directly in message forwarding instead of using `postMessageToInstance()`. Works but inconsistent—consider consolidating in follow-up.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
