### PR TITLE
Harden PR CI dispatch against token leak and fork runs

### DIFF
--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -5,9 +5,6 @@ inputs:
   workflow:
     description: 'Workflow filename in elementor/angie-dev-tools'
     required: true
-  token:
-    description: 'Bot token that can dispatch workflows on angie-dev-tools'
-    required: true
   dry_run:
     description: 'Optional dry_run input for the approver workflow'
     required: false
@@ -19,13 +16,13 @@ runs:
     - name: Dispatch workflow
       shell: bash
       env:
-        GH_TOKEN: ${{ inputs.token }}
         WORKFLOW: ${{ inputs.workflow }}
         DRY_RUN: ${{ inputs.dry_run }}
         PR_INPUT: ${{ github.event.pull_request.html_url || github.event.inputs.pr_input }}
         REPOSITORY: ${{ github.repository }}
         EVENT_NAME: ${{ github.event_name }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        GH_API_TOKEN: ${{ github.token }}
       run: |
         if [ -z "$GH_TOKEN" ]; then
           echo "ANGIE_DEV_TOOLS_BOT_TOKEN is required to dispatch private angie-dev-tools workflows." >&2
@@ -36,15 +33,21 @@ runs:
           exit 1
         fi
 
-        if [ "$EVENT_NAME" = "pull_request" ]; then
+        if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
           if [ "$PR_HEAD_REPO" != "$REPOSITORY" ]; then
             echo "Skipping fork PR dispatch."
             exit 0
           fi
-        elif [[ "$PR_INPUT" =~ github.com/([^/]+)/([^/]+)/pull/[0-9]+ ]]; then
+        elif [[ "$PR_INPUT" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)/?$ ]]; then
           URL_REPO="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+          PR_NUM="${BASH_REMATCH[3]}"
           if [ "$URL_REPO" != "$REPOSITORY" ]; then
             echo "Refusing to dispatch a PR from another repository: $URL_REPO" >&2
+            exit 1
+          fi
+          HEAD_REPO="$(GH_TOKEN="$GH_API_TOKEN" gh api "repos/${REPOSITORY}/pulls/${PR_NUM}" --jq .head.repo.full_name)"
+          if [ "$HEAD_REPO" != "$REPOSITORY" ]; then
+            echo "Refusing to dispatch a fork PR: ${HEAD_REPO}" >&2
             exit 1
           fi
         else

--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -22,7 +22,6 @@ runs:
         REPOSITORY: ${{ github.repository }}
         EVENT_NAME: ${{ github.event_name }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-        GH_API_TOKEN: ${{ github.token }}
       run: |
         if [ -z "$GH_TOKEN" ]; then
           echo "ANGIE_DEV_TOOLS_BOT_TOKEN is required to dispatch private angie-dev-tools workflows." >&2
@@ -33,7 +32,7 @@ runs:
           exit 1
         fi
 
-        if [ "$EVENT_NAME" != "workflow_dispatch" ]; then
+        if [ "$EVENT_NAME" = "pull_request" ]; then
           if [ "$PR_HEAD_REPO" != "$REPOSITORY" ]; then
             echo "Skipping fork PR dispatch."
             exit 0
@@ -45,7 +44,7 @@ runs:
             echo "Refusing to dispatch a PR from another repository: $URL_REPO" >&2
             exit 1
           fi
-          HEAD_REPO="$(GH_TOKEN="$GH_API_TOKEN" gh api "repos/${REPOSITORY}/pulls/${PR_NUM}" --jq .head.repo.full_name)"
+          HEAD_REPO="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUM}" --jq .head.repo.full_name)"
           if [ "$HEAD_REPO" != "$REPOSITORY" ]; then
             echo "Refusing to dispatch a fork PR: ${HEAD_REPO}" >&2
             exit 1

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -17,7 +17,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   dispatch:

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -1,7 +1,7 @@
 name: PR CI Approver
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   dispatch:
@@ -33,7 +34,8 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
+        env:
+          GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-approver.yml
-          token: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
           dry_run: ${{ github.event.inputs.dry_run }}

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -1,7 +1,7 @@
 name: PR CI Approver
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -12,7 +12,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   dispatch:

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -1,7 +1,7 @@
 name: PR CI Reviewers
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:
@@ -12,6 +12,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   dispatch:
@@ -28,6 +29,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
+        env:
+          GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-reviewers.yml
-          token: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -1,7 +1,7 @@
 name: PR CI Reviewers
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -1,7 +1,7 @@
 name: PR Slack Ready for Review
 
 on:
-  pull_request_target:
+  pull_request:
     types: [ready_for_review]
 
 permissions:

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -1,7 +1,7 @@
 name: PR Slack Ready for Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ready_for_review]
 
 permissions:
@@ -19,6 +19,7 @@ jobs:
           persist-credentials: false
           ref: ${{ github.event.pull_request.base.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
+        env:
+          GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-slack-ready.yml
-          token: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Security follow-up for #75.

- Pass `ANGIE_DEV_TOOLS_BOT_TOKEN` as `GH_TOKEN` on the step, not as a composite input.
- Require a canonical `https://github.com/<owner>/<repo>/pull/<n>` URL on `workflow_dispatch`.
- Refuse dispatch when that PR’s head repo is a fork (`gh api` with the same bot token).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b6a3e18f-9872-45b7-b482-8de110ca3582?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b6a3e18f-9872-45b7-b482-8de110ca3582&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

