### PR TITLE
feat: wire loadSidebarV2 boot through per-instance state

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -562,7 +562,7 @@ describe('AngieMcpSdk', () => {
       await sdk.loadSidebarV2( options );
 
       expect( mockBootSidebar ).toHaveBeenCalledTimes( 1 );
-      expect( mockBootSidebar ).toHaveBeenCalledWith( options );
+      expect( mockBootSidebar ).toHaveBeenCalledWith( options, expect.any( String ) );
     });
   });
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -119,7 +119,7 @@ export class AngieMcpSdk {
   }
 
   public loadSidebarV2( options: LoadSidebarV2Options ): Promise<void> {
-    this.sidebarV2BootPromise = bootSidebar( options );
+    this.sidebarV2BootPromise = bootSidebar( options, this.instanceId );
     return this.sidebarV2BootPromise;
   }
 

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -14,7 +14,7 @@ jest.mock( '../sidebar', () => ( {
 } ) );
 
 jest.mock( './open-embedded-iframe', () => ( {
-	openEmbeddedIframe: jest.fn( () => Promise.resolve( true ) ),
+	openEmbeddedIframe: jest.fn( (): Promise<boolean> => Promise.resolve( true ) ),
 } ) );
 
 jest.mock( './embedded-handshake', () => ( {
@@ -124,5 +124,25 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 			'sdk123',
 		);
 		expect( getFirstInstance()?.instanceId ).toBe( 'sdk123' );
+	} );
+
+	it( 'should skip embedded config when iframe fails to open', async () => {
+		mockOpenEmbeddedIframe.mockImplementationOnce( () => Promise.resolve( false ) );
+		await bootSidebar( { container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } } );
+		expect( mockSendEmbeddedConfig ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should inject per-container widget styles for a custom container id', async () => {
+		await bootSidebar( {
+			container: {
+				layout: LAYOUT_FLOATING_CHAT,
+				id: 'help-center',
+				chatToggleButton: { enabled: false, selector: '#angie-widget-toggle' },
+			},
+			host: { appId: 'app-a' },
+		} );
+
+		expect( document.getElementById( 'angie-chat-widget-styles-help-center' ) ).not.toBeNull();
+		expect( document.getElementById( 'angie-chat-widget-styles' ) ).toBeNull();
 	} );
 } );

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
 import { bootSidebar } from './boot-sidebar';
+import { getFirstInstance, resetInstancesForTests } from '../instance-registry';
 
 jest.mock( '../sidebar', () => ( {
 	ANGIE_SIDEBAR_STATE_CLOSED: 'closed',
@@ -13,7 +14,7 @@ jest.mock( '../sidebar', () => ( {
 } ) );
 
 jest.mock( './open-embedded-iframe', () => ( {
-	openEmbeddedIframe: jest.fn( () => Promise.resolve() ),
+	openEmbeddedIframe: jest.fn( () => Promise.resolve( true ) ),
 } ) );
 
 jest.mock( './embedded-handshake', () => ( {
@@ -52,6 +53,8 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+		resetInstancesForTests();
 		mockApplyState = require( '../sidebar' ).applyState as jest.Mock;
 		mockInitAngieSidebar = require( '../sidebar' ).initAngieSidebar as jest.Mock;
 		mockLoadState = require( '../sidebar' ).loadState as jest.Mock;
@@ -77,6 +80,7 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		);
 		expect( mockSendEmbeddedConfig ).toHaveBeenCalledWith(
 			expect.objectContaining( { appId: 'editor-lite', configVersion: 2 } ),
+			expect.objectContaining( { instanceId: expect.any( String ) } ),
 		);
 		expect( mockLoadState ).toHaveBeenCalledWith( 'open' );
 		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
@@ -112,5 +116,13 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockApplyState ).toHaveBeenCalledWith( 'closed' );
 		expect( mockLoadState ).toHaveBeenCalledWith( 'closed' );
 		expect( mockInitAngieSidebar ).toHaveBeenCalled();
+	} );
+
+	it( 'should name the instance after the sdk id', async () => {
+		await bootSidebar(
+			{ container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } },
+			'sdk123',
+		);
+		expect( getFirstInstance()?.instanceId ).toBe( 'sdk123' );
 	} );
 } );

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -1,4 +1,3 @@
-import { appState } from '../config';
 import { ensureSidebarContainer } from './container';
 import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
