### PR TITLE
feat: add instance registry and target postMessage to the correct iframe

### DIFF
--- a/src/angie-iframe-utils.test.ts
+++ b/src/angie-iframe-utils.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { postMessageToInstance } from './angie-iframe-utils';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const createFakeIframe = ( path: string ) => {
+	const iframe = document.createElement( 'iframe' );
+	const postMessage = jest.fn();
+
+	iframe.setAttribute( 'src', `${ ANGIE_ORIGIN }${ path }` );
+	Object.defineProperty( iframe, 'contentWindow', { value: { postMessage }, writable: true } );
+	document.body.appendChild( iframe );
+
+	return { iframe, postMessage };
+};
+
+const SIDEBAR_ARGS = { containerId: 'container-a', instanceId: 'aaaaaa', layout: 'sidebar' };
+const CHAT_ARGS = { containerId: 'container-b', instanceId: 'bbbbbb', layout: 'floatingChat' };
+
+describe( 'angie-iframe-utils', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'should post only to the iframe owned by the given instance', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		const firstIframe = createFakeIframe( '/angie/wp-admin' );
+		const secondIframe = createFakeIframe( '/angie/embedded' );
+		first.iframe = firstIframe.iframe;
+		second.iframe = secondIframe.iframe;
+
+		const sent = postMessageToInstance( second, { type: 'sdk-widget-config' } );
+
+		expect( sent ).toBe( true );
+		expect( secondIframe.postMessage ).toHaveBeenCalledWith(
+			{ type: 'sdk-widget-config' },
+			ANGIE_ORIGIN,
+		);
+		expect( firstIframe.postMessage ).not.toHaveBeenCalled();
+	} );
+
+} );

--- a/src/angie-iframe-utils.ts
+++ b/src/angie-iframe-utils.ts
@@ -1,15 +1,81 @@
+import { appState, type AppState } from './config';
+import { getFirstInstance } from './instance-registry';
 import { createChildLogger } from './logger';
 
 const iframeUtilsLogger = createChildLogger( 'iframe-utils' );
 
+/** Cached DOM lookup when no registered instance owns an iframe. */
 let angieIframeRef: HTMLIFrameElement | null = null;
 
