### PR TITLE
[AI-9273] Feature: Deep links with #angie-prompt work after loadSidebarV2

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ window.location.hash = 'angie-prompt=' + encodeURIComponent('Fix this error') + 
 - `angie-prompt`: The prompt text to populate in the input field
 - `angie-new-chat`: When set to `true`, clears the current conversation and opens a fresh chat with the prompt pre-filled in the input
 
+Both `loadSidebar()` and `loadSidebarV2()` watch the hash, on page load and on every later hash change. You do not need any hash code of your own.
+
 **Note:** Always call `await sdk.waitForReady()` before triggering Angie.
 
 ---

--- a/demo/trigger-angie-prompt/host.js
+++ b/demo/trigger-angie-prompt/host.js
@@ -1,8 +1,6 @@
 import { AngieMcpSdk, LAYOUT_SIDEBAR } from '../../dist/index.js';
 
 const DEFAULT_PROMPT = 'Help me improve the headline on this page for conversions.';
-const HASH_PARAM_PROMPT = 'angie-prompt';
-const HASH_PARAM_NEW_CHAT = 'angie-new-chat';
 
 const sdk = new AngieMcpSdk();
 const statusEl = document.getElementById( 'demo-status' );
@@ -26,55 +24,6 @@ const setStatus = ( message, type = 'idle' ) => {
 };
 
 const getPrompt = () => promptInput?.value?.trim() || DEFAULT_PROMPT;
-
-const parseHashParams = ( hash ) => {
-	const paramString = hash.startsWith( '#' ) ? hash.substring( 1 ) : hash;
-	return new URLSearchParams( paramString );
-};
-
-const readPromptFromHash = ( hash ) => {
-	if ( ! hash.includes( `${ HASH_PARAM_PROMPT }=` ) ) {
-		return null;
-	}
-
-	const params = parseHashParams( hash );
-	const prompt = params.get( HASH_PARAM_PROMPT ) || '';
-
-	if ( ! prompt ) {
-		return null;
-	}
-
-	return {
-		prompt,
-		newChat: params.get( HASH_PARAM_NEW_CHAT ) === 'true',
-	};
-};
-
-const clearPromptHash = () => {
-	if ( ! window.location.hash ) {
-		return;
-	}
-
-	const scrollY = window.scrollY;
-	history.replaceState( null, '', `${ window.location.pathname }${ window.location.search }` );
-	window.scrollTo( 0, scrollY );
-};
-
-const consumeHashOnLoad = () => {
-	const hashPrompt = readPromptFromHash( window.location.hash );
-
-	if ( ! hashPrompt ) {
-		return null;
-	}
-
-	const scrollY = window.scrollY;
-	clearPromptHash();
-	window.scrollTo( 0, scrollY );
-
-	return hashPrompt;
-};
-
-const pendingHashPrompt = consumeHashOnLoad();
 
 const triggerWithPrompt = async ( { newChat = false, prompt = getPrompt() } = {} ) => {
 	try {
@@ -120,25 +69,6 @@ document.querySelectorAll( '[data-prompt-chip]' ).forEach( ( chip ) => {
 	} );
 } );
 