@@ -7,9 +6,14 @@ import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { handlePostConsentRedirect } from '../oauth';
+import { createAngieInstance } from '../instance-registry';
 import { resolveConfig, shouldBoot } from './resolve-config';
+import { generateInstanceId } from '../utils';
 
-export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void> => {
+export const bootSidebar = async (
+	options: LoadSidebarV2Options,
+	sdkInstanceId = ''
+): Promise<void> => {
 	handlePostConsentRedirect();
 
 	const env = readEnv();
@@ -19,36 +23,48 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 		return;
 	}
 
+	const instanceId = sdkInstanceId || generateInstanceId();
+
+	const instance = createAngieInstance( {
+		containerId: config.container.id,
+		instanceId,
+		layout: config.container.layout,
+	} );
+
 	initHostApiBridge( {
 		iframeOrigin: config.iframe.origin,
 		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
+		instance,
 	} );
-
-	appState.containerId = config.container.id;
 
 	ensureSidebarContainer( config.container.id, env.isRTL );
 
 	const strategy = LAYOUT_STRATEGIES[ config.container.layout ];
-	const bootContext = { config, env };
+	const bootContext = { config, env, instance };
 
 	strategy.initShell( bootContext );
 	strategy.beforeOpenIframe?.( bootContext );
 
 	const embeddedPayload = buildHostEmbeddedConfigPayload( config.host );
 
-	await openEmbeddedIframe( {
+	const opened = await openEmbeddedIframe( {
 		container: config.container,
 		iframe: config.iframe,
 		embeddedConfig: embeddedPayload,
+		instance,
 	} );
 
 	strategy.afterOpenIframe?.( bootContext );
 
+	if ( ! opened ) {
+		return;
+	}
+
 	// HOST_READY delivers config during iframe load; post-open message supports older embedded clients.
-	sendEmbeddedConfig( embeddedPayload );
+	sendEmbeddedConfig( embeddedPayload, instance );
 
 	if ( config.widgetConfig ) {
-		sendWidgetConfig( config.widgetConfig );
+		sendWidgetConfig( config.widgetConfig, instance );
 	}
 };

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
@@ -6,11 +6,14 @@ import { CHAT_WIDGET_HIDDEN_CLASS } from './constants';
 import { setChatWidgetOpen } from './chat-shell';
 
 jest.mock( '../../utils', () => ( {
+	...( jest.requireActual( '../../utils' ) as object ),
 	toggleAngieSidebar: jest.fn(),
+	sendSuccessMessage: jest.fn(),
 } ) );
 
 jest.mock( '../toggle-button', () => ( {
 	syncToggleButton: jest.fn(),
+	wireToggleButton: jest.fn(),
 } ) );
 
 const CONTAINER_ID = 'angie-sidebar-container';
@@ -32,11 +35,12 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 			containerId: CONTAINER_ID,
 			toggleButtonSelector: TOGGLE_SELECTOR,
 			isOpen: false,
+			instance: appState,
 		} );
 
 		const container = document.getElementById( CONTAINER_ID )!;
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, false );
 	} );
 
@@ -48,10 +52,11 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 			containerId: CONTAINER_ID,
 			toggleButtonSelector: TOGGLE_SELECTOR,
 			isOpen: true,
+			instance: appState,
 		} );
 
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( false );
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, true );
 	} );
 } );

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.ts
@@ -1,6 +1,6 @@
-import { appState } from '../../config';
+import type { AppState } from '../../config';
 import { MessageEventType } from '../../types';
