### PR TITLE
feat: support multiple loadSidebarV2 instances on one page

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -120,9 +120,9 @@
         <strong>loadSidebarV2 — floating chat</strong>
         <span>Minimal floating chat widget layout.</span>
       </a>
-      <a class="card" href="./load-sidebar-v2-right-click-floating/">
-        <strong>loadSidebarV2 — right click floating</strong>
-        <span>Right-click a text area to rewrite it with a host MCP server.</span>
+      <a class="card" href="./load-sidebar-v2-multi-instance/">
+        <strong>loadSidebarV2 — three instances</strong>
+        <span>A sidebar and two floating chats on one page, each with its own iframe and widget config.</span>
       </a>
       <a class="card" href="./load-sidebar-v1-demo/">
         <strong>loadSidebar (v1)</strong>

--- a/demo/load-sidebar-v2-multi-instance/host.js
+++ b/demo/load-sidebar-v2-multi-instance/host.js
@@ -1,0 +1,66 @@
+import { AngieMcpSdk, LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from '../../dist/index.js';
+
+const sidebarSdk = new AngieMcpSdk();
+const chatSdk = new AngieMcpSdk();
+const chatSdk2 = new AngieMcpSdk();
+
+await sidebarSdk.loadSidebarV2( {
+	host: { appId: 'demo-sidebar', instanceId: 'demo-sidebar' },
+	container: {
+		layout: LAYOUT_SIDEBAR,
+		chatToggleButton: { enabled: true, selector: '#sidebar-toggle' },
+	},
+	widgetConfig: { title: 'Sidebar instance' },
+} );
+
+await chatSdk.loadSidebarV2( {
+	host: { appId: 'demo-chat', instanceId: 'demo-chat' },
+	container: { id: 'angie-chat-container', layout: LAYOUT_FLOATING_CHAT },
+	widgetConfig: { title: 'Chat A instance' },
+} );
+
+await chatSdk2.loadSidebarV2( {
+	host: { appId: 'demo-chat-2', instanceId: 'demo-chat-2' },
+	container: { id: 'angie-chat-container-2', layout: LAYOUT_FLOATING_CHAT },
+	widgetConfig: { title: 'Chat B instance' },
+} );
+
+const iframes = () => [ ...document.querySelectorAll( 'iframe[src*="angie/"]' ) ].map(
+	( frame ) => ( {
+		elementId: frame.id,
+		container: frame.closest( 'div[id]' )?.id,
+		urlInstanceId: new URL( frame.src ).searchParams.get( 'instanceId' ),
+	} ),
+);
+
+const toggles = () => [ ...document.querySelectorAll( '[id^="angie-widget-toggle"], #sidebar-toggle' ) ]
+	.map( ( button ) => ( { id: button.id, expanded: button.getAttribute( 'aria-expanded' ) } ) );
+
+const openContainers = () => [ ...document.querySelectorAll( 'div[id^="angie-"]' ) ]
+	.filter( ( element ) => element.querySelector( 'iframe' ) )
+	.map( ( element ) => ( {
+		container: element.id,
+		open: ! element.classList.contains( 'angie-widget-hidden' ),
+	} ) );
+
+const styleTags = () => [ ...document.querySelectorAll( 'style[id]' ) ].map( ( tag ) => tag.id );
+
+const storage = () => Object.fromEntries(
+	Object.keys( localStorage )
+		.filter( ( key ) => key.startsWith( 'angie' ) )
+		.map( ( key ) => [ key, localStorage.getItem( key ) ] ),
+);
+
+window.angieDemo = {
+	AngieMcpSdk,
+	LAYOUT_FLOATING_CHAT,
+	LAYOUT_SIDEBAR,
+	sidebarSdk,
+	chatSdk,
+	chatSdk2,
+	iframes,
+	toggles,
+	openContainers,
+	styleTags,
+	storage,
+};

--- a/demo/load-sidebar-v2-multi-instance/index.html
+++ b/demo/load-sidebar-v2-multi-instance/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>loadSidebarV2 — three instances</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/types.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod/v4": "../../node_modules/zod/v4/index.js"
+    }
+  }
+  </script>
+  <style>
+    body { margin: 0; padding: 1rem 1rem 8rem; font-family: system-ui, sans-serif; }
+    h2 { margin-block: 1.5rem 0.5rem; font-size: 1rem; }
+    code { background: #f2f2f2; padding: 0.1em 0.35em; border-radius: 3px; }
+    ul { line-height: 1.7; }
+
+    /* Move the second chat aside so both floating widgets stay visible.
+       `body #id.class` outranks the SDK's `#id.class` rules whatever the order. */
+    body #angie-chat-container-2.angie-widget-container {
+      inset-inline-end: 440px !important;
+    }
+    body #angie-widget-toggle-demo-chat-2 {
+      inset-inline-end: 96px !important;
+      background: #6366f1 !important;
+    }
+  </style>
+</head>
+<body>
+  <p><a href="../">← All demos</a></p>
+
+  <h2>Three Angie instances on one page</h2>
+  <p>
+    One <code>sidebar</code> and two <code>floatingChat</code> instances. Each has its own
+    container, iframe, and widget config.
+  </p>
+
+  <ul>
+    <li><strong>Sidebar</strong> — <code>demo-sidebar</code>, opens with the button below.</li>
+    <li><strong>Chat A</strong> — <code>demo-chat</code>, pink toggle at the bottom right.</li>
+    <li><strong>Chat B</strong> — <code>demo-chat-2</code>, indigo toggle beside it.</li>
+  </ul>
+
+  <p>
+    <button type="button" id="sidebar-toggle">Open the sidebar instance</button>
+  </p>
+
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <div id="angie-chat-container" aria-hidden="true"></div>
+  <div id="angie-chat-container-2" aria-hidden="true"></div>
+
+  <script type="module" src="./host.js"></script>
+</body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.5.2",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -564,6 +564,29 @@ describe('AngieMcpSdk', () => {
       expect( mockBootSidebar ).toHaveBeenCalledTimes( 1 );
       expect( mockBootSidebar ).toHaveBeenCalledWith( options, expect.any( String ) );
     });