-document.querySelectorAll( '.demo-hash-link--in-page' ).forEach( ( link ) => {
-	link.addEventListener( 'click', ( event ) => {
-		event.preventDefault();
-		const hash = link.getAttribute( 'href' );
-		const hashPrompt = hash ? readPromptFromHash( hash ) : null;
-
-		if ( ! hashPrompt ) {
-			setStatus( 'Hash link is missing a prompt.', 'error' );
-			return;
-		}
-
-		if ( promptInput ) {
-			promptInput.value = hashPrompt.prompt;
-		}
-
-		void triggerWithPrompt( hashPrompt );
-	} );
-} );
-
 sdk.loadSidebarV2( {
 	host: {
 		appId: 'demo-trigger-angie-prompt',
@@ -175,14 +105,6 @@ sdk.loadSidebarV2( {
 	},
 } ).then( () => {
 	setStatus( 'Angie sidebar loaded. Use the controls or hash links below.' );
-
-	if ( pendingHashPrompt ) {
-		if ( promptInput ) {
-			promptInput.value = pendingHashPrompt.prompt;
-		}
-
-		void triggerWithPrompt( pendingHashPrompt );
-	}
 } ).catch( ( error ) => {
 	setStatus( error instanceof Error ? error.message : 'Failed to load Angie', 'error' );
 } );

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -87,12 +87,15 @@ await sdk.triggerAngie({
             same screen, or open in a new tab when linking from emails, docs, or another page.
             Add <code>&amp;angie-new-chat=true</code> to start a fresh chat.
           </p>
+          <p class="demo-card-lead">
+            <code>loadSidebarV2()</code> watches the hash on its own: it sends the prompt, then
+            clears the hash. This page has no hash-handling code of its own.
+          </p>
 
           <h3 class="demo-hash-group-title">In this page</h3>
           <ul class="demo-hash-links">
             <li>
               <a
-                class="demo-hash-link--in-page"
                 href="#angie-prompt=What%20should%20I%20change%20before%20publishing%3F"
               >
                 Pre-publish review
@@ -100,7 +103,6 @@ await sdk.triggerAngie({
             </li>
             <li>
               <a
-                class="demo-hash-link--in-page"
                 href="#angie-prompt=Suggest%20a%20clearer%20call%20to%20action%20for%20this%20screen."
               >
                 Better CTA
@@ -147,7 +149,10 @@ await sdk.triggerAngie({
 
         <section class="demo-card" aria-labelledby="status-heading">
           <h2 id="status-heading">3. Status</h2>
-          <p class="demo-card-lead">Last trigger result from the host page.</p>
+          <p class="demo-card-lead">
+            Last result from the controls above. Hash links are handled inside the SDK, so they do
+            not report here.
+          </p>
           <div class="demo-status" id="demo-status" role="status" aria-live="polite">
             Loading Angie sidebar…
           </div>

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -89,6 +89,12 @@ describe('AngieMcpSdk', () => {
   });
 
   afterEach(() => {
+    // Detach every listener this test registered, otherwise SDK instances keep
+    // reacting to events (hashchange in particular) during later tests.
+    for ( const [ type, listener ] of addEventListenerSpy.mock.calls as [ string, EventListener ][] ) {
+      window.removeEventListener( type, listener );
+    }
+
     jest.restoreAllMocks();
     addEventListenerSpy.mockRestore();
   });
@@ -671,6 +677,21 @@ describe('AngieMcpSdk', () => {
               newChat: false,
             }),
           }),
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should trigger from the hash after loadSidebarV2', async () => {
+      window.location.hash = '#angie-prompt=Fix%20error';
+
+      await sdk.loadSidebarV2( { host: { appId: 'editor-lite' } } );
+      await new Promise( ( resolve ) => setTimeout( resolve, 0 ) );
+
+      expect(postMessageSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'sdk-trigger-angie',
+          payload: expect.objectContaining({ prompt: 'Fix error' }),
         }),
         expect.anything()
       );

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -116,6 +116,7 @@ export class AngieMcpSdk {
 
   public loadSidebarV2( options: LoadSidebarV2Options ): Promise<void> {
     this.sidebarV2BootPromise = bootSidebar( options );
+    this.setupPromptHashDetection();
     return this.sidebarV2BootPromise;
   }
 

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -37,6 +37,7 @@ Local demos:
 - [`demo/load-sidebar-v2-floating-chat/`](../../demo/load-sidebar-v2-floating-chat/) — minimal floating chat
 - [`demo/load-sidebar-v2-full-config/`](../../demo/load-sidebar-v2-full-config/) — full example (`aiContext`, custom CSS)
 - [`demo/load-sidebar-v2-widget-config/`](../../demo/load-sidebar-v2-widget-config/) — `widgetConfig` presets (help center, visitor widget, sandbox)
+- [`demo/trigger-angie-prompt/`](../../demo/trigger-angie-prompt/) — `triggerAngie()` and `#angie-prompt=` deep links
 
 ## Layouts
 
@@ -103,6 +104,18 @@ loadSidebarV2(options)
 ```
 
 Entry point: [`boot-sidebar.ts`](./boot-sidebar.ts). Layout strategies: [`layouts/index.ts`](./layouts/index.ts).
+
+## Prompt deep links
+
+`loadSidebarV2()` watches the URL hash for `angie-prompt` (plus optional `angie-new-chat=true`), on
+load and on every later `hashchange`:
+
+```
+https://example.com/pricing#angie-prompt=Which%20plan%20fits%20me%3F
+```
+
+It waits for Angie, sends the prompt, then clears the hash. Hosts need no hash code of their own.
+Full reference: [Hash Parameter Method](../../README.md#hash-parameter-method).
 
 ## Host API bridge
 


### PR DESCRIPTION
## Problem
Hosts that embed Angie with `loadSidebarV2()` did not get `#angie-prompt` deep links. Those links already worked with `loadSidebar()`. Hosts had to parse and clear the hash themselves, or the prompt never opened.

## Solution
`loadSidebarV2()` now watches the hash the same way as `loadSidebar()`. The SDK sends the prompt and clears the hash. Host pages do not need their own hash code. The trigger demo was updated to show that.

Jira: https://elementor.atlassian.net/browse/AI-9273

Made with [Cursor](https://cursor.com)