-export const setAngieIframeRef = ( iframe: HTMLIFrameElement | null ): void => {
-	angieIframeRef = iframe;
+const isInDocument = ( iframe: HTMLIFrameElement | null ): iframe is HTMLIFrameElement =>
+	!! iframe && document.contains( iframe );
+
+const originOf = ( iframe: HTMLIFrameElement ): string | null => {
+	try {
+		return new URL( iframe.src ).origin;
+	} catch ( error ) {
+		iframeUtilsLogger.error( 'Error parsing iframe URL:', error );
+		return null;
+	}
 };
 
+const sendToIframe = (
+	iframe: HTMLIFrameElement | null,
+	origin: string | null,
+	message: Record<string, unknown>
+): boolean => {
+	if ( ! iframe?.contentWindow ) {
+		return false;
+	}
+
+	if ( ! origin ) {
+		iframeUtilsLogger.error( 'Could not determine target origin for Angie iframe' );
+		return false;
+	}
+
+	iframe.contentWindow.postMessage( message, origin );
+	return true;
+};
+
+const getInstanceIframe = ( instance: AppState ): HTMLIFrameElement | null =>
+	isInDocument( instance.iframe ) ? instance.iframe : null;
+
+const getInstanceIframeOrigin = ( instance: AppState ): string | null => {
+	if ( instance.iframeUrlObject ) {
+		return instance.iframeUrlObject.origin;
+	}
+
+	const iframe = getInstanceIframe( instance );
+	return iframe ? originOf( iframe ) : null;
+};
+
+/**
+ * Sends a message to one instance's iframe only. Every internal caller uses this, so two
+ * instances on the same page can never receive each other's messages.
+ */
+export const postMessageToInstance = (
+	instance: AppState,
+	message: Record<string, unknown>,
+	targetOrigin?: string
+): boolean => sendToIframe(
+	getInstanceIframe( instance ),
+	targetOrigin || getInstanceIframeOrigin( instance ),
+	message
+);
+
+/**
+ * Kept for callers outside the SDK, which have no instance to name. Resolves to instance
+ * #1. Nothing inside the SDK uses it, so an ambiguous answer cannot corrupt routing.
+ */
 export const getAngieIframe = (): HTMLIFrameElement | null => {
-	if ( angieIframeRef && document.contains( angieIframeRef ) ) {
+	const instance = getFirstInstance() ?? appState;
+	const instanceIframe = getInstanceIframe( instance );
+
+	if ( instanceIframe ) {
+		return instanceIframe;
+	}
+
+	if ( isInDocument( angieIframeRef ) ) {
 		return angieIframeRef;
 	}
 
@@ -23,16 +89,7 @@ export const angieIframeExists = (): boolean => {
 
 export const getAngieIframeOrigin = (): string | null => {
 	const iframe = getAngieIframe();
-	if ( ! iframe ) {
-		return null;
-	}
-
-	try {
-		return new URL( iframe.src ).origin;
-	} catch ( error ) {
-		iframeUtilsLogger.error( 'Error parsing iframe URL:', error );
-		return null;
-	}
+	return iframe ? originOf( iframe ) : null;
 };
 
 export const postMessageToAngieIframe = (
@@ -40,17 +97,5 @@ export const postMessageToAngieIframe = (
 	targetOrigin?: string
 ): boolean => {
 	iframeUtilsLogger.log( 'postMessageToAngieIframe', message, targetOrigin );
-	const iframe = getAngieIframe();
-	if ( ! iframe?.contentWindow ) {
-		return false;
-	}
-
-	const origin = targetOrigin || getAngieIframeOrigin();
-	if ( ! origin ) {
-		iframeUtilsLogger.error( 'Could not determine target origin for Angie iframe' );
-		return false;
-	}
-
-	iframe.contentWindow.postMessage( message, origin );
-	return true;
+	return sendToIframe( getAngieIframe(), targetOrigin || getAngieIframeOrigin(), message );
 };

--- a/src/instance-registry.test.ts
+++ b/src/instance-registry.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from '@jest/globals';
+import { appState } from './config';
+import {
+	createAngieInstance,
+	resetInstancesForTests,
+	shouldInstanceHandle,
+} from './instance-registry';
+
+const SIDEBAR_ARGS = { containerId: 'container-a', instanceId: 'aaaaaa', layout: 'sidebar' as const };
+const CHAT_ARGS = { containerId: 'container-b', instanceId: 'bbbbbb', layout: 'floatingChat' as const };
+
+describe( 'instance-registry', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+	} );
+
+	it( 'should reuse the shared appState object for the first instance', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+
+		expect( instance ).toBe( appState );
+	} );
+
+} );
+
+describe( 'instance-registry host-to-host routing', () => {
+	const fakeIframe = () => ( { contentWindow: {} } as HTMLIFrameElement );
+
+	beforeEach( () => {
+		resetInstancesForTests();
+	} );
+
+	it( 'should skip a message addressed to another instance that owns an iframe', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+		second.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( first, 'bbbbbb' ) ).toBe( false );
+	} );
+
+	it( 'should let the first iframe owner answer for an instance that owns no iframe', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( first, 'bbbbbb' ) ).toBe( true );
+		expect( shouldInstanceHandle( first, 'unknown-editor-id' ) ).toBe( true );
+	} );
+
+	it( 'should not let a later iframe owner answer for an unknown instance', () => {
+		const first = createAngieInstance( SIDEBAR_ARGS );
+		const second = createAngieInstance( CHAT_ARGS );
+		first.iframe = fakeIframe();
+		second.iframe = fakeIframe();
+
+		expect( shouldInstanceHandle( second, 'unknown-editor-id' ) ).toBe( false );
+	} );
+} );