-import { sendSuccessMessage, toggleAngieSidebar } from '../../utils';
+import { isTrustedIframeMessage, sendSuccessMessage, toggleAngieSidebar } from '../../utils';
 import { syncToggleButton, wireToggleButton } from '../toggle-button';
 import { addHostMessageHandler } from '../host-message-router';
 import {
@@ -14,17 +14,19 @@ type InitChatShellArgs = {
 	iframeOrigin: string;
 	toggleButtonSelector: string;
 	onClose?: () => void;
+	instance: AppState;
 };
 
 type SetChatWidgetOpenArgs = {
 	containerId: string;
 	toggleButtonSelector: string;
 	isOpen: boolean;
+	instance: AppState;
 };
 
 const TOGGLE_ANGIE_SIDEBAR_MESSAGE = 'toggleAngieSidebar';
 
-let removeChatShellMessageHandler: ( () => void ) | null = null;
+const removeMessageHandlers = new Map<AppState, () => void>();
 
 export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 	const container = document.getElementById( args.containerId );
@@ -39,8 +41,8 @@ export const setChatWidgetOpen = ( args: SetChatWidgetOpenArgs ): void => {
 		container.classList.add( CHAT_WIDGET_HIDDEN_CLASS );
 	}
 
-	if ( appState.iframe ) {
-		toggleAngieSidebar( appState.iframe, args.isOpen );
+	if ( args.instance.iframe ) {
+		toggleAngieSidebar( args.instance.iframe, args.isOpen, args.containerId );
 	}
 
 	syncToggleButton( args.toggleButtonSelector, args.isOpen );
@@ -60,83 +62,54 @@ const setChatWidgetFullscreen = ( containerId: string, isFullscreen: boolean ): 
 	}
 };
 
