### PR TITLE
[AI-9384] Feature: SDK clients attach context to messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,10 +177,27 @@ In most cases, you don't need to `await` it since registration happens in the ba
 
 ## Triggering Angie with Prompts
 
-The SDK can also trigger Angie with custom prompts - useful for help buttons or deep linking.
+The SDK can trigger Angie with a prompt, model-visible message context, or both.
 
 ```typescript
-import { AngieMcpSdk } from '@elementor/angie-sdk';
+interface MessageContext {
+  label: string;
+  content: string;
+}
+
+interface AngieTriggerRequest {
+  prompt?: string;
+  context?: { source?: string } & Record<string, unknown>;
+  messageContext?: MessageContext;
+  options?: {
+    timeout?: number;
+    newChat?: boolean;
+  };
+}
+```
+
+```typescript
+import { AngieMcpSdk, type MessageContext } from '@elementor/angie-sdk';
 
 // Register your MCP server and trigger Angie
 const server = createSeoMcpServer();
@@ -199,22 +216,36 @@ sdk.registerServer({
 await sdk.triggerAngie({
   prompt: 'Help me optimize this page for SEO',
   context: { pageType: 'product', source: 'my-plugin' },
+  messageContext: {
+    label: 'Current SEO report',
+    content: 'The page is missing a meta description.',
+  },
   options: {
     timeout: 30000, // Optional: 30 seconds timeout (default: 30000)
-    
+    newChat: true,
   }
 });
 
-// Or simplified version
+// A prompt without context
 await sdk.triggerAngie({
   prompt: 'Help me create a contact page'
 });
+
+// Model-visible context without a prompt
+const messageContext: MessageContext = {
+  label: 'Selected error',
+  content: 'Checkout failed with error code PAYMENT_DECLINED.',
+};
+
+await sdk.triggerAngie({ messageContext });
 ```
 
-**Options:**
-- `timeout`: How long to wait for Angie response (milliseconds)  
-- `angie-new-chat`: When `true`, clears the current conversation and opens a fresh chat with the prompt pre-filled in the input
-- `context`: Additional data to help Angie understand the request
+**Request fields:**
+- `prompt`: Optional prompt text.
+- `messageContext`: Optional labeled content that is visible to the model. It can be used without `prompt`.
+- `context`: Optional integration metadata. The SDK adds the current `pageUrl` and `pageTitle`; supplied values can override them. This legacy field is not model-visible message content.
+- `options.timeout`: How long to wait for Angie response in milliseconds (default: `30000`).
+- `options.newChat`: When `true`, clears the current conversation and opens a fresh chat.
 
 ### Hash Parameter Method
 

--- a/README.md
+++ b/README.md
@@ -177,10 +177,10 @@ In most cases, you don't need to `await` it since registration happens in the ba
 
 ## Triggering Angie with Prompts
 
-The SDK can trigger Angie with a prompt, model-visible message context, or both.
+The SDK can trigger Angie with a prompt, a context attachment, or both.
 
 ```typescript
-interface MessageContext {
+interface ContextAttachment {
   label: string;
   content: string;
 }
@@ -188,7 +188,7 @@ interface MessageContext {
 interface AngieTriggerRequest {
   prompt?: string;
   context?: { source?: string } & Record<string, unknown>;
-  messageContext?: MessageContext;
+  contextAttachment?: ContextAttachment;
   options?: {
     timeout?: number;
     newChat?: boolean;
@@ -197,7 +197,7 @@ interface AngieTriggerRequest {
 ```
 
 ```typescript
-import { AngieMcpSdk, type MessageContext } from '@elementor/angie-sdk';
+import { AngieMcpSdk, type ContextAttachment } from '@elementor/angie-sdk';
 
 // Register your MCP server and trigger Angie
 const server = createSeoMcpServer();
@@ -216,7 +216,7 @@ sdk.registerServer({
 await sdk.triggerAngie({
   prompt: 'Help me optimize this page for SEO',
   context: { pageType: 'product', source: 'my-plugin' },
-  messageContext: {
+  contextAttachment: {
     label: 'Current SEO report',
     content: 'The page is missing a meta description.',
   },
@@ -231,18 +231,18 @@ await sdk.triggerAngie({
   prompt: 'Help me create a contact page'
 });
 
-// Model-visible context without a prompt
-const messageContext: MessageContext = {
+// Attach context without pre-filling a prompt
+const contextAttachment: ContextAttachment = {
   label: 'Selected error',
   content: 'Checkout failed with error code PAYMENT_DECLINED.',
 };
 
-await sdk.triggerAngie({ messageContext });
+await sdk.triggerAngie({ contextAttachment });
 ```
 
 **Request fields:**
 - `prompt`: Optional prompt text.
