### PR TITLE
Replace quotaError with quotaBanner and inChatQuotaErrorMessage in WidgetConfig

### DIFF
--- a/demo/load-sidebar-v2-right-click-floating/host.js
+++ b/demo/load-sidebar-v2-right-click-floating/host.js
@@ -226,6 +226,7 @@ await sdk.loadSidebarV2( {
 		featuredMcpServer: CONTEXT_SERVER_NAME,
 		localServers: { skipLoading: true },
 		topBar: { enabled: false },
+		quotaBanner: { enabled: true },
 	},
 } );
 

--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -98,7 +98,7 @@ const buildSandboxWidgetConfig = () => ( {
 	modeSwitcher: { enabled: true, default: 'agent' },
 	closeButton: 'collapse',
 	statusBanner: { enabled: true },
-	quotaError: { enabled: true },
+	quotaBanner: { enabled: true },
 	userProfileMenu: { enabled: true },
 	topBar: { enabled: false },
 } );

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -129,8 +129,12 @@
               <dd>Opt in to Angie ops/incident status messages (off by default)</dd>
             </div>
             <div>
-              <dt><code>quotaError</code></dt>
-              <dd>Opt in to the quota-blocked banner (off by default); <code>customMessage</code> overrides the copy</dd>
+              <dt><code>quotaBanner</code></dt>
+              <dd>Show the quota-blocked banner</dd>
+            </div>
+            <div>
+              <dt><code>inChatQuotaErrorMessage</code></dt>
+              <dd>Custom in-chat message shown when the daily limit is hit</dd>
             </div>
           </dl>
           <p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -45,11 +45,6 @@ export type ModelsConfig = {
   execution: string;
 };
 
-export type QuotaErrorConfig = {
-  enabled: boolean;
-  customMessage?: string;
-};
-
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -63,7 +58,8 @@ export type WidgetConfig = {
   commands?: FeatureToggle;
   testMode?: FeatureToggle;
   statusBanner?: FeatureToggle;
-  quotaError?: QuotaErrorConfig;
+  quotaBanner?: FeatureToggle;
+  inChatQuotaErrorMessage?: string;
   userProfileMenu?: FeatureToggle;
   localServers?: LocalServersConfig;
   planning?: FeatureToggle;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type ModelsConfig, type QuotaErrorConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -100,11 +100,12 @@ Control the embedded app top bar (the bar containing new chat, history, and the 
 |-------|------|---------|
 | `topBar` | `{ enabled: boolean }` | `enabled: false` hides the whole top bar (new chat, history, and user menu) |
 
-### Quota error banner
+### Quota
 
 | Field | Type | Purpose |
 |-------|------|---------|
-| `quotaError` | `{ enabled: boolean; customMessage?: string }` | **Opt in** to the usage/quota-blocked banner — off by default. Pass `{ enabled: true }` to show it; `customMessage` overrides the default blocking copy. Hiding it (the default) means a quota-blocked chat stops responding without an in-chat explanation, so only leave it off if the host surfaces the block elsewhere. |
+| `quotaBanner` | `{ enabled: boolean }` | Show the quota-blocked banner. |
+| `inChatQuotaErrorMessage` | `string` | Custom in-chat message shown when the daily limit is hit. |
 
 ## Patterns from production hosts
 


### PR DESCRIPTION
## Summary
Splits the previous `quotaError` config object into two independent, single-purpose fields:

- `quotaBanner?: FeatureToggle` — show/hide the quota-blocked banner
- `inChatQuotaErrorMessage?: string` — custom in-chat message shown when the daily limit is hit

Previously `quotaError` conflated banner visibility with the in-chat message copy. Separating them lets a host toggle the banner and customize the in-chat message independently.

## Changes
- Remove `QuotaErrorConfig` type and its export
- Add `quotaBanner` and `inChatQuotaErrorMessage` to `WidgetConfig`
- Update `widget-config.md` docs and the widget-config demo
- Bump version to `1.7.1`

## Breaking change
`quotaError` and the `QuotaErrorConfig` type are removed. Hosts using `quotaError: { enabled, customMessage }` must migrate to `quotaBanner: { enabled }` and `inChatQuotaErrorMessage`.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Refactor quota configuration to decouple the visibility of the quota banner from the custom in-chat error message.

## 2. What Changed (Where)
| File | Change |
| :--- | :--- |
| `src/angie-mcp-sdk.ts` | Replaced `quotaError` config with `quotaBanner` (toggle) and `inChatQuotaErrorMessage` (string). |
| `src/index.ts` | Removed `QuotaErrorConfig` from public exports. |
| `demo/**/*` | Updated demo host configs and HTML documentation to reflect new property names. |
| `package.json` | Bumped version to `1.7.1`. |
| `src/.../widget-config.md` | Updated quota documentation table. |

## 4. Risks
Breaking change: Hosts relying on `quotaError` will need to update to `quotaBanner` and `inChatQuotaErrorMessage`.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