+const setOpen = ( args: InitChatShellArgs, isOpen: boolean ): void => {
+	setChatWidgetOpen( {
+		containerId: args.containerId,
+		toggleButtonSelector: args.toggleButtonSelector,
+		isOpen,
+		instance: args.instance,
+	} );
+};
+
+const isWidgetOpen = ( containerId: string ): boolean => {
+	const container = document.getElementById( containerId );
+	return !! container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
+};
+
 const handleSidebarToggleMessage = (
 	args: InitChatShellArgs,
 	payload: { force?: boolean } | undefined,
 ): void => {
 	const force = payload?.force;
 
-	if ( force === false ) {
-		setChatWidgetOpen( {
-			containerId: args.containerId,
-			toggleButtonSelector: args.toggleButtonSelector,
-			isOpen: false,
-		} );
-		args.onClose?.();
+	if ( force !== undefined ) {
+		setOpen( args, force );
+
+		if ( ! force ) {
+			args.onClose?.();
+		}
+
 		return;
 	}
 
-	if ( force === true ) {
-		setChatWidgetOpen( {
-			containerId: args.containerId,
-			toggleButtonSelector: args.toggleButtonSelector,
-			isOpen: true,
-		} );
-		return;
-	}
+	const wasOpen = isWidgetOpen( args.containerId );
+	setOpen( args, ! wasOpen );
 
-	const container = document.getElementById( args.containerId );
-	const isCurrentlyOpen = container && ! container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS );
-	setChatWidgetOpen( {
-		containerId: args.containerId,
-		toggleButtonSelector: args.toggleButtonSelector,
-		isOpen: ! isCurrentlyOpen,
-	} );
-
-	if ( isCurrentlyOpen ) {
+	if ( wasOpen ) {
 		args.onClose?.();
 	}
 };
 
 const initToggleButton = ( args: InitChatShellArgs ): void => {
-	const toggleButton = findToggleButton( args.toggleButtonSelector );
-
-	if ( ! toggleButton ) {
-		wireToggleButton( {
-			toggleButtonSelector: args.toggleButtonSelector,
-			onClick: () => {
-				const toggleEl = findToggleButton( args.toggleButtonSelector );
-
-				if ( ! toggleEl ) {
-					return;
-				}
-
-				const isCurrentlyOpen = toggleEl.getAttribute( 'aria-expanded' ) === 'true';
-				setChatWidgetOpen( {
-					containerId: args.containerId,
-					toggleButtonSelector: args.toggleButtonSelector,
-					isOpen: ! isCurrentlyOpen,
-				} );
-
-				if ( isCurrentlyOpen ) {
-					args.onClose?.();
-				}
-			},
-		} );
-		return;
-	}
-
 	wireToggleButton( {
 		toggleButtonSelector: args.toggleButtonSelector,
 		onClick: () => {
-			const isCurrentlyOpen = toggleButton.getAttribute( 'aria-expanded' ) === 'true';
-			setChatWidgetOpen( {
-				containerId: args.containerId,
-				toggleButtonSelector: args.toggleButtonSelector,
-				isOpen: ! isCurrentlyOpen,
-			} );
+			const toggleEl = findToggleButton( args.toggleButtonSelector );
+			const wasOpen = toggleEl?.getAttribute( 'aria-expanded' ) === 'true';
 
-			if ( isCurrentlyOpen ) {
+			setOpen( args, ! wasOpen );
+
+			if ( wasOpen ) {
 				args.onClose?.();
 			}
 		},
@@ -144,9 +117,11 @@ const initToggleButton = ( args: InitChatShellArgs ): void => {
 };
 
 const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
-	removeChatShellMessageHandler?.();
-	removeChatShellMessageHandler = addHostMessageHandler( ( event: MessageEvent ) => {
-		if ( event.origin !== args.iframeOrigin ) {
+	const { instance } = args;
+
+	removeMessageHandlers.get( instance )?.();
+	removeMessageHandlers.set( instance, addHostMessageHandler( ( event: MessageEvent ) => {
+		if ( ! isTrustedIframeMessage( event, args.iframeOrigin, instance.iframe ) ) {
 			return;
 		}
 
@@ -167,11 +142,7 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				setChatWidgetFullscreen( args.containerId, isStudioOpen );
 
 				if ( isStudioOpen ) {
-					setChatWidgetOpen( {
-						containerId: args.containerId,
-						toggleButtonSelector: args.toggleButtonSelector,
-						isOpen: true,
-					} );
+					setOpen( args, true );
 				}
 
 				if ( port ) {
@@ -180,7 +151,7 @@ const setupChatWidgetMessageListeners = ( args: InitChatShellArgs ): void => {
 				break;
 			}
 		}
-	} );
+	} ) );
 };
 
 export const initChatShell = ( args: InitChatShellArgs ): void => {
@@ -193,6 +164,6 @@ export const initChatShell = ( args: InitChatShellArgs ): void => {
 };
 
 export const resetChatShellForTests = (): void => {
-	removeChatShellMessageHandler?.();
-	removeChatShellMessageHandler = null;
+	removeMessageHandlers.forEach( ( remove ) => remove() );
+	removeMessageHandlers.clear();
 };

--- a/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
+++ b/src/load-sidebar-v2/chat-toggle/init-floating-chat-layout.ts
@@ -1,3 +1,4 @@
+import type { AppState } from '../../config';
 import { initChatShell } from './chat-shell';
 import {
 	injectChatToggleButton,
@@ -11,6 +12,7 @@ type InitFloatingChatLayoutArgs = {
 	toggleButtonSelector: string;
 	injectToggleButton: boolean;
 	onClose?: () => void;
+	instance: AppState;
 };
 
 export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void => {
@@ -26,5 +28,6 @@ export const initFloatingChatLayout = ( args: InitFloatingChatLayoutArgs ): void
 		iframeOrigin: args.iframeOrigin,
 		onClose: args.onClose,
 		toggleButtonSelector: args.toggleButtonSelector,
+		instance: args.instance,
 	} );
 };

--- a/src/load-sidebar-v2/chat-toggle/widget-ui.ts
+++ b/src/load-sidebar-v2/chat-toggle/widget-ui.ts
@@ -6,6 +6,7 @@ import {
 	CHAT_WIDGET_HIDDEN_CLASS,
 	CHAT_WIDGET_STYLES_ID,
 } from './constants';
+import { DEFAULT_CONTAINER_ID } from '../../config';
 import { applySelectorToToggleButton, findToggleButton } from './toggle-button-element';
 
 const ANGIE_ICON_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 16 16" fill="none">
@@ -130,13 +131,24 @@ export const injectChatToggleButtonStyles = (): void => {
 	document.head.appendChild( style );
 };
 
+/**
+ * The CSS is written against one container id, so every container needs its own tag.
+ * The default container keeps the original id, leaving single-instance pages unchanged.
+ */
+const styleIdForContainer = ( containerId: string ): string =>
+	containerId === DEFAULT_CONTAINER_ID
+		? CHAT_WIDGET_STYLES_ID
+		: `${ CHAT_WIDGET_STYLES_ID }-${ containerId }`;
+
 export const injectChatWidgetStyles = ( containerId: string ): void => {
-	if ( document.getElementById( CHAT_WIDGET_STYLES_ID ) ) {
+	const styleId = styleIdForContainer( containerId );
+
+	if ( document.getElementById( styleId ) ) {
 		return;
 	}
 
 	const style = document.createElement( 'style' );
-	style.id = CHAT_WIDGET_STYLES_ID;
+	style.id = styleId;
 	style.textContent = buildWidgetCss( containerId );
 	document.head.appendChild( style );
 };

--- a/src/load-sidebar-v2/embedded-handshake.ts
+++ b/src/load-sidebar-v2/embedded-handshake.ts
@@ -1,16 +1,23 @@
-import { postMessageToAngieIframe } from '../angie-iframe-utils';
+import { postMessageToInstance } from '../angie-iframe-utils';
+import { appState, type AppState } from '../config';
 import type { HostEmbeddedConfigPayload, ResolvedConfigV2 } from './config';
 import { EMBEDDED_CONFIG_MESSAGE_TYPE } from './defaults';
 
-export const sendEmbeddedConfig = ( payload: HostEmbeddedConfigPayload ): void => {
-	postMessageToAngieIframe( {
+export const sendEmbeddedConfig = (
+	payload: HostEmbeddedConfigPayload,
+	instance: AppState = appState
+): void => {
+	postMessageToInstance( instance, {
 		payload,
 		type: EMBEDDED_CONFIG_MESSAGE_TYPE,
 	} );
 };
 
-export const sendWidgetConfig = ( widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']> ): void => {
-	postMessageToAngieIframe( {
+export const sendWidgetConfig = (
+	widgetConfig: NonNullable<ResolvedConfigV2['widgetConfig']>,
+	instance: AppState = appState
+): void => {
+	postMessageToInstance( instance, {
 		payload: widgetConfig,
 		type: 'sdk-widget-config',
 	} );

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -9,7 +9,7 @@ import {
 	resetHostApiBridgeForTests,
 } from './host-api-bridge';
 import { appState } from '../config';
-import { resetInstancesForTests } from '../instance-registry';
+import { createAngieInstance, resetInstancesForTests } from '../instance-registry';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -88,6 +88,68 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 			status: 'success',
 			payload: { 'X-Custom-Token': 'second' },
 		} );
+	} );
+
+	it( 'should route messages to the matching instance when several share an origin', async () => {
+		const windowA = {} as Window;
+		const windowB = {} as Window;
+		const instanceA = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const instanceB = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'sidebar',
+		} );
+		instanceA.iframe = { contentWindow: windowA } as HTMLIFrameElement;
+		instanceB.iframe = { contentWindow: windowB } as HTMLIFrameElement;
+
+		const headersA = jest.fn( async () => ( { 'X-Instance': 'a' } ) ) as jest.MockedFunction<ExternalHeadersCallback>;
+		const headersB = jest.fn( async () => ( { 'X-Instance': 'b' } ) ) as jest.MockedFunction<ExternalHeadersCallback>;
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders: headersA,
+			instance: instanceA,
+		} );
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getExternalHeaders: headersB,
+			instance: instanceB,
+		} );
+
+		const portA = createMockPort();
+		window.dispatchEvent( Object.assign( new Event( 'message' ), {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			source: windowA,
+			ports: [ portA as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( headersA ).toHaveBeenCalledTimes( 1 );
+		expect( headersB ).not.toHaveBeenCalled();
+		expect( portA.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { 'X-Instance': 'a' },
+		} );
+
+		const portUnknown = createMockPort();
+		window.dispatchEvent( Object.assign( new Event( 'message' ), {
+			data: { type: GET_EXTERNAL_HEADERS_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			source: {} as Window,
+			ports: [ portUnknown as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( headersA ).toHaveBeenCalledTimes( 1 );
+		expect( headersB ).not.toHaveBeenCalled();
+		expect( portUnknown.postMessage ).not.toHaveBeenCalled();
 	} );
 
 	it( 'should ignore messages from other origins', async () => {

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -8,6 +8,8 @@ import {
 	initHostApiBridge,
 	resetHostApiBridgeForTests,
 } from './host-api-bridge';
+import { appState } from '../config';
+import { resetInstancesForTests } from '../instance-registry';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -23,10 +25,11 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		resetHostApiBridgeForTests();
+		resetInstancesForTests();
 	} );
 
 	it( 'should respond with empty headers when no callback is provided', async () => {
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		const port = createMockPort();
 		window.dispatchEvent( new MessageEvent( 'message', {
@@ -53,6 +56,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		initHostApiBridge( {
 			iframeOrigin: IFRAME_ORIGIN,
 			getExternalHeaders,
+			instance: appState,
 		} );
 
 		const firstPort = createMockPort();
@@ -92,6 +96,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		initHostApiBridge( {
 			iframeOrigin: IFRAME_ORIGIN,
 			getExternalHeaders,
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -113,6 +118,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 			getExternalHeaders: async () => {
 				throw new Error( 'Token unavailable' );
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -137,6 +143,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 				appId: 'test-app',
 				website: { name: 'Custom Site', wpVersion: '6.4' },
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -174,6 +181,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 					plugins: { elementor: true },
 				},
 			},
+			instance: appState,
 		} );
 
 		const port = createMockPort();
@@ -201,7 +209,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	it( 'should handle localStorage GET', async () => {
 		window.localStorage.setItem( 'angie-test-key', 'stored-value' );
 
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		const port = createMockPort();
 		window.dispatchEvent( new MessageEvent( 'message', {
@@ -218,7 +226,7 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 	} );
 
 	it( 'should handle localStorage SET', async () => {
-		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN } );
+		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 
 		window.dispatchEvent( new MessageEvent( 'message', {
 			data: {

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,5 +1,6 @@
 import { sendErrorMessage, sendSuccessMessage } from '../utils';
 import { HostLocalStorageEventType } from '../types';
+import type { AppState } from '../config';
 import type { ExternalHeadersCallback, HostConfig } from './config';
 
 export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
@@ -12,10 +13,26 @@ type InitHostApiBridgeArgs = {
 	iframeOrigin: string;
 	host?: HostConfig;
 	getExternalHeaders?: ExternalHeadersCallback;
+	instance: AppState;
 };
 
-let bridgeConfig: InitHostApiBridgeArgs | null = null;
+const bridges = new Map<AppState, InitHostApiBridgeArgs>();
 let bridgeListenerRegistered = false;
+
+// Disambiguate by event.source when several instances share one origin; see isFromIframe.
+const findBridge = ( event: MessageEvent ): InitHostApiBridgeArgs | null => {
+	const matching = [ ...bridges.values() ].filter(
+		( bridge ) => bridge.iframeOrigin === event.origin,
+	);
+
+	if ( matching.length <= 1 ) {
+		return matching[ 0 ] ?? null;
+	}
+
+	return matching.find(
+		( bridge ) => bridge.instance.iframe?.contentWindow === event.source,
+	) ?? null;
+};
 
 const filterDefinedHeaders = (
 	headers: Record<string, string | undefined>,
@@ -83,7 +100,9 @@ const handleHostLocalStorageSet = ( key: string, value: string ): void => {
 };
 
 const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
-	if ( ! bridgeConfig || event.origin !== bridgeConfig.iframeOrigin ) {
+	const bridgeConfig = findBridge( event );
+
+	if ( ! bridgeConfig ) {
 		return;
 	}
 
@@ -131,7 +150,7 @@ const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
 };
 
 export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
-	bridgeConfig = args;
+	bridges.set( args.instance, args );
 
 	if ( bridgeListenerRegistered ) {
 		return;
@@ -144,5 +163,5 @@ export const initHostApiBridge = ( args: InitHostApiBridgeArgs ): void => {
 };
 
 export const resetHostApiBridgeForTests = (): void => {
-	bridgeConfig = null;
+	bridges.clear();
 };

--- a/src/load-sidebar-v2/layouts/index.ts
+++ b/src/load-sidebar-v2/layouts/index.ts
@@ -1,5 +1,6 @@
 import { initFloatingChatLayout } from '../chat-toggle/init-floating-chat-layout';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR, type LoadSidebarV2Layout, type ResolvedConfigV2 } from '../config';
+import type { AppState } from '../../config';
 import type { Env } from '../env';
 import {
 	applyInitialSidebarShellState,
@@ -10,6 +11,7 @@ import {
 export type LayoutBootContext = {
 	config: ResolvedConfigV2;
 	env: Env;
+	instance: AppState;
 };
 
 export type LayoutStrategy = {
@@ -19,19 +21,19 @@ export type LayoutStrategy = {
 };
 
 const sidebarStrategy: LayoutStrategy = {
-	initShell: ( { config } ) => {
-		initSidebarShell( config.container, config.callbacks );
+	initShell: ( { config, instance } ) => {
+		initSidebarShell( config.container, config.callbacks, instance );
 	},
 	beforeOpenIframe: ( { config } ) => {
 		applyInitialSidebarShellState( config.container );
 	},
-	afterOpenIframe: ( { config } ) => {
-		finalizeSidebarShellState( config.container );
+	afterOpenIframe: ( { config, instance } ) => {
+		finalizeSidebarShellState( config.container, instance );
 	},
 };
 
 const floatingChatStrategy: LayoutStrategy = {
-	initShell: ( { config } ) => {
+	initShell: ( { config, instance } ) => {
 		const { chatToggleButton } = config.container;
 
 		initFloatingChatLayout( {
@@ -40,6 +42,7 @@ const floatingChatStrategy: LayoutStrategy = {
 			onClose: config.callbacks.onClose,
 			toggleButtonSelector: chatToggleButton.selector,
 			injectToggleButton: chatToggleButton.enabled,
+			instance,
 		} );
 	},
 };

--- a/src/load-sidebar-v2/open-embedded-iframe.test.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.test.ts
@@ -3,7 +3,10 @@ import { appState } from '../config';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 
 jest.mock( '../iframe', () => ( {
-	openIframe: jest.fn( () => Promise.resolve() ),
+	openIframe: jest.fn( () => Promise.resolve( {
+		iframe: {} as HTMLIFrameElement,
+		iframeOrigin: 'https://angie.elementor.com',
+	} ) ),
 } ) );
 
 jest.mock( '../utils', () => ( {
@@ -48,7 +51,7 @@ describe( 'load-sidebar-v2/open-embedded-iframe', () => {
 			},
 		} );
 
-		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false );
+		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, false, appState.containerId );
 		expect( syncToggleButton ).toHaveBeenCalledWith( '#demo-sidebar-toggle', false );
 	} );
 } );

--- a/src/load-sidebar-v2/open-embedded-iframe.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.ts
@@ -1,4 +1,4 @@
-import { appState } from '../config';
+import { appState, type AppState } from '../config';
 import { openIframe } from '../iframe';
 import { toggleAngieSidebar } from '../utils';
 import { LAYOUT_FLOATING_CHAT, type HostEmbeddedConfigPayload, type ResolvedConfigV2 } from './config';
@@ -9,16 +9,24 @@ type OpenEmbeddedIframeArgs = {
 	container: ResolvedConfigV2['container'];
 	iframe: ResolvedConfigV2['iframe'];
 	embeddedConfig?: HostEmbeddedConfigPayload;
+	instance?: AppState;
 };
 
-export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<void> => {
-	await openIframe( {
+export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promise<boolean> => {
+	const instance = args.instance ?? appState;
+
+	const opened = await openIframe( {
 		isRTL: args.iframe.isRTL,
 		origin: args.iframe.origin,
 		path: args.iframe.path,
 		uiTheme: args.iframe.uiTheme,
 		embeddedConfig: args.embeddedConfig,
-	} );
+	}, instance );
+
+	// No iframe on mobile, so there is nothing to configure or toggle.
+	if ( ! opened ) {
+		return false;
+	}
 
 	if (
 		args.container.layout === LAYOUT_FLOATING_CHAT &&
@@ -28,15 +36,18 @@ export const openEmbeddedIframe = async ( args: OpenEmbeddedIframeArgs ): Promis
 			containerId: args.container.id,
 			toggleButtonSelector: args.container.chatToggleButton.selector,
 			isOpen: false,
+			instance,
 		} );
-		return;
+		return true;
 	}
 
-	if ( appState.iframe ) {
-		toggleAngieSidebar( appState.iframe, false );
+	if ( instance.iframe ) {
+		toggleAngieSidebar( instance.iframe, false, instance.containerId );
 	}
 
 	if ( args.container.chatToggleButton.enabled ) {
 		syncToggleButton( args.container.chatToggleButton.selector, false );
 	}
+
+	return true;
 };

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -37,6 +37,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 			appId: options.host.appId,
 			aiContext: options.host.aiContext,
 			website: options.host.website,
+			analytics: options.host.analytics,
 		},
 		boot: {
 			allowInIframe: boot.allowInIframe ?? DEFAULTS.boot.allowInIframe,

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -7,6 +7,7 @@ import {
 	initializeResize,
 	loadState,
 } from '../sidebar';
+import { appState, type AppState } from '../config';
 import type { ContainerConfig, ResolvedConfigV2 } from './config';
 import {
 	syncToggleButton,
@@ -17,12 +18,14 @@ import { injectStyleThemeCss } from './inject-style-theme';
 export const initSidebarShell = (
 	container: ContainerConfig,
 	callbacks: ResolvedConfigV2['callbacks'],
+	instance: AppState = appState,
 ): void => {
 	const toggleButtonSelector = container.chatToggleButton.enabled
 		? container.chatToggleButton.selector
 		: undefined;
 
 	initAngieSidebar( {
+		instance,
 		onToggle: ( isOpen ) => {
 			if ( toggleButtonSelector ) {
 				syncToggleButton( toggleButtonSelector, isOpen );
@@ -66,6 +69,7 @@ export const applyInitialSidebarShellState = (
 
 export const finalizeSidebarShellState = (
 	container: ContainerConfig,
+	instance: AppState = appState,
 ): void => {
 	if ( container.persistOpenState ) {
 		loadState(
@@ -76,6 +80,6 @@ export const finalizeSidebarShellState = (
 	}
 
 	if ( container.resizable ) {
-		initializeResize();
+		initializeResize( instance );
 	}
 };


### PR DESCRIPTION
## Summary
- Pass `instance` through loadSidebarV2 boot, layouts, host-api-bridge, and chat shell
- Register instances via `createAngieInstance` on boot
- Pass SDK `instanceId` into `bootSidebar`

Still single-instance at runtime — no boot guards yet. Split from former #68. Stack 3/4.

## Test plan
- [x] `npm test` (200 tests)
- [x] `npm run build`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Refactoring sidebar boot to support per-instance state instead of global `appState`. Enables multi-instance sidebar support on same page without state collisions.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `angie-mcp-sdk.ts` | Pass `instanceId` to `bootSidebar()` |
| `boot-sidebar.ts` | Create instance via registry, thread through layout strategies |
| `chat-shell.ts` | Replace global `removeChatShellMessageHandler` with per-instance `Map`, add `instance` param |
| `embedded-handshake.ts` | Accept optional `instance` param, default to `appState` for backward compat |
| `host-api-bridge.ts` | Store bridges per-instance in `Map`, disambiguate by `event.source` |
| `open-embedded-iframe.ts` | Return boolean (success), accept instance param |
| `shell.ts`, `layouts/index.ts` | Thread instance through sidebar/layout initialization |
| `widget-ui.ts` | Generate per-container style IDs to avoid CSS collisions |
| Test files | Mock return values updated, instance params added to assertions |

## 3. How It Works

1. `SDK.loadSidebarV2()` → generates/receives `instanceId` → calls `bootSidebar(options, instanceId)`
2. `bootSidebar` creates `AppState` instance via registry, threads through: layout strategies → chat shell → host API bridge → embedded config senders
3. Message handlers keyed by instance (`Map<AppState, cleanup>`), allowing proper routing when multiple iframes share origin
4. `openEmbeddedIframe()` returns success boolean to short-circuit config sending if iframe open fails
5. Per-container style IDs prevent CSS rule conflicts in multi-instance scenarios

## 4. Risks

None identified. Backward-compatible defaults preserve single-instance behavior; test coverage expanded for multi-instance routing. Message handler cleanup properly scoped per-instance.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