-- `messageContext`: Optional labeled content that is visible to the model. It can be used without `prompt`.
+- `contextAttachment`: Optional labeled content attached to the next submitted user message. It can be used without `prompt` and is not rendered as part of the message text.
 - `context`: Optional integration metadata. The SDK adds the current `pageUrl` and `pageTitle`; supplied values can override them. This legacy field is not model-visible message content.
 - `options.timeout`: How long to wait for Angie response in milliseconds (default: `30000`).
 - `options.newChat`: When `true`, clears the current conversation and opens a fresh chat.

--- a/demo/trigger-angie-prompt/host.js
+++ b/demo/trigger-angie-prompt/host.js
@@ -1,6 +1,10 @@
 import { AngieMcpSdk, LAYOUT_SIDEBAR } from '../../dist/index.js';
 
 const DEFAULT_PROMPT = 'Help me improve the headline on this page for conversions.';
+const CONTEXT_ATTACHMENT = {
+	label: 'Current page headline',
+	content: 'Build faster with Angie',
+};
 
 const sdk = new AngieMcpSdk();
 const statusEl = document.getElementById( 'demo-status' );
@@ -32,6 +36,7 @@ const triggerWithPrompt = async ( { newChat = false, prompt = getPrompt() } = {}
 
 		const response = await sdk.triggerAngie( {
 			prompt,
+			contextAttachment: CONTEXT_ATTACHMENT,
 			options: {
 				newChat,
 				timeout: 30000,

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, beforeEach, jest, afterEach } from '@jest/globals
 import { AngieMcpSdk } from './angie-mcp-sdk';
 import { appState } from './config';
 import type { AngieServerConfig, ServerRegistration, AngieDetectionResult, ClientCreationResponse } from './types';
-import { AngieServerType } from './types';
+import { AngieServerType, MessageEventType } from './types';
 
 // Mock dependencies
 jest.mock('./angie-detector');
@@ -205,6 +205,52 @@ describe('AngieMcpSdk', () => {
 
       // Assert
       expect(result).toBe(false);
+    });
+  });
+
+  describe('triggerAngie', () => {
+    it('should send message context unchanged without requiring a prompt', async () => {
+      const messageContext = {
+        label: 'Selected error',
+        content: 'Checkout failed with error code PAYMENT_DECLINED.',
+      };
+      const postMessageSpy = jest.spyOn(window, 'postMessage').mockImplementation((message: any) => {
+        if (message?.type === MessageEventType.SDK_TRIGGER_ANGIE) {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: {
+              type: MessageEventType.SDK_TRIGGER_ANGIE_RESPONSE,
+              payload: {
+                success: true,
+                requestId: message.payload.requestId,
+              },
+            },
+          }));
+        }
+      });
+      mockAngieDetector.isReady.mockReturnValue(true);
+
+      await sdk.triggerAngie({
+        messageContext,
+        context: {
+          source: 'checkout-plugin',
+          pageUrl: 'https://example.com/checkout',
+          pageTitle: 'Checkout',
+        },
+      });
+
+      const triggerMessage = postMessageSpy.mock.calls.find(
+        ([message]) => message.type === MessageEventType.SDK_TRIGGER_ANGIE
+      )?.[0];
+
+      expect(triggerMessage.payload.prompt).toBeUndefined();
+      expect(triggerMessage.payload.messageContext).toBe(messageContext);
+      expect(triggerMessage.payload.context).toEqual({
+        source: 'checkout-plugin',
+        pageUrl: 'https://example.com/checkout',
+        pageTitle: 'Checkout',
+      });
+
+      postMessageSpy.mockRestore();
     });
   });
 

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -209,8 +209,8 @@ describe('AngieMcpSdk', () => {
   });
 
   describe('triggerAngie', () => {
-    it('should send message context unchanged without requiring a prompt', async () => {
-      const messageContext = {
+    it('should send a context attachment unchanged without requiring a prompt', async () => {
+      const contextAttachment = {
         label: 'Selected error',
         content: 'Checkout failed with error code PAYMENT_DECLINED.',
       };
@@ -230,7 +230,7 @@ describe('AngieMcpSdk', () => {
       mockAngieDetector.isReady.mockReturnValue(true);
 
       await sdk.triggerAngie({
-        messageContext,
+        contextAttachment,
         context: {
           source: 'checkout-plugin',
           pageUrl: 'https://example.com/checkout',
@@ -243,7 +243,7 @@ describe('AngieMcpSdk', () => {
       )?.[0];
 
       expect(triggerMessage.payload.prompt).toBeUndefined();
-      expect(triggerMessage.payload.messageContext).toBe(messageContext);
+      expect(triggerMessage.payload.contextAttachment).toBe(contextAttachment);
       expect(triggerMessage.payload.context).toEqual({
         source: 'checkout-plugin',
         pageUrl: 'https://example.com/checkout',

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -290,8 +290,8 @@ export class AngieMcpSdk {
   }
 
   /**
-   * Triggers Angie with a prompt, message context, or both
-   * @param request - The trigger request containing optional prompt and context
+   * Triggers Angie with a prompt, context attachment, or both
+   * @param request - The trigger request containing an optional prompt and context attachment
    * @returns Promise resolving to Angie's response
    */
   public async triggerAngie(request: AngieTriggerRequest): Promise<AngieTriggerResponse> {
@@ -325,7 +325,7 @@ export class AngieMcpSdk {
           requestId,
           prompt: request.prompt,
           options: request.options,
-          messageContext: request.messageContext,
+          contextAttachment: request.contextAttachment,
           context: {
             pageUrl: window.location.href,
             pageTitle: document.title,

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -290,8 +290,8 @@ export class AngieMcpSdk {
   }
 
   /**
-   * Triggers Angie with a specified prompt and optional context
-   * @param request - The trigger request containing prompt and optional context
+   * Triggers Angie with a prompt, message context, or both
+   * @param request - The trigger request containing optional prompt and context
    * @returns Promise resolving to Angie's response
    */
   public async triggerAngie(request: AngieTriggerRequest): Promise<AngieTriggerResponse> {
@@ -325,6 +325,7 @@ export class AngieMcpSdk {
           requestId,
           prompt: request.prompt,
           options: request.options,
+          messageContext: request.messageContext,
           context: {
             pageUrl: window.location.href,
             pageTitle: document.title,

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -11,7 +11,7 @@ jest.mock('./logger', () => ({
 }));
 
 describe('listenToSDK', () => {
-	it('should relay message context unchanged to the Angie iframe', async () => {
+	it('should relay a context attachment unchanged to the Angie iframe', async () => {
 		const iframePostMessage = jest.fn();
 		const appState = {
 			open: false,
@@ -24,7 +24,7 @@ describe('listenToSDK', () => {
 			containerId: 'angie-sidebar-container',
 		} satisfies AppState;
 		const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
-		const messageContext = {
+		const contextAttachment = {
 			label: 'Selected error',
 			content: 'Checkout failed with error code PAYMENT_DECLINED.',
 		};
@@ -41,19 +41,19 @@ describe('listenToSDK', () => {
 				type: MessageEventType.SDK_TRIGGER_ANGIE,
 				payload: {
 					requestId: 'request-123',
-					messageContext,
+					contextAttachment,
 				},
 			},
 		} as MessageEvent);
 
 		const relayedMessage = iframePostMessage.mock.calls[0][0] as {
 			payload: {
-				messageContext?: typeof messageContext;
+				contextAttachment?: typeof contextAttachment;
 				prompt?: string;
 			};
 		};
 
-		expect(relayedMessage.payload.messageContext).toBe(messageContext);
+		expect(relayedMessage.payload.contextAttachment).toBe(contextAttachment);
 		expect(relayedMessage.payload.prompt).toBeUndefined();
 		expect(iframePostMessage).toHaveBeenCalledWith(
 			expect.objectContaining({

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import type { AppState } from './config';
+import { listenToSDK } from './sdk';
+import { MessageEventType } from './types';
+
+jest.mock('./logger', () => ({
+	createChildLogger: jest.fn(() => ({
+		log: jest.fn(),
+		error: jest.fn(),
+	})),
+}));
+
+describe('listenToSDK', () => {
+	it('should relay message context unchanged to the Angie iframe', async () => {
+		const iframePostMessage = jest.fn();
+		const appState = {
+			open: false,
+			iframe: {
+				contentWindow: {
+					postMessage: iframePostMessage,
+				},
+			} as unknown as HTMLIFrameElement,
+			iframeUrlObject: new URL('https://angie.elementor.com'),
+			containerId: 'angie-sidebar-container',
+		} satisfies AppState;
+		const addEventListenerSpy = jest.spyOn(window, 'addEventListener');
+		const messageContext = {
+			label: 'Selected error',
+			content: 'Checkout failed with error code PAYMENT_DECLINED.',
+		};
+
+		listenToSDK(appState);
+
+		const messageHandler = addEventListenerSpy.mock.calls.find(
+			([type]) => type === 'message'
+		)?.[1] as unknown as (event: MessageEvent) => Promise<void>;
+
+		await messageHandler({
+			origin: window.location.origin,
+			data: {
+				type: MessageEventType.SDK_TRIGGER_ANGIE,
+				payload: {
+					requestId: 'request-123',
+					messageContext,
+				},
+			},
+		} as MessageEvent);
+
+		const relayedMessage = iframePostMessage.mock.calls[0][0] as {
+			payload: {
+				messageContext?: typeof messageContext;
+				prompt?: string;
+			};
+		};
+
+		expect(relayedMessage.payload.messageContext).toBe(messageContext);
+		expect(relayedMessage.payload.prompt).toBeUndefined();
+		expect(iframePostMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: MessageEventType.SDK_TRIGGER_ANGIE,
+			}),
+			appState.iframeUrlObject.origin
+		);
+
+		window.removeEventListener('message', messageHandler);
+		addEventListenerSpy.mockRestore();
+	});
+});

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -81,7 +81,7 @@ export const listenToSDK = ( appState: AppState ) => {
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 
 				try {
-					const { requestId, prompt, context, options } = event.data.payload;
+					const { requestId, prompt, context, messageContext, options } = event.data.payload;
 
 					if ( appState.iframe ) {
 						appState.iframe.contentWindow?.postMessage( {
@@ -90,6 +90,7 @@ export const listenToSDK = ( appState: AppState ) => {
 								requestId,
 								prompt,
 								context,
+								messageContext,
 								options,
 							},
 						}, appState.iframeUrlObject?.origin || '' );

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -81,7 +81,7 @@ export const listenToSDK = ( appState: AppState ) => {
 				sdkLogger.log( 'SDK Trigger Angie received', event.data );
 
 				try {
-					const { requestId, prompt, context, messageContext, options } = event.data.payload;
+					const { requestId, prompt, context, contextAttachment, options } = event.data.payload;
 
 					if ( appState.iframe ) {
 						appState.iframe.contentWindow?.postMessage( {
@@ -90,7 +90,7 @@ export const listenToSDK = ( appState: AppState ) => {
 								requestId,
 								prompt,
 								context,
-								messageContext,
+								contextAttachment,
 								options,
 							},
 						}, appState.iframeUrlObject?.origin || '' );

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,11 +98,17 @@ export interface ClientCreationResponse {
   error?: string;
 }
 
+export interface MessageContext {
+  label: string;
+  content: string;
+}
+
 export interface AngieTriggerRequest {
   prompt?: string;
-  context:{
+  context?: {
     source?: string;
-  }& Record<string, any>;
+  } & Record<string, unknown>;
+  messageContext?: MessageContext;
   options?: {
     timeout?: number;
     newChat?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface ClientCreationResponse {
   error?: string;
 }
 
-export interface MessageContext {
+export interface ContextAttachment {
   label: string;
   content: string;
 }
@@ -108,7 +108,7 @@ export interface AngieTriggerRequest {
   context?: {
     source?: string;
   } & Record<string, unknown>;
-  messageContext?: MessageContext;
+  contextAttachment?: ContextAttachment;
   options?: {
     timeout?: number;
     newChat?: boolean;


### PR DESCRIPTION
## Problem
SDK clients can open Angie with a prompt, but cannot attach contextual information such as the selected Elementor element to the user's next message without placing that data in the prompt text.

## Solution
Add an optional labeled `contextAttachment` to `triggerAngie`, relay it unchanged to Angie, and demonstrate it in the trigger example. The attachment can be supplied with or without a prompt and remains distinct from integration metadata.

## Video proof demo
**Where:** WordPress admin → Angie
**Steps:** open Angie → confirm the sidebar loads → capture a screenshot
**Pass:** Angie sidebar is visible and loaded
**Fail:** sign-in prompt, blank iframe, or Angie fails to open

Jira: https://elementor.atlassian.net/browse/AI-9384

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Extends SDK trigger API to support attaching context (labeled content) to messages independently of prompts, enabling use cases like error reporting or metadata attachment without pre-filling user input.

## 2. What Changed (Where)

| File | Change |
|------|--------|
| `src/types.ts` | Added `ContextAttachment` interface; made `AngieTriggerRequest.context` optional with proper typing |
| `src/angie-mcp-sdk.ts` | Pass `contextAttachment` through trigger payload; updated JSDoc |
| `src/sdk.ts` | Destructure and relay `contextAttachment` in message routing |
| `demo/trigger-angie-prompt/host.js` | Demo usage of context attachment feature |
| `README.md` | Documented API, examples, field semantics |
| `*.test.ts` | Added test coverage for context-only triggers |

## 3. How It Works

Request flows: SDK client → `triggerAngie({contextAttachment, prompt?})` → window.postMessage to routing layer → relayed via iframe.postMessage to Angie iframe. Context attachment transmits as opaque labeled content, never rendered as message text—decoupled from prompt requirement.

## 4. Risks

Minor: TypeScript interface change to `context` field (now `{ source?: string } & Record<string, unknown>` vs `any`) tightens typing but is backward compatible. Message routing adds one field to payload—negligible performance impact.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
