### PR TITLE
Run PR CI approver after reviewers finish

### DIFF
--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -9,66 +9,10 @@ inputs:
     description: 'Optional dry_run input for the approver workflow'
     required: false
     default: ''
-  wait_for_other_checks:
-    description: 'Wait for other PR checks to leave IN_PROGRESS before dispatching'
-    required: false
-    default: 'false'
 
 runs:
   using: 'composite'
   steps:
-    - name: Wait for other PR checks
-      if: inputs.wait_for_other_checks == 'true'
-      shell: bash
-      env:
-        PR_INPUT: ${{ github.event.pull_request.html_url || github.event.inputs.pr_input }}
-        REPOSITORY: ${{ github.repository }}
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        set -euo pipefail
-
-        if [ -z "$PR_INPUT" ]; then
-          echo "PR URL or number is required to wait for checks." >&2
-          exit 1
-        fi
-
-        deadline=$((SECONDS + 2700))
-        seen_checks=0
-
-        while (( SECONDS < deadline )); do
-          json="$(gh pr checks "$PR_INPUT" --repo "$REPOSITORY" --json name,state,workflow 2>/dev/null || true)"
-          if [ -z "$json" ] || [ "$json" = "[]" ]; then
-            echo "No PR checks reported yet; waiting..."
-            sleep 15
-            continue
-          fi
-          seen_checks=1
-
-          pending="$(jq -r '
-            .[]
-            | select(.workflow != "PR CI Reviewers" and .workflow != "PR CI Approver" and .workflow != "PR Slack Ready for Review")
-            | select((.name // "") | test("gitStream|gitstream") | not)
-            | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING")
-            | "\(.name) [\(.workflow // "unknown")] \(.state)"
-          ' <<<"$json")"
-
-          if [ -z "$pending" ]; then
-            echo "All other PR checks have finished."
-            exit 0
-          fi
-
-          echo "Waiting for other PR checks to finish:"
-          echo "$pending"
-          sleep 15
-        done
-
-        if [ "$seen_checks" -eq 0 ]; then
-          echo "Timed out waiting for PR checks to appear." >&2
-        else
-          echo "Timed out waiting for other PR checks to finish." >&2
-        fi
-        exit 1
-
     - name: Dispatch workflow
       shell: bash
       env:
@@ -118,20 +62,7 @@ runs:
           ARGS+=(-f "dry_run=${DRY_RUN}")
         fi
 
-        PR_NUM=""
-        if [[ "$PR_INPUT" =~ /pull/([0-9]+) ]]; then
-          PR_NUM="${BASH_REMATCH[1]}"
-        elif [[ "$PR_INPUT" =~ ^[0-9]+$ ]]; then
-          PR_NUM="$PR_INPUT"
-        fi
-
-        EXISTING_JSON="$(gh run list \
-          --repo elementor/angie-dev-tools \
-          --workflow "$WORKFLOW" \
-          --limit 50 \
-          --json databaseId \
-          --jq '[.[].databaseId]')"
-        DISPATCH_START="$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)"
+        SINCE="$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)"
 
         gh workflow run "$WORKFLOW" \
           --repo elementor/angie-dev-tools \
@@ -140,47 +71,16 @@ runs:
 
         echo "Dispatched ${WORKFLOW} on elementor/angie-dev-tools for ${PR_INPUT}"
 
-        run_mentions_pr() {
-          local id="$1"
-          local details logs
-          details="$(gh run view "$id" --repo elementor/angie-dev-tools --json displayTitle,name,url,jobs 2>/dev/null || true)"
-          if [ -n "$details" ] && echo "$details" | grep -F -q -- "$PR_INPUT"; then
-            return 0
-          fi
-          if [ -n "$PR_NUM" ] && [ -n "$details" ] && echo "$details" | grep -E -q -- "/pull/${PR_NUM}([^0-9]|$)|#${PR_NUM}([^0-9]|$)"; then
-            return 0
-          fi
-          logs="$(gh run view "$id" --repo elementor/angie-dev-tools --log 2>/dev/null | head -c 200000 || true)"
-          if [ -n "$logs" ] && echo "$logs" | grep -F -q -- "$PR_INPUT"; then
-            return 0
-          fi
-          return 1
-        }
-
         RUN_ID=""
-        for attempt in $(seq 1 30); do
-          CANDIDATES="$(gh run list \
+        for _ in $(seq 1 30); do
+          RUN_ID="$(gh run list \
             --repo elementor/angie-dev-tools \
             --workflow "$WORKFLOW" \
             --event workflow_dispatch \
-            --limit 30 \
-            --json databaseId,createdAt,displayTitle,name,url \
-            --jq --arg since "$DISPATCH_START" --argjson existing "$EXISTING_JSON" \
-              '[.[] | select(.createdAt >= $since and (($existing | index(.databaseId)) | not))] | sort_by(.createdAt) | reverse')"
-
-          CANDIDATES="${CANDIDATES:-[]}"
-          mapfile -t CANDIDATE_IDS < <(jq -r '.[].databaseId // empty' <<<"$CANDIDATES")
-          for id in "${CANDIDATE_IDS[@]}"; do
-            if [ -n "$id" ] && run_mentions_pr "$id"; then
-              RUN_ID="$id"
-              break
-            fi
-          done
-
-          if [ -z "$RUN_ID" ] && [ "$attempt" -ge 8 ] && [ "${#CANDIDATE_IDS[@]}" -eq 1 ] && [ -n "${CANDIDATE_IDS[0]}" ]; then
-            RUN_ID="${CANDIDATE_IDS[0]}"
-          fi
-
+            --limit 10 \
+            --json databaseId,createdAt \
+            --jq --arg since "$SINCE" \
+              '[.[] | select(.createdAt >= $since)] | first | .databaseId // empty')"
           if [ -n "$RUN_ID" ]; then
             break
           fi
@@ -192,14 +92,5 @@ runs:
           exit 1
         fi
 
-        echo "REMOTE_RUN_ID=${RUN_ID}" >> "$GITHUB_ENV"
-
-    - name: Wait for remote workflow
-      if: env.REMOTE_RUN_ID != ''
-      shell: bash
-      env:
-        WORKFLOW: ${{ inputs.workflow }}
-      run: |
-        RUN_URL="$(gh run view "$REMOTE_RUN_ID" --repo elementor/angie-dev-tools --json url --jq .url)"
-        echo "Waiting for ${WORKFLOW} run ${REMOTE_RUN_ID}: ${RUN_URL}"
-        gh run watch "$REMOTE_RUN_ID" --repo elementor/angie-dev-tools --exit-status --interval 10
+        echo "Waiting for ${WORKFLOW} run ${RUN_ID}"
+        gh run watch "$RUN_ID" --repo elementor/angie-dev-tools --exit-status --interval 10

--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -1,5 +1,5 @@
 name: 'Dispatch angie-dev-tools workflow'
-description: 'Trigger a private angie-dev-tools workflow with the current PR context'
+description: 'Trigger a private angie-dev-tools workflow with the current PR context and wait for it to finish'
 
 inputs:
   workflow:
@@ -62,9 +62,53 @@ runs:
           ARGS+=(-f "dry_run=${DRY_RUN}")
         fi
 
+        mapfile -t EXISTING_IDS < <(gh run list \
+          --repo elementor/angie-dev-tools \
+          --workflow "$WORKFLOW" \
+          --limit 50 \
+          --json databaseId \
+          --jq '.[].databaseId')
+
         gh workflow run "$WORKFLOW" \
           --repo elementor/angie-dev-tools \
           --ref master \
           "${ARGS[@]}"
 
         echo "Dispatched ${WORKFLOW} on elementor/angie-dev-tools for ${PR_INPUT}"
+
+        RUN_ID=""
+        for _ in $(seq 1 30); do
+          mapfile -t CANDIDATE_IDS < <(gh run list \
+            --repo elementor/angie-dev-tools \
+            --workflow "$WORKFLOW" \
+            --event workflow_dispatch \
+            --limit 20 \
+            --json databaseId,createdAt \
+            --jq 'sort_by(.createdAt) | reverse | .[].databaseId')
+          for id in "${CANDIDATE_IDS[@]}"; do
+            already_seen=0
+            for existing in "${EXISTING_IDS[@]}"; do
+              if [ "$id" = "$existing" ]; then
+                already_seen=1
+                break
+              fi
+            done
+            if [ "$already_seen" -eq 0 ]; then
+              RUN_ID="$id"
+              break
+            fi
+          done
+          if [ -n "$RUN_ID" ]; then
+            break
+          fi
+          sleep 2
+        done
+
+        if [ -z "$RUN_ID" ]; then
+          echo "Timed out waiting for dispatched ${WORKFLOW} run to appear." >&2
+          exit 1
+        fi
+
+        RUN_URL="$(gh run view "$RUN_ID" --repo elementor/angie-dev-tools --json url --jq .url)"
+        echo "Waiting for ${WORKFLOW} run ${RUN_ID}: ${RUN_URL}"
+        gh run watch "$RUN_ID" --repo elementor/angie-dev-tools --exit-status --interval 10

--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -9,10 +9,66 @@ inputs:
     description: 'Optional dry_run input for the approver workflow'
     required: false
     default: ''
+  wait_for_other_checks:
+    description: 'Wait for other PR checks to leave IN_PROGRESS before dispatching'
+    required: false
+    default: 'false'
 
 runs:
   using: 'composite'
   steps:
+    - name: Wait for other PR checks
+      if: inputs.wait_for_other_checks == 'true'
+      shell: bash
+      env:
+        PR_INPUT: ${{ github.event.pull_request.html_url || github.event.inputs.pr_input }}
+        REPOSITORY: ${{ github.repository }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "$PR_INPUT" ]; then
+          echo "PR URL or number is required to wait for checks." >&2
+          exit 1
+        fi
+
+        deadline=$((SECONDS + 2700))
+        seen_checks=0
+
+        while (( SECONDS < deadline )); do
+          json="$(gh pr checks "$PR_INPUT" --repo "$REPOSITORY" --json name,state,workflow 2>/dev/null || true)"
+          if [ -z "$json" ] || [ "$json" = "[]" ]; then
+            echo "No PR checks reported yet; waiting..."
+            sleep 15
+            continue
+          fi
+          seen_checks=1
+
+          pending="$(jq -r '
+            .[]
+            | select(.workflow != "PR CI Reviewers" and .workflow != "PR CI Approver" and .workflow != "PR Slack Ready for Review")
+            | select((.name // "") | test("gitStream|gitstream") | not)
+            | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING")
+            | "\(.name) [\(.workflow // "unknown")] \(.state)"
+          ' <<<"$json")"
+
+          if [ -z "$pending" ]; then
+            echo "All other PR checks have finished."
+            exit 0
+          fi
+
+          echo "Waiting for other PR checks to finish:"
+          echo "$pending"
+          sleep 15
+        done
+
+        if [ "$seen_checks" -eq 0 ]; then
+          echo "Timed out waiting for PR checks to appear." >&2
+        else
+          echo "Timed out waiting for other PR checks to finish." >&2
+        fi
+        exit 1
+
     - name: Dispatch workflow
       shell: bash
       env:
@@ -109,6 +165,14 @@ runs:
           exit 1
         fi
 
-        RUN_URL="$(gh run view "$RUN_ID" --repo elementor/angie-dev-tools --json url --jq .url)"
-        echo "Waiting for ${WORKFLOW} run ${RUN_ID}: ${RUN_URL}"
-        gh run watch "$RUN_ID" --repo elementor/angie-dev-tools --exit-status --interval 10
+        echo "REMOTE_RUN_ID=${RUN_ID}" >> "$GITHUB_ENV"
+
+    - name: Wait for remote workflow
+      if: env.REMOTE_RUN_ID != ''
+      shell: bash
+      env:
+        WORKFLOW: ${{ inputs.workflow }}
+      run: |
+        RUN_URL="$(gh run view "$REMOTE_RUN_ID" --repo elementor/angie-dev-tools --json url --jq .url)"
+        echo "Waiting for ${WORKFLOW} run ${REMOTE_RUN_ID}: ${RUN_URL}"
+        gh run watch "$REMOTE_RUN_ID" --repo elementor/angie-dev-tools --exit-status --interval 10

--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -118,12 +118,20 @@ runs:
           ARGS+=(-f "dry_run=${DRY_RUN}")
         fi
 
-        mapfile -t EXISTING_IDS < <(gh run list \
+        PR_NUM=""
+        if [[ "$PR_INPUT" =~ /pull/([0-9]+) ]]; then
+          PR_NUM="${BASH_REMATCH[1]}"
+        elif [[ "$PR_INPUT" =~ ^[0-9]+$ ]]; then
+          PR_NUM="$PR_INPUT"
+        fi
+
+        EXISTING_JSON="$(gh run list \
           --repo elementor/angie-dev-tools \
           --workflow "$WORKFLOW" \
           --limit 50 \
           --json databaseId \
-          --jq '.[].databaseId')
+          --jq '[.[].databaseId]')"
+        DISPATCH_START="$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)"
 
         gh workflow run "$WORKFLOW" \
           --repo elementor/angie-dev-tools \
@@ -132,28 +140,47 @@ runs:
 
         echo "Dispatched ${WORKFLOW} on elementor/angie-dev-tools for ${PR_INPUT}"
 
+        run_mentions_pr() {
+          local id="$1"
+          local details logs
+          details="$(gh run view "$id" --repo elementor/angie-dev-tools --json displayTitle,name,url,jobs 2>/dev/null || true)"
+          if [ -n "$details" ] && echo "$details" | grep -F -q -- "$PR_INPUT"; then
+            return 0
+          fi
+          if [ -n "$PR_NUM" ] && [ -n "$details" ] && echo "$details" | grep -E -q -- "/pull/${PR_NUM}([^0-9]|$)|#${PR_NUM}([^0-9]|$)"; then
+            return 0
+          fi
+          logs="$(gh run view "$id" --repo elementor/angie-dev-tools --log 2>/dev/null | head -c 200000 || true)"
+          if [ -n "$logs" ] && echo "$logs" | grep -F -q -- "$PR_INPUT"; then
+            return 0
+          fi
+          return 1
+        }
+
         RUN_ID=""
-        for _ in $(seq 1 30); do
-          mapfile -t CANDIDATE_IDS < <(gh run list \
+        for attempt in $(seq 1 30); do
+          CANDIDATES="$(gh run list \
             --repo elementor/angie-dev-tools \
             --workflow "$WORKFLOW" \
             --event workflow_dispatch \
-            --limit 20 \
-            --json databaseId,createdAt \
-            --jq 'sort_by(.createdAt) | reverse | .[].databaseId')
+            --limit 30 \
+            --json databaseId,createdAt,displayTitle,name,url \
+            --jq --arg since "$DISPATCH_START" --argjson existing "$EXISTING_JSON" \
+              '[.[] | select(.createdAt >= $since and (($existing | index(.databaseId)) | not))] | sort_by(.createdAt) | reverse')"
+
+          CANDIDATES="${CANDIDATES:-[]}"
+          mapfile -t CANDIDATE_IDS < <(jq -r '.[].databaseId // empty' <<<"$CANDIDATES")
           for id in "${CANDIDATE_IDS[@]}"; do
-            already_seen=0
-            for existing in "${EXISTING_IDS[@]}"; do
-              if [ "$id" = "$existing" ]; then
-                already_seen=1
-                break
-              fi
-            done
-            if [ "$already_seen" -eq 0 ]; then
+            if [ -n "$id" ] && run_mentions_pr "$id"; then
               RUN_ID="$id"
               break
             fi
           done
+
+          if [ -z "$RUN_ID" ] && [ "$attempt" -ge 8 ] && [ "${#CANDIDATE_IDS[@]}" -eq 1 ] && [ -n "${CANDIDATE_IDS[0]}" ]; then
+            RUN_ID="${CANDIDATE_IDS[0]}"
+          fi
+
           if [ -n "$RUN_ID" ]; then
             break
           fi

--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -62,35 +62,17 @@ runs:
           ARGS+=(-f "dry_run=${DRY_RUN}")
         fi
 
-        SINCE="$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ)"
-
-        gh workflow run "$WORKFLOW" \
+        RUN_URL="$(gh workflow run "$WORKFLOW" \
           --repo elementor/angie-dev-tools \
           --ref master \
-          "${ARGS[@]}"
+          "${ARGS[@]}")"
 
-        echo "Dispatched ${WORKFLOW} on elementor/angie-dev-tools for ${PR_INPUT}"
+        echo "Dispatched ${WORKFLOW} on elementor/angie-dev-tools for ${PR_INPUT}: ${RUN_URL}"
 
-        RUN_ID=""
-        for _ in $(seq 1 30); do
-          RUN_ID="$(gh run list \
-            --repo elementor/angie-dev-tools \
-            --workflow "$WORKFLOW" \
-            --event workflow_dispatch \
-            --limit 10 \
-            --json databaseId,createdAt \
-            --jq --arg since "$SINCE" \
-              '[.[] | select(.createdAt >= $since)] | first | .databaseId // empty')"
-          if [ -n "$RUN_ID" ]; then
-            break
-          fi
-          sleep 2
-        done
-
-        if [ -z "$RUN_ID" ]; then
-          echo "Timed out waiting for dispatched ${WORKFLOW} run to appear." >&2
+        if [[ ! "$RUN_URL" =~ /actions/runs/([0-9]+) ]]; then
+          echo "gh workflow run did not return a run URL." >&2
           exit 1
         fi
 
-        echo "Waiting for ${WORKFLOW} run ${RUN_ID}"
+        RUN_ID="${BASH_REMATCH[1]}"
         gh run watch "$RUN_ID" --repo elementor/angie-dev-tools --exit-status --interval 10

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -15,19 +15,21 @@ on:
 
 permissions:
   contents: read
+  checks: read
+  statuses: read
 
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-approver.yml
           dry_run: ${{ github.event.inputs.dry_run }}
+          wait_for_other_checks: 'true'

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -18,6 +18,12 @@ permissions:
 
 jobs:
   dispatch:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -15,21 +15,19 @@ on:
 
 permissions:
   contents: read
-  checks: read
-  statuses: read
 
 jobs:
   dispatch:
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-approver.yml
           dry_run: ${{ github.event.inputs.dry_run }}
-          wait_for_other_checks: 'true'

--- a/.github/workflows/pr-ci-approver.yml
+++ b/.github/workflows/pr-ci-approver.yml
@@ -1,8 +1,6 @@
 name: PR CI Approver
 
 on:
-  pull_request:
-    types: [opened, ready_for_review, synchronize]
   workflow_dispatch:
     inputs:
       pr_input:
@@ -20,18 +18,13 @@ permissions:
 
 jobs:
   dispatch:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -12,6 +12,8 @@ on:
 
 permissions:
   contents: read
+  checks: read
+  statuses: read
 
 jobs:
   reviewers:
@@ -27,7 +29,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
@@ -43,14 +44,14 @@ jobs:
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-approver.yml
+          wait_for_other_checks: 'true'

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -14,7 +14,7 @@ permissions:
   contents: read
 
 jobs:
-  dispatch:
+  reviewers:
     if: |
       github.event_name == 'workflow_dispatch' ||
       (
@@ -22,6 +22,7 @@ jobs:
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       )
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,3 +33,24 @@ jobs:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-reviewers.yml
+
+  approver:
+    needs: reviewers
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+      - uses: ./.github/actions/dispatch-angie-dev-tools
+        env:
+          GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
+        with:
+          workflow: pr-ci-approver.yml

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -12,8 +12,6 @@ on:
 
 permissions:
   contents: read
-  checks: read
-  statuses: read
 
 jobs:
   reviewers:
@@ -29,6 +27,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
@@ -37,21 +36,15 @@ jobs:
 
   approver:
     needs: reviewers
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
-      )
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
         with:
           workflow: pr-ci-approver.yml
-          wait_for_other_checks: 'true'

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -36,6 +36,12 @@ jobs:
 
   approver:
     needs: reviewers
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/pr-ci-reviewers.yml
+++ b/.github/workflows/pr-ci-reviewers.yml
@@ -22,7 +22,7 @@ jobs:
         contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
       )
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,7 +37,7 @@ jobs:
   approver:
     needs: reviewers
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -13,6 +13,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -17,7 +17,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Run the PR CI approver after reviewers, and wait for each dispatched angie-dev-tools workflow to finish (5-minute job timeout).

