### PR TITLE
Add topBar toggle to WidgetConfig to hide the app top bar

### DIFF
--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -102,6 +102,7 @@ const buildSandboxWidgetConfig = () => ( {
 	betaBanner: { enabled: true },
 	aiContextGuidance: { enabled: true },
 	userProfileMenu: { enabled: true },
+	header: { enabled: false, showCloseButton: true },
 } );
 
 const PRESETS = {

--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -102,7 +102,7 @@ const buildSandboxWidgetConfig = () => ( {
 	betaBanner: { enabled: true },
 	aiContextGuidance: { enabled: true },
 	userProfileMenu: { enabled: true },
-	header: { enabled: false, showCloseButton: true },
+	topBar: { enabled: false },
 } );
 
 const PRESETS = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -36,6 +36,11 @@ export type ModelsConfig = {
   execution: string;
 };
 
+export type HeaderConfig = {
+  enabled?: boolean;
+  showCloseButton?: boolean;
+};
+
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -54,6 +59,7 @@ export type WidgetConfig = {
   localServers?: LocalServersConfig;
   planning?: FeatureToggle;
   models?: ModelsConfig;
+  header?: HeaderConfig;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -36,11 +36,6 @@ export type ModelsConfig = {
   execution: string;
 };
 
-export type HeaderConfig = {
-  enabled?: boolean;
-  showCloseButton?: boolean;
-};
-
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -59,7 +54,7 @@ export type WidgetConfig = {
   localServers?: LocalServersConfig;
   planning?: FeatureToggle;
   models?: ModelsConfig;
-  header?: HeaderConfig;
+  topBar?: FeatureToggle;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -67,6 +67,21 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		} );
 	} );
 
+	it( 'should merge widgetConfig.header with layout defaults', () => {
+		const config = resolveConfig(
+			{
+				host: { appId: 'editor-lite' },
+				widgetConfig: { header: { enabled: false, showCloseButton: false } },
+			},
+			DEFAULT_ENV,
+		);
+
+		expect( config.widgetConfig ).toEqual( {
+			closeButton: 'collapse',
+			header: { enabled: false, showCloseButton: false },
+		} );
+	} );
+
 	it( 'should preserve callbacks.onClose', () => {
 		const onClose = jest.fn();
 		const config = resolveConfig(

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -67,18 +67,18 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		} );
 	} );
 
-	it( 'should merge widgetConfig.header with layout defaults', () => {
+	it( 'should merge widgetConfig.topBar with layout defaults', () => {
 		const config = resolveConfig(
 			{
 				host: { appId: 'editor-lite' },
-				widgetConfig: { header: { enabled: false, showCloseButton: false } },
+				widgetConfig: { topBar: { enabled: false } },
 			},
 			DEFAULT_ENV,
 		);
 
 		expect( config.widgetConfig ).toEqual( {
 			closeButton: 'collapse',
-			header: { enabled: false, showCloseButton: false },
+			topBar: { enabled: false },
 		} );
 	} );
 

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -96,11 +96,11 @@ Each toggle uses `{ enabled: boolean }`.
 
 ### Top bar
 
-Control the embedded app top bar (the bar containing new chat, navigation, and the user menu).
+Control the embedded app top bar (the bar containing new chat, history, and the user menu).
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `topBar` | `{ enabled: boolean }` | `enabled: false` hides the whole top bar (new chat, navigation, and user menu) |
+| `topBar` | `{ enabled: boolean }` | `enabled: false` hides the whole top bar (new chat, history, and user menu) |
 
 ## Patterns from production hosts
 

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -94,13 +94,13 @@ Each toggle uses `{ enabled: boolean }`.
 |-------|------|--------|
 | `closeButton` | `'collapse' \| 'close'` | `collapse` — hide panel, keep session; `close` — dismiss widget |
 
-### Header
+### Top bar
 
-Control the embedded app header (the top bar that contains the title and the built-in close button).
+Control the embedded app top bar (the bar containing new chat, navigation, and the user menu).
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `header` | `{ enabled?: boolean; showCloseButton?: boolean }` | `enabled: false` hides the whole header. `showCloseButton` only applies when the header is hidden: it toggles a minimal close-only header bar so the user can still close/collapse |
+| `topBar` | `{ enabled: boolean }` | `enabled: false` hides the whole top bar (new chat, navigation, and user menu) |
 
 ## Patterns from production hosts
 

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -94,6 +94,14 @@ Each toggle uses `{ enabled: boolean }`.
 |-------|------|--------|
 | `closeButton` | `'collapse' \| 'close'` | `collapse` — hide panel, keep session; `close` — dismiss widget |
 
+### Header
+
+Control the embedded app header (the top bar that contains the title and the built-in close button).
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `header` | `{ enabled?: boolean; showCloseButton?: boolean }` | `enabled: false` hides the whole header. `showCloseButton` only applies when the header is hidden: it toggles a minimal close-only header bar so the user can still close/collapse |
+
 ## Patterns from production hosts
 
 These mirror [`ai-remote-integration`](https://github.com/elementor/elementor-ai/tree/main/editor-saas-services/packages/ai-remote-integration) (Elementor my.elementor sidebar and visitor floating widget).


### PR DESCRIPTION
## Overview

Adds an optional `topBar` toggle to `WidgetConfig` so embed hosts can hide Angie's built-in top bar (the bar containing new chat, history, and the user menu).

## Changes

### `topBar` configuration (`WidgetConfig`)

- New optional `topBar?: { enabled: boolean }` field, a regular feature toggle consistent with the other widget config options.
- `{ enabled: false }` hides the whole top bar (new chat, history, and user menu).
- Omitted or `{ enabled: true }` preserves the default top bar.
- Documented in `widget-config.md` under a new "Top bar" section, and added to the widget-config demo host.

## Test plan

- [x] `npm test` passes (added `resolve-config` coverage for merging `topBar` with layout defaults)
- [x] `npm run build` produces dist types including `topBar` on `WidgetConfig`

Made with [Cursor](https://cursor.com)

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds `topBar` config option to allow hosts to hide the embedded app's top navigation bar (new chat, history, user menu). Enables UI customization for constrained layouts.

## 2. What Changed (Where)

- `WidgetConfig` type: added `topBar?: FeatureToggle` field
- Demo config: set `topBar: { enabled: false }` example
- Tests: added merge validation for `topBar` with layout defaults
- Docs: documented `topBar` field behavior
- Version bumped 1.5.2 → 1.5.3

## 3. How It Works

`topBar` accepts `{ enabled: boolean }`. When `false`, hides the entire top bar UI. Config merges with layout defaults via existing `resolveConfig` pipeline (no new logic paths).

## 4. Risks

None identified. Additive field with backward compatibility (optional, defaults to undefined). Test coverage included for config resolution.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