+
+    it('should adopt host.instanceId so routing matches the booted instance', async () => {
+      const mockBootSidebar = require('./load-sidebar-v2/boot-sidebar').bootSidebar as jest.MockedFunction<any>;
+      const options = {
+        host: {
+          appId: 'editor-lite',
+          instanceId: 'stable-id',
+        },
+      };
+      mockAngieDetector.isReady.mockReturnValue(true);
+
+      await sdk.loadSidebarV2( options );
+
+      expect( mockBootSidebar ).toHaveBeenCalledWith( options, 'stable-id' );
+
+      const promise = sdk.triggerAngie( { prompt: 'hi', context: {}, options: { timeout: 50 } } );
+      const call = ( window.postMessage as jest.MockedFunction<any> ).mock.calls.find(
+        ( item: any[] ) => item[ 0 ]?.type === 'sdk-trigger-angie',
+      );
+
+      expect( call?.[ 0 ].payload.instanceId ).toBe( 'stable-id' );
+      await expect( promise ).rejects.toThrow( 'timed out' );
+    });
   });
 
   describe('parseHashParams', () => {

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -119,6 +119,10 @@ export class AngieMcpSdk {
   }
 
   public loadSidebarV2( options: LoadSidebarV2Options ): Promise<void> {
+    if ( options.host.instanceId ) {
+      this.instanceId = options.host.instanceId;
+    }
+
     this.sidebarV2BootPromise = bootSidebar( options, this.instanceId );
     return this.sidebarV2BootPromise;
   }
@@ -320,6 +324,7 @@ export class AngieMcpSdk {
         type: MessageEventType.SDK_TRIGGER_ANGIE,
         payload: {
           requestId,
+          instanceId: this.instanceId,
           prompt: request.prompt,
           options: request.options,
           context: {

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -53,7 +53,7 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 
 | Section | Purpose |
 |---------|---------|
-| `host` | **Required.** `appId`, optional `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
+| `host` | **Required.** `appId`, optional `instanceId` (see [multiple instances](#multiple-instances-on-one-page)), `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
 | `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
 | `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
@@ -76,6 +76,51 @@ Keep it focused on what helps the agent answer screen-level questions:
 Example: [`demo/load-sidebar-v2-full-config/host.js`](../../demo/load-sidebar-v2-full-config/host.js) reads `#demo-host-app` into `whatUserSees` and lists allowed actions in `whatUserCanDo`.
 
 Enable `widgetConfig.aiContextGuidance: { enabled: true }` so users see that host context is available. Full reference: [widget-config.md](./widget-config.md).
+
+## Multiple instances on one page
+
+You can run more than one Angie instance on the same page. Each one keeps its own
+iframe, its own config and its own messages.
+
+Two rules:
+
+1. **Give every extra instance its own `container.id`.** The default is
+   `angie-sidebar-container` for every layout, so two instances that do not set it would
+   share one `<div>`. Booting the second one throws an error that names the id.
+2. **Only one instance may use the `sidebar` layout.** That layout paints through
+   page-wide CSS (`body.angie-sidebar-active` and `#angie-sidebar-container`), so a
+   second sidebar would have no styling and would share the first one's open state.
+   Booting a second sidebar throws. Extra instances must use `floatingChat`.
+
+```js
+const sidebarSdk = new AngieMcpSdk();
+await sidebarSdk.loadSidebarV2( {
+	host: { appId: 'my-app', instanceId: 'my-app-sidebar' },
+	container: { layout: LAYOUT_SIDEBAR },
+} );
+
+const chatSdk = new AngieMcpSdk();
+await chatSdk.loadSidebarV2( {
+	host: { appId: 'my-app-help', instanceId: 'my-app-help' },
+	container: { id: 'angie-help-container', layout: LAYOUT_FLOATING_CHAT },
+} );
+```
+
+Working example: [`demo/load-sidebar-v2-multi-instance`](../../demo/load-sidebar-v2-multi-instance/).
+
+### host.instanceId
+
+Optional. Names the instance. When you leave it out, the SDK generates a new id on every
+page load.
+
+The id names the instance's iframe (`angie-iframe-<instanceId>`), appears as the
+`instanceId` query parameter in the iframe URL, and routes MCP server registrations back
+to the right instance. Pass a stable id when you want those to stay the same across page
+loads, for example to target the iframe from your own CSS or end-to-end tests.
+
+Legacy globals (`window.toggleAngieSidebar`, `getAngieIframe()`, and similar helpers)
+still target the first booted instance. Hold the `AngieMcpSdk` object if you need a
+specific instance.
 
 ### Custom CSS (toggle + sidebar panel)
 

--- a/src/load-sidebar-v2/boot-sidebar.integration.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.integration.test.ts
@@ -1,0 +1,125 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { bootSidebar } from './boot-sidebar';
+import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
+import { CHAT_WIDGET_HIDDEN_CLASS } from './chat-toggle/constants';
+import { resetHostApiBridgeForTests } from './host-api-bridge';
+import { resetHostMessageRouterForTests } from './host-message-router';
+import { resetChatShellForTests } from './chat-toggle/chat-shell';
+import { resetInstancesForTests } from '../instance-registry';
+
+jest.mock( '../openSaaSPage', () => ( { openSaaSPage: jest.fn() } ) );
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+type FakeIframe = {
+	iframe: HTMLIFrameElement;
+	postMessage: jest.Mock;
+	contentWindow: Window;
+};
+
+const openedIframes: FakeIframe[] = [];
+
+const iframeOf = ( containerId: string ): FakeIframe => {
+	const container = document.getElementById( containerId )!;
+	const found = openedIframes.find( ( item ) => container.contains( item.iframe ) );
+
+	if ( ! found ) {
+		throw new Error( `no iframe was mounted into #${ containerId }` );
+	}
+
+	return found;
+};
+
+const sentPayload = ( target: FakeIframe, type: string ): unknown =>
+	( target.postMessage.mock.calls.find(
+		( call: unknown[] ) => ( call[ 0 ] as { type: string } ).type === type,
+	)?.[ 0 ] as { payload: unknown } | undefined )?.payload;
+
+const sentTypes = ( target: FakeIframe ): string[] =>
+	target.postMessage.mock.calls.map( ( call: unknown[] ) => ( call[ 0 ] as { type: string } ).type );
+
+const emitFromIframe = ( target: FakeIframe, data: unknown ): void => {
+	window.dispatchEvent( Object.assign( new Event( 'message' ), {
+		origin: ANGIE_ORIGIN,
+		source: target.contentWindow,
+		data,
+	} ) );
+};
+
+describe( 'load-sidebar-v2/boot-sidebar integration', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'matchMedia', {
+			writable: true,
+			value: jest.fn().mockImplementation( ( query: unknown ) => ( {
+				matches: false,
+				media: String( query ),
+				addEventListener: jest.fn(),
+				removeEventListener: jest.fn(),
+			} ) ),
+		} );
+		Object.defineProperty( window, 'screen', { writable: true, value: { availWidth: 1280 } } );
+	} );
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		document.body.innerHTML = '';
+		document.head.innerHTML = '';
+		document.body.className = '';
+		openedIframes.length = 0;
+		resetInstancesForTests();
+		resetHostApiBridgeForTests();
+		resetHostMessageRouterForTests();
+		resetChatShellForTests();
+
+		( require( '../openSaaSPage' ).openSaaSPage as jest.Mock ).mockImplementation(
+			async ( props: any ) => {
+				const iframe = document.createElement( 'iframe' );
+				const postMessage = jest.fn();
+				const contentWindow = { postMessage } as unknown as Window;
+
+				Object.defineProperty( iframe, 'contentWindow', { value: contentWindow } );
+				iframe.id = props.iframeElementId;
+				iframe.setAttribute( 'src', `${ props.origin }/${ props.path }` );
+				props.insertCallback?.( iframe );
+				openedIframes.push( { iframe, postMessage, contentWindow } );
+
+				return { iframe, iframeUrlObject: new URL( ANGIE_ORIGIN ) };
+			},
+		);
+	} );
+
+	it( 'should run a sidebar and a floating chat side by side', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR },
+			host: { appId: 'app-sidebar', instanceId: 'sidebar1' },
+			widgetConfig: { title: 'Sidebar' },
+		} );
+		await bootSidebar( {
+			container: {
+				id: 'chat-b',
+				layout: LAYOUT_FLOATING_CHAT,
+				chatToggleButton: { enabled: true, selector: '#toggle-chat-b' },
+			},
+			host: { appId: 'app-b', instanceId: 'bbbbbb' },
+			widgetConfig: { title: 'Widget B' },
+		} );
+
+		const sidebarIframe = iframeOf( 'angie-sidebar-container' );
+		const chatIframe = iframeOf( 'chat-b' );
+
+		expect( sentPayload( sidebarIframe, 'sdk-widget-config' ) )
+			.toEqual( expect.objectContaining( { title: 'Sidebar' } ) );
+		expect( sentPayload( chatIframe, 'sdk-widget-config' ) )
+			.toEqual( expect.objectContaining( { title: 'Widget B' } ) );
+
+		const sidebarWasActive = document.body.classList.contains( 'angie-sidebar-active' );
+		const sidebarMessagesBefore = sentTypes( sidebarIframe ).length;
+
+		emitFromIframe( chatIframe, { type: 'toggleAngieSidebar', payload: { force: true } } );
+
+		expect( document.getElementById( 'chat-b' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( false );
+		expect( document.body.classList.contains( 'angie-sidebar-active' ) ).toBe( sidebarWasActive );
+		expect( sentTypes( sidebarIframe ) ).toHaveLength( sidebarMessagesBefore );
+	} );
+} );

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -118,11 +118,53 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockInitAngieSidebar ).toHaveBeenCalled();
 	} );
 