On PRs this is one workflow: reviewers, then approver (`needs: reviewers`). Dispatch uses the run URL returned by `gh workflow run`, then `gh run watch`. Manual approver remains `workflow_dispatch` only.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53284cea-74ef-4994-bfde-a399b8943ade?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53284cea-74ef-4994-bfde-a399b8943ade&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

PR CI approver workflow was triggering independently on every PR event. Now it runs as a dependent job after reviewers finish, eliminating redundant parallel executions and ensuring proper sequencing.

## 2. What Changed (Where)

- `.github/workflows/pr-ci-reviewers.yml`: Renamed job `dispatch` → `reviewers`, added dependent `approver` job with `needs: reviewers`
- `.github/workflows/pr-ci-approver.yml`: Removed `pull_request` trigger, now dispatch-only; simplified ref to `github.sha`
- `.github/actions/dispatch-angie-dev-tools/action.yaml`: Added workflow run capture, polling with `gh run watch`, exit-status validation

## 3. How It Works

Reviewers job runs → completes → triggers approver job as dependent. Action now captures run ID from `gh workflow run` output, validates it matches URL pattern, then blocks with `gh run watch --exit-status` to await remote workflow completion before marking step done.

## 4. Risks

Timeout deadlock if remote workflow hangs: 5-minute local timeout may exhaust before remote completes. URL regex validation could fail on gh CLI format changes. Missing `--exit-status` handling if remote fails silently.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
