### PR TITLE
Clone videoproof kit from angie-dev-tools master

### DIFF
--- a/.github/workflows/videoproof-ci.yml
+++ b/.github/workflows/videoproof-ci.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Clone videoproof kit
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
-          VIDEO_PROOF_KIT_REF: ${{ vars.VIDEO_PROOF_KIT_REF || 'cursor/videoproof-runner' }}
+          VIDEO_PROOF_KIT_REF: ${{ vars.VIDEO_PROOF_KIT_REF || 'master' }}
         run: |
           if [ -z "$GH_TOKEN" ]; then
             echo "ANGIE_DEV_TOOLS_BOT_TOKEN is required to clone elementor/angie-dev-tools." >&2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Videoproof-CI was cloning `elementor/angie-dev-tools` at `cursor/videoproof-runner`, which no longer exists (`fatal: Remote branch cursor/videoproof-runner not found`).

The kit is on `master`, so the default `VIDEO_PROOF_KIT_REF` is now `master`. A repo variable can still override it.

## Test plan
- After merge (or on this PR, if Videoproof-CI runs), confirm **Clone videoproof kit** uses `--branch master` and succeeds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e0d33323-adbf-4753-ad7d-9285aa582692?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e0d33323-adbf-4753-ad7d-9285aa582692&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