-	it( 'should name the instance after the sdk id', async () => {
+	it( 'should refuse a second sidebar layout instance', async () => {
+		await bootSidebar( { container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } } );
+
+		await expect( bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR, id: 'sidebar-b' },
+			host: { appId: 'app-b' },
+		} ) ).rejects.toThrow( /sidebar/i );
+	} );
+
+	it( 'should refuse a container id that another instance already uses', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-a' },
+		} );
+
+		await expect( bootSidebar( {
+			container: { layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-b' },
+		} ) ).rejects.toThrow( /angie-sidebar-container/ );
+	} );
+
+	it( 'should refuse an instance id that another instance already uses', async () => {
+		await bootSidebar( {
+			container: { id: 'chat-a', layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-a', instanceId: 'shared-id' },
+		} );
+
+		await expect( bootSidebar( {
+			container: { id: 'chat-b', layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-b', instanceId: 'shared-id' },
+		} ) ).rejects.toThrow( /shared-id/ );
+	} );
+
+	it( 'should name the instance after the sdk id, or the host id when given', async () => {
 		await bootSidebar(
 			{ container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a' } },
 			'sdk123',
 		);
 		expect( getFirstInstance()?.instanceId ).toBe( 'sdk123' );
+
+		resetInstancesForTests();
+		document.body.innerHTML = '';
+
+		await bootSidebar(
+			{ container: { layout: LAYOUT_SIDEBAR }, host: { appId: 'app-a', instanceId: 'stable' } },
+			'sdk123',
+		);
+		expect( getFirstInstance()?.instanceId ).toBe( 'stable' );
 	} );
 } );

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -1,12 +1,23 @@
 import { ensureSidebarContainer } from './container';
-import { buildHostEmbeddedConfigPayload, type LoadSidebarV2Options } from './config';
+import {
+	buildHostEmbeddedConfigPayload,
+	LAYOUT_SIDEBAR,
+	type LoadSidebarV2Options,
+} from './config';
+import { DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR } from './defaults';
 import { sendEmbeddedConfig, sendWidgetConfig } from './embedded-handshake';
 import { readEnv } from './env';
 import { initHostApiBridge } from './host-api-bridge';
 import { LAYOUT_STRATEGIES } from './layouts';
 import { openEmbeddedIframe } from './open-embedded-iframe';
 import { handlePostConsentRedirect } from '../oauth';
-import { createAngieInstance } from '../instance-registry';
+import {
+	createAngieInstance,
+	getFirstInstance,
+	getInstanceByContainerId,
+	getInstanceById,
+	hasSidebarLayoutInstance,
+} from '../instance-registry';
 import { resolveConfig, shouldBoot } from './resolve-config';
 import { generateInstanceId } from '../utils';
 
@@ -23,7 +34,38 @@ export const bootSidebar = async (
 		return;
 	}
 
-	const instanceId = sdkInstanceId || generateInstanceId();
+	// Sidebar uses page-wide CSS and open state, so only one is supported.
+	if ( config.container.layout === LAYOUT_SIDEBAR && hasSidebarLayoutInstance() ) {
+		throw new Error(
+			'Angie SDK: only one sidebar layout instance is supported on a page. ' +
+			'Use container.layout "floatingChat" for the extra instance.'
+		);
+	}
+
+	if ( getInstanceByContainerId( config.container.id ) ) {
+		throw new Error(
+			`Angie SDK: container id "${ config.container.id }" is already used by another ` +
+			'Angie instance. Give this instance its own container.id.'
+		);
+	}
+
+	const instanceId = config.host.instanceId || sdkInstanceId || generateInstanceId();
+
+	if ( getInstanceById( instanceId ) ) {
+		throw new Error(
+			`Angie SDK: instance id "${ instanceId }" is already used by another ` +
+			'Angie instance. Give this instance its own host.instanceId.'
+		);
+	}
+
+	// Two instances would otherwise fight over the same default toggle button.
+	if (
+		getFirstInstance() &&
+		config.container.chatToggleButton.selector === DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR
+	) {
+		config.container.chatToggleButton.selector =
+			`${ DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR }-${ instanceId }`;
+	}
 
 	const instance = createAngieInstance( {
 		containerId: config.container.id,

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.test.ts
@@ -3,7 +3,9 @@ import { appState } from '../../config';
 import { toggleAngieSidebar } from '../../utils';
 import { syncToggleButton } from '../toggle-button';
 import { CHAT_WIDGET_HIDDEN_CLASS } from './constants';
-import { setChatWidgetOpen } from './chat-shell';
+import { initChatShell, resetChatShellForTests, setChatWidgetOpen } from './chat-shell';
+import { createAngieInstance, resetInstancesForTests } from '../../instance-registry';
+import { resetHostMessageRouterForTests } from '../host-message-router';
 
 jest.mock( '../../utils', () => ( {
 	...( jest.requireActual( '../../utils' ) as object ),
@@ -58,5 +60,100 @@ describe( 'load-sidebar-v2/chat-toggle/chat-shell', () => {
 		expect( container.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( false );
 		expect( toggleAngieSidebar ).toHaveBeenCalledWith( appState.iframe, true, CONTAINER_ID );
 		expect( syncToggleButton ).toHaveBeenCalledWith( TOGGLE_SELECTOR, true );
+	} );
+} );
+
+describe( 'load-sidebar-v2/chat-toggle/chat-shell multi-instance', () => {
+	const IFRAME_ORIGIN = 'https://angie.elementor.com';
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetChatShellForTests();
+		resetHostMessageRouterForTests();
+		resetInstancesForTests();
+		document.body.innerHTML = `
+			<div id="chat-a" class="${ CHAT_WIDGET_HIDDEN_CLASS }"></div>
+			<div id="chat-b" class="${ CHAT_WIDGET_HIDDEN_CLASS }"></div>
+			<button id="toggle-a" type="button"></button>
+			<button id="toggle-b" type="button"></button>
+		`;
+	} );
+
+	it( 'should open only the widget whose iframe sent the toggle message', () => {
+		const first = createAngieInstance( {
+			containerId: 'chat-a',
+			instanceId: 'aaaaaa',
+			layout: 'floatingChat',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'chat-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const secondWindow = {} as Window;
+		first.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+		second.iframe = { contentWindow: secondWindow } as HTMLIFrameElement;
+
+		initChatShell( {
+			containerId: 'chat-a',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-a',
+			instance: first,
+		} );
+		initChatShell( {
+			containerId: 'chat-b',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-b',
+			instance: second,
+		} );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: IFRAME_ORIGIN,
+			source: secondWindow,
+			data: { type: 'toggleAngieSidebar', payload: { force: true } },
+		} ) );
+
+		expect( document.getElementById( 'chat-b' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( false );
+		expect( document.getElementById( 'chat-a' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( true );
+	} );
+
+	it( 'should keep the first widget listening after a second one starts', () => {
+		const first = createAngieInstance( {
+			containerId: 'chat-a',
+			instanceId: 'aaaaaa',
+			layout: 'floatingChat',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'chat-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const firstWindow = {} as Window;
+		first.iframe = { contentWindow: firstWindow } as HTMLIFrameElement;
+		second.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+
+		initChatShell( {
+			containerId: 'chat-a',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-a',
+			instance: first,
+		} );
+		initChatShell( {
+			containerId: 'chat-b',
+			iframeOrigin: IFRAME_ORIGIN,
+			toggleButtonSelector: '#toggle-b',
+			instance: second,
+		} );
+
+		window.dispatchEvent( new MessageEvent( 'message', {
+			origin: IFRAME_ORIGIN,
+			source: firstWindow,
+			data: { type: 'toggleAngieSidebar', payload: { force: true } },
+		} ) );
+
+		expect( document.getElementById( 'chat-a' )!.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) )
+			.toBe( false );
 	} );
 } );

--- a/src/load-sidebar-v2/chat-toggle/chat-shell.ts
+++ b/src/load-sidebar-v2/chat-toggle/chat-shell.ts
@@ -1,4 +1,5 @@
 import type { AppState } from '../../config';
+import { hasSidebarLayoutInstance } from '../../instance-registry';
 import { MessageEventType } from '../../types';
 import { isTrustedIframeMessage, sendSuccessMessage, toggleAngieSidebar } from '../../utils';
 import { syncToggleButton, wireToggleButton } from '../toggle-button';
@@ -158,9 +159,12 @@ export const initChatShell = ( args: InitChatShellArgs ): void => {
 	initToggleButton( args );
 	setupChatWidgetMessageListeners( args );
 
-	window.toggleAngieSidebar = ( force?: boolean ) => {
-		handleSidebarToggleMessage( args, { force } );
-	};
+	// Preserve the sidebar's global toggle when both layouts are used.
+	if ( ! hasSidebarLayoutInstance() ) {
+		window.toggleAngieSidebar = ( force?: boolean ) => {
+			handleSidebarToggleMessage( args, { force } );
+		};
+	}
 };
 
 export const resetChatShellForTests = (): void => {

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -12,6 +12,7 @@ export type LoadSidebarV2ContainerStyleTheme = 'wordpress' | '';
 
 export type HostConfig = {
 	appId: string;
+	instanceId?: string;
 	aiContext?: Record<string, unknown>;
 	website?: Record<string, unknown>;
 	analytics?: Record<string, unknown>;

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -9,7 +9,7 @@ import {
 	resetHostApiBridgeForTests,
 } from './host-api-bridge';
 import { appState } from '../config';
-import { resetInstancesForTests } from '../instance-registry';
+import { createAngieInstance, resetInstancesForTests } from '../instance-registry';
 
 const IFRAME_ORIGIN = 'http://localhost:4000';
 
@@ -26,6 +26,48 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		jest.clearAllMocks();
 		resetHostApiBridgeForTests();
 		resetInstancesForTests();
+	} );
+
+	it( 'should answer each instance with its own host config', async () => {
+		const first = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const second = createAngieInstance( {
+			containerId: 'container-b',
+			instanceId: 'bbbbbb',
+			layout: 'floatingChat',
+		} );
+		const secondWindow = {} as Window;
+		first.iframe = { contentWindow: {} as Window } as HTMLIFrameElement;
+		second.iframe = { contentWindow: secondWindow } as HTMLIFrameElement;
+
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: { appId: 'app-a', analytics: { screenPath: '/a' } },
+			instance: first,
+		} );
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: { appId: 'app-b', analytics: { screenPath: '/b' } },
+			instance: second,
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_ANALYTICS_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			source: secondWindow,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { payload: expect.objectContaining( { screenPath: '/b' } ) },
+		} );
 	} );
 
 	it( 'should respond with empty headers when no callback is provided', async () => {

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -35,6 +35,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 	return {
 		host: {
 			appId: options.host.appId,
+			instanceId: options.host.instanceId,
 			aiContext: options.host.aiContext,
 			website: options.host.website,
 			analytics: options.host.analytics,


### PR DESCRIPTION
## Summary
- Add `host.instanceId` and boot guards (one sidebar, unique container/id)
- Route `triggerAngie` by instance; auto-suffix default toggle selectors
- Add three-instance demo, README docs, and bump version to **1.6.0**

Stack 4/4. Replaces #69 (could not retarget base after #68 split).

Safety net: `feat/multi-instance-support` @ `2a549cc` remains the full single-commit reference.

## Test plan
- [x] `npm test` (208 tests)
- [x] `npm run build`
- [ ] Open `demo/load-sidebar-v2-multi-instance/`


Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Enables multiple independent Angie instances (sidebar + floating chats) on one page with isolated iframes, configs, and state. Prevents conflicts through instance registry and validation.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `src/angie-mcp-sdk.ts` | Adopt `host.instanceId` for routing; include `instanceId` in trigger messages |
| `src/load-sidebar-v2/boot-sidebar.ts` | Add instance validation (duplicate container IDs, instance IDs, sidebar-layout limits); compute instanceId priority |
| `src/load-sidebar-v2/config.ts` | Add optional `instanceId` to `HostConfig` |
| `src/load-sidebar-v2/chat-toggle/chat-shell.ts` | Guard global `window.toggleAngieSidebar` when sidebar exists; preserve first instance's toggle |
| Tests & demo | Multi-instance integration tests, validation tests, demo page with 3 instances |

## 3. How It Works

When `loadSidebarV2()` boots:
1. **Priority resolution**: `host.instanceId` (stable) > `sdkInstanceId` (from SDK) > generated ID
2. **Validation**: Registry checks for duplicate container IDs, instance IDs, and blocks second sidebar layout
3. **Toggle button deconfliction**: If multiple instances exist, append `instanceId` to default selector
4. **Message routing**: Each instance receives its own config via iframe; `triggerAngie` includes `instanceId` to route MCP responses correctly
5. **Global fallback**: Legacy `window.toggleAngieSidebar` targets first booted sidebar; hold SDK reference for specific instances

## 4. Risks

**Sidebar CSS conflict**: Two `sidebar` layouts share `body.angie-sidebar-active` and `#angie-sidebar-container`—blocked by validation. **Container collision**: Requires unique `container.id` per instance; validation throws if reused. **Legacy API limitation**: Global helpers (`window.toggleAngieSidebar`, `getAngieIframe()`) target first instance only—documented trade-off, SDK object handles specific instances.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