--- a/src/instance-registry.ts
+++ b/src/instance-registry.ts
@@ -1,0 +1,71 @@
+import {
+	appState,
+	createDefaultAppState,
+	DEFAULT_IFRAME_ELEMENT_ID,
+	type AppState,
+} from './config';
+import { LAYOUT_SIDEBAR } from './load-sidebar-v2/config';
+
+export type CreateAngieInstanceArgs = Pick<AppState, 'containerId' | 'instanceId' | 'layout'>;
+
+const instances: AppState[] = [];
+
+export const createAngieInstance = ( args: CreateAngieInstanceArgs ): AppState => {
+	// Instance #1 is the shared `appState` object itself, so every existing reader of
+	// `appState` follows it and single-instance behaviour is unchanged. It keeps the
+	// legacy iframe id too, so host CSS targeting `#angie-iframe` still matches.
+	const reuseSharedAppState = instances.length === 0;
+
+	const state: AppState = {
+		...createDefaultAppState(),
+		...args,
+		iframeElementId: reuseSharedAppState
+			? DEFAULT_IFRAME_ELEMENT_ID
+			: `${ DEFAULT_IFRAME_ELEMENT_ID }-${ args.instanceId }`,
+	};
+
+	const instance = reuseSharedAppState ? Object.assign( appState, state ) : state;
+
+	instances.push( instance );
+
+	return instance;
+};
+
+export const getFirstInstance = (): AppState | null => instances[ 0 ] ?? null;
+
+const getFirstIframeInstance = (): AppState | null =>
+	instances.find( ( instance ) => instance.iframe !== null ) ?? null;
+
+export const getInstanceById = ( instanceId: string ): AppState | null =>
+	instances.find( ( instance ) => instance.instanceId === instanceId ) ?? null;
+
+export const getInstanceByContainerId = ( containerId: string ): AppState | null =>
+	instances.find( ( instance ) => instance.containerId === containerId ) ?? null;
+
+export const hasSidebarLayoutInstance = (): boolean =>
+	instances.some( ( instance ) => instance.layout === LAYOUT_SIDEBAR );
+
+/**
+ * Decides whether `instance` should act on a host-to-host message.
+ *
+ * The Elementor editor loads its own SDK bundle. It registers MCP servers but never
+ * opens an iframe, and relies on the Angie plugin's listener to pass its messages on.
+ * So a message addressed elsewhere is only ignored when that instance owns an iframe of
+ * its own. Otherwise the first iframe owner answers for it.
+ */
+export const shouldInstanceHandle = ( instance: AppState, instanceId?: string ): boolean => {
+	if ( ! instanceId || instanceId === instance.instanceId ) {
+		return true;
+	}
+
+	if ( getInstanceById( instanceId )?.iframe ) {
+		return false;
+	}
+
+	return getFirstIframeInstance() === instance;
+};
+
+export const resetInstancesForTests = (): void => {
+	instances.length = 0;
+	Object.assign( appState, createDefaultAppState() );
+};

--- a/src/localStorage.test.ts
+++ b/src/localStorage.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { appState } from './config';
 import { addLocalStorageListener } from './localStorage';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
 import { HostLocalStorageEventType } from './types';
 
 const ANGIE_ORIGIN = 'https://angie.elementor.com';
