### PR TITLE
Disable top bar in right-click floating demo

### DIFF
--- a/demo/load-sidebar-v2-right-click-floating/host.js
+++ b/demo/load-sidebar-v2-right-click-floating/host.js
@@ -225,6 +225,7 @@ await sdk.loadSidebarV2( {
 		modeSwitcher: { enabled: false, default: 'agent' },
 		featuredMcpServer: CONTEXT_SERVER_NAME,
 		localServers: { skipLoading: true },
+		topBar: { enabled: false },
 	},
 } );
 


### PR DESCRIPTION
## Summary
- Hide the app top bar in the right-click floating sidebar demo by adding `topBar: { enabled: false }` to the widget config.

## Test plan
- Load the right-click floating demo and confirm the top bar no longer renders.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Hiding the top bar in the right-click floating demo for a cleaner UI.

## 2. What Changed (Where)
- `demo/load-sidebar-v2-right-click-floating/host.js`: Disabled `topBar` in `loadSidebarV2` config.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
