### PR TITLE
Add include/exclude allowlist for built-in local MCP servers

### DIFF
--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -29,6 +29,20 @@ export type ModeSwitcherConfig = {
 };
 
 export type LocalServersConfig = {
+  /**
+   * Allowlist of built-in iframe MCP servers to load. When present, only the
+   * listed servers are constructed and connected; `exclude` is ignored.
+   */
+  include?: string[];
+  /**
+   * Blocklist of built-in iframe MCP servers. Only applied when `include` is
+   * absent: all built-ins except the listed ones load.
+   */
+  exclude?: string[];
+  /**
+   * @deprecated Use `include: []` instead. When `true`, Angie does not
+   * auto-load the built-in local MCP servers.
+   */
   skipLoading?: boolean;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type LocalServersConfig, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type LocalServersConfig, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -86,7 +86,19 @@ Each toggle uses `{ enabled: boolean }`.
 |-------|------|---------|
 | `modeSwitcher` | `{ enabled?: boolean; default?: 'agent' \| 'plan' \| 'ask' }` | Show or hide Agent / Plan / Ask switcher; set the initial mode |
 | `featuredMcpServer` | `string` | Name of a **host-registered** local MCP server Angie should surface first (must match `registerServer({ name })`) |
-| `localServers` | `{ skipLoading?: boolean }` | When `skipLoading: true`, Angie does not auto-load host local servers — use when you register servers yourself after `waitForReady()` |
+| `localServers` | `{ include?: string[]; exclude?: string[]; skipLoading?: boolean }` | Control which built-in iframe MCP servers load. See [Built-in local MCP servers](#built-in-local-mcp-servers) |
+
+### Built-in local MCP servers
+
+`localServers` governs only the iframe's **built-in** MCP servers, not servers you register via `registerServer()` on the host page.
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `include` | `string[]` | Allowlist: only the listed built-in servers load. Takes precedence — `exclude` is ignored when `include` is present |
+| `exclude` | `string[]` | Blocklist: all built-ins except the listed ones load. Only applied when `include` is absent |
+| `skipLoading` | `boolean` | **Deprecated** — equivalent to `include: []`. When `true`, no built-in servers load |
+
+Precedence: `include` wins if present; otherwise `exclude` applies; omitting both loads the full default set. Unknown names are ignored with a warning.
 
 ### Close behavior
 
@@ -136,7 +148,7 @@ await sdk.waitForReady();
 sdk.registerServer({ name: HELP_CENTER_SERVER, /* ... */ });
 ```
 
-`localServers.skipLoading: true` avoids a race: register your MCP servers after `waitForReady()`, then Angie uses `featuredMcpServer` to prioritize the right one.
+`localServers.skipLoading: true` (deprecated — prefer `include: []`) avoids a race: register your MCP servers after `waitForReady()`, then Angie uses `featuredMcpServer` to prioritize the right one.
 
 ### Visitor floating search widget
 


### PR DESCRIPTION
## Overview

Extends `WidgetConfig.localServers` so embed hosts can load a subset of the iframe's **built-in** MCP servers instead of the full default set. Previously the only control was `localServers.skipLoading`, which is all-or-nothing.

The SDK exposes configuration only — the fields are forwarded to the embedded application through the existing `sdk-widget-config` postMessage. No new transport or runtime logic in the SDK.

## Changes

### `localServers` configuration (`WidgetConfig`)

- `include?: string[]` — allowlist. When present, only the listed built-in servers load; `exclude` is ignored.
- `exclude?: string[]` — blocklist. Applied only when `include` is absent: all built-ins except the listed ones load.
- `skipLoading?: boolean` — now marked `@deprecated`, equivalent to `include: []`. Still works.
- Precedence: `include` wins if present, otherwise `exclude` applies, and omitting both preserves today's behavior (full default set). Unknown names are ignored with a warning.
- `LocalServersConfig` is kept internal to `WidgetConfig` and is not re-exported from the package entry point — hosts configure it via `WidgetConfig`.

### Docs

- Documented in `widget-config.md` under a new "Built-in local MCP servers" section, including the precedence rules and the deprecation of `skipLoading`.

## Test plan

- [x] `npm run build` produces dist types with `include` / `exclude` on `localServers`

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Extends `LocalServersConfig` with granular control over built-in MCP server loading via `include`/`exclude` allowlists, deprecating the coarse `skipLoading` boolean in favor of explicit filtering.

## 2. What Changed (Where)

- `src/angie-mcp-sdk.ts`: Added `include` and `exclude` fields to `LocalServersConfig` type; marked `skipLoading` deprecated.
- `src/load-sidebar-v2/widget-config.md`: Documented new fields, precedence rules, and deprecation path; clarified scope (built-in servers only).

## 3. How It Works

`include` takes absolute precedence (whitelist mode); `exclude` applies only when `include` absent (blacklist mode); both omitted loads defaults. Unknown server names logged as warnings but don't fail. `skipLoading: true` equivalent to `include: []`.

## 4. Risks

Backward compatibility preserved—`skipLoading` remains functional. Minor risk: users mixing `include` + `exclude` may expect AND behavior instead of include-wins semantics; docs mitigate this clearly.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