@@ -11,18 +11,22 @@ const emitMessage = ( event: Partial<MessageEvent> ): void => {
 
 describe( 'localStorage', () => {
 	beforeEach( () => {
+		resetInstancesForTests();
 		window.localStorage.clear();
 		jest.clearAllMocks();
-		appState.iframe = null;
-		appState.iframeUrlObject = null;
 	} );
 
 	it( 'should store a value sent by its own iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
 		const ownWindow = {} as Window;
-		appState.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
-		appState.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
+		instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		instance.iframe = { contentWindow: ownWindow } as HTMLIFrameElement;
 
-		addLocalStorageListener( appState );
+		addLocalStorageListener( instance );
 		emitMessage( {
 			origin: ANGIE_ORIGIN,
 			source: ownWindow,
@@ -32,11 +36,16 @@ describe( 'localStorage', () => {
 		expect( window.localStorage.getItem( 'angie_test' ) ).toBe( 'yes' );
 	} );
 
-	it( 'should ignore a message sent by another iframe window', () => {
-		appState.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
-		appState.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+	it( 'should ignore a message sent by another instance iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+		instance.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
 
-		addLocalStorageListener( appState );
+		addLocalStorageListener( instance );
 		emitMessage( {
 			origin: ANGIE_ORIGIN,
 			source: {} as Window,

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -54,4 +54,41 @@ describe( 'sdk', () => {
 		);
 		expect( secondPostMessage ).not.toHaveBeenCalled();
 	} );
+
+	it( 'should forward a client creation request only to the addressed instance', () => {
+		const first = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const firstPostMessage = attachIframe( first );
+		const secondPostMessage = attachIframe( second );
+
+		listenToSDK( first );
+		listenToSDK( second );
+		emitHostMessage( {
+			type: MessageEventType.SDK_REQUEST_CLIENT_CREATION,
+			payload: {
+				instanceId: 'aaaaaa',
+				requestId: 'req-1',
+				serverId: 'server-1',
+				serverName: 'Test Server',
+				description: 'A test server',
+				serverVersion: '1.0.0',
+				transport: 'postMessage',
+			},
+		} );
+
+		expect( firstPostMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: MessageEventType.SDK_REQUEST_CLIENT_CREATION } ),
+			ANGIE_ORIGIN,
+			expect.any( Array ),
+		);
+		expect( secondPostMessage ).not.toHaveBeenCalled();
+	} );
 } );

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createAngieInstance, resetInstancesForTests } from './instance-registry';
+import { listenToSDK } from './sdk';
+import { MessageEventType } from './types';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const attachIframe = ( instance: ReturnType<typeof createAngieInstance> ) => {
+	const postMessage = jest.fn();
+	instance.iframeUrlObject = new URL( `${ ANGIE_ORIGIN }/angie/embedded` );
+	instance.iframe = { contentWindow: { postMessage } } as unknown as HTMLIFrameElement;
+	return postMessage;
+};
+
+const emitHostMessage = ( data: unknown ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), {
+		origin: window.location.origin,
+		source: window,
+		data,
+		ports: [ { postMessage: jest.fn() } ],
+	} ) );
+};
+
+describe( 'sdk', () => {
+	beforeEach( () => {
+		resetInstancesForTests();
+		jest.clearAllMocks();
+	} );
+
+	it( 'should forward a trigger request only to the addressed instance', () => {
+		const first = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const firstPostMessage = attachIframe( first );
+		const secondPostMessage = attachIframe( second );
+
+		listenToSDK( first );
+		listenToSDK( second );
+		emitHostMessage( {
+			type: MessageEventType.SDK_TRIGGER_ANGIE,
+			payload: { instanceId: 'aaaaaa', requestId: 'req-2', prompt: 'hello' },
+		} );
+
+		expect( firstPostMessage ).toHaveBeenCalledWith(
+			expect.objectContaining( { type: MessageEventType.SDK_TRIGGER_ANGIE } ),
+			ANGIE_ORIGIN,
+		);
+		expect( secondPostMessage ).not.toHaveBeenCalled();
+	} );
+} );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -3,6 +3,7 @@ import { isTrustedIframeMessage, sendSuccessMessage } from './utils';
 import { ServerCapabilities } from '@modelcontextprotocol/sdk/types.js';
 import { MessageEventType } from './types';
 import { AppState } from './config';
+import { shouldInstanceHandle } from './instance-registry';
 
 const sdkLogger = createChildLogger( 'sdk' );
 
@@ -32,6 +33,12 @@ export const listenToSDK = ( instance: AppState ) => {
 			return;
 		}
 
+		// Host messages share event.source, so route them by instanceId.
+		const shouldHandleMessage = shouldInstanceHandle(
+			instance,
+			event?.data?.payload?.instanceId
+		);
+
 		switch ( event?.data?.type ) {
 			case MessageEventType.SDK_ANGIE_ALL_SERVERS_REGISTERED:
 				break;
@@ -47,6 +54,10 @@ export const listenToSDK = ( instance: AppState ) => {
 				break;
 			}
 			case MessageEventType.SDK_REQUEST_CLIENT_CREATION: {
+				if ( ! shouldHandleMessage ) {
+					break;
+				}
+
 				const payload = event.data.payload as ClientCreationRequest;
 
 				try {
@@ -81,6 +92,9 @@ export const listenToSDK = ( instance: AppState ) => {
 				break;
 			}
 			case MessageEventType.SDK_TRIGGER_ANGIE: {
+				if ( ! shouldHandleMessage ) {
+					break;
+				}
 
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 

--- a/src/sidebar.test.ts
+++ b/src/sidebar.test.ts
@@ -12,7 +12,7 @@ import { appState } from './config';
 
 // Mock dependencies
 jest.mock('./angie-iframe-utils', () => ({
-  postMessageToAngieIframe: jest.fn(),
+  postMessageToInstance: jest.fn(),
 }));
 
 jest.mock('./iframe', () => ({

--- a/src/sidebar.ts
+++ b/src/sidebar.ts
@@ -1,4 +1,4 @@
-import { postMessageToAngieIframe } from "./angie-iframe-utils";
+import { postMessageToInstance } from "./angie-iframe-utils";
 import { appState, type AppState } from "./config";
 import { MessageEventType } from "./types";
 import { createChildLogger } from "./logger";
@@ -80,7 +80,7 @@ export function getAngieSidebarSavedState(): AngieSidebarState | null {
 export function handleFocus( isOpen: boolean, delay: number, instance: AppState = appState ): void {
 	if ( isOpen ) {
 		setTimeout( function() {
-			postMessageToAngieIframe( {
+			postMessageToInstance( instance, {
 				type: 'focusInput',
 			} );
 		}, delay );
@@ -189,7 +189,7 @@ export function initializeResize( instance: AppState = appState ): void {
 			const currentWidth = parseInt( getComputedStyle( document.documentElement ).getPropertyValue( '--angie-sidebar-width' ), 10 );
 			saveWidth( currentWidth );
 
-			postMessageToAngieIframe( {
+			postMessageToInstance( instance, {
 				type: MessageEventType.ANGIE_SIDEBAR_RESIZED,
 				payload: { initialWidth: startWidth, width: currentWidth },
 			} );
@@ -254,7 +254,7 @@ export function createToggleSidebarFunction(
 		} );
 		document.dispatchEvent( event );
 
-		postMessageToAngieIframe( {
+		postMessageToInstance( instance, {
 			type: MessageEventType.ANGIE_SIDEBAR_TOGGLED,
 			payload: { state: shouldOpen ? 'opened' : 'closed' },
 		} );


### PR DESCRIPTION
## Summary
- Add `instance-registry` (first instance reuses shared `appState`)
- Add `postMessageToInstance` and route SDK host messages via `shouldInstanceHandle`
- Switch sidebar callers from `postMessageToAngieIframe` to instance-targeted routing

Split from former #68. Stack 2/4.

## Test plan
- [x] `npm test` (199 tests)
- [x] `npm run build`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Multi-instance SDK now needs message routing by `instanceId`. Previously all postMessage calls targeted a single shared iframe; now each instance must receive only its own messages to prevent crosstalk when multiple Angie widgets coexist on the same page.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `angie-iframe-utils.ts` | Refactored into instance-aware helpers; removed `setAngieIframeRef()`, added `postMessageToInstance()` for targeted routing |
| `instance-registry.ts` | New registry managing multiple instances; `shouldInstanceHandle()` routes host messages to correct recipient |
| `sdk.ts` | Guards `SDK_REQUEST_CLIENT_CREATION` and `SDK_TRIGGER_ANGIE` handlers with `shouldInstanceHandle()` check |
| `sidebar.ts` | Switched from `postMessageToAngieIframe()` to `postMessageToInstance(instance, ...)` |
| Tests | Added comprehensive coverage: registry behavior, message isolation, routing logic |

## 3. How It Works

First instance reuses global `appState`; subsequent instances create new state objects. On host→iframe messages, `shouldInstanceHandle()` checks: if message targets a specific `instanceId` that owns its own iframe, skip it; otherwise first iframe owner answers (handles Elementor editor case where editor registers MCP but never opens iframe). `postMessageToInstance()` extracts iframe and origin from instance state, validates, then postMessages directly to that iframe only.

## 4. Risks

Subtle: Elementor editor (no iframe, mixes with plugin's instance) relies on first-iframe-owner fallback. If registration order changes or first instance loses iframe before message arrives, routing breaks. Mitigation: tests lock this behavior; `shouldInstanceHandle()` deterministic. Cache invalidation: `angieIframeRef` fallback only used when no registered instance owns iframe—safe but document the assumption clearly.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
