### PR TITLE
Fix refresh pings resetting MCP on the wrong widget

### DIFF
--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -432,14 +432,65 @@ describe('AngieMcpSdk', () => {
       expect(mockRegistrationQueue.resetAllToPending).toHaveBeenCalled();
     });
 
-    it('should reset queue on refresh ping with no instanceId', () => {
-      const event = {
-        data: {
-          type: 'sdk-angie-refresh-ping',
-        },
-      } as unknown as MessageEvent<any>;
+    it('should ignore a refresh ping sent by another instance iframe', () => {
+      const ownWindow = {} as Window;
+      const siblingWindow = {} as Window;
+      jest.spyOn( instanceRegistry, 'getInstanceById' ).mockReturnValue( {
+        iframe: { contentWindow: ownWindow } as HTMLIFrameElement,
+        iframeUrlObject: new URL( 'https://angie.elementor.com/angie/embedded' ),
+      } as ReturnType<typeof instanceRegistry.getInstanceById> );
 
-      refreshPingHandler(event);
+      refreshPingHandler( {
+        origin: 'https://angie.elementor.com',
+        source: siblingWindow,
+        data: { type: 'sdk-angie-refresh-ping', payload: { timestamp: 1 } },
+      } as unknown as MessageEvent<any> );
+
+      expect(mockRegistrationQueue.resetAllToPending).not.toHaveBeenCalled();
+    });
+
+    it('should accept an id-less refresh ping sent by its own iframe', () => {
+      const ownWindow = {} as Window;
+      jest.spyOn( instanceRegistry, 'getInstanceById' ).mockReturnValue( {
+        iframe: { contentWindow: ownWindow } as HTMLIFrameElement,
+        iframeUrlObject: new URL( 'https://angie.elementor.com/angie/embedded' ),
+      } as ReturnType<typeof instanceRegistry.getInstanceById> );
+
+      refreshPingHandler( {
+        origin: 'https://angie.elementor.com',
+        source: ownWindow,
+        data: { type: 'sdk-angie-refresh-ping', payload: { timestamp: 1 } },
+      } as unknown as MessageEvent<any> );
+
+      expect(mockRegistrationQueue.resetAllToPending).toHaveBeenCalled();
+    });
+
+    it('should ignore an unverifiable id-less refresh ping while siblings are registered', () => {
+      jest.spyOn( instanceRegistry, 'getInstanceCount' ).mockReturnValue( 2 );
+      jest.spyOn( instanceRegistry, 'getInstanceById' ).mockReturnValue( {
+        iframe: null,
+        iframeUrlObject: new URL( 'https://angie.elementor.com/angie/embedded' ),
+      } as ReturnType<typeof instanceRegistry.getInstanceById> );
+
+      refreshPingHandler( {
+        origin: 'https://angie.elementor.com',
+        data: { type: 'sdk-angie-refresh-ping', payload: { timestamp: 1 } },
+      } as unknown as MessageEvent<any> );
+
+      expect(mockRegistrationQueue.resetAllToPending).not.toHaveBeenCalled();
+    });
+
+    it('should still accept an unverifiable id-less refresh ping as the only instance', () => {
+      jest.spyOn( instanceRegistry, 'getInstanceCount' ).mockReturnValue( 1 );
+      jest.spyOn( instanceRegistry, 'getInstanceById' ).mockReturnValue( {
+        iframe: null,
+        iframeUrlObject: new URL( 'https://angie.elementor.com/angie/embedded' ),
+      } as ReturnType<typeof instanceRegistry.getInstanceById> );
+
+      refreshPingHandler( {
+        origin: 'https://angie.elementor.com',
+        data: { type: 'sdk-angie-refresh-ping', payload: { timestamp: 1 } },
+      } as unknown as MessageEvent<any> );
 
       expect(mockRegistrationQueue.resetAllToPending).toHaveBeenCalled();
     });

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -177,7 +177,6 @@ export class AngieMcpSdk {
         }
 
         if ( ! this.isRefreshPingForThisInstance( event, instance ) ) {
-          this.logger.log(`Ignoring refresh ping from another instance's iframe. This instanceId: ${this.instanceId}`);
           return;
         }
 

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -2,14 +2,14 @@ import type { Logger } from '@elementor/angie-logger';
 import { AngieDetector } from './angie-detector';
 import { BrowserContextTransport } from './browser-context-transport';
 import { ClientManager } from './client-manager';
-import { appState, DEFAULT_CONTAINER_ID } from './config';
+import { appState, DEFAULT_CONTAINER_ID, type AppState } from './config';
 import { createChildLogger } from './logger';
 import { openIframe } from './iframe';
 import { addLocalStorageListener } from './localStorage';
 import { handlePostConsentRedirect } from './oauth';
 import { initAngieSidebar } from './sidebar';
 import { RegistrationQueue } from './registration-queue';
-import { getInstanceById } from './instance-registry';
+import { getInstanceById, getInstanceCount } from './instance-registry';
 import { generateInstanceId } from './utils';
 import { bootSidebar } from './load-sidebar-v2/boot-sidebar';
 import type { LoadSidebarV2Options } from './load-sidebar-v2/config';
@@ -148,21 +148,36 @@ export class AngieMcpSdk {
     return this.sidebarV2BootPromise;
   }
 
-  // listen to MessageEventType.SDK_ANGIE_READY_PING
+  // Id-less pings: match event.source so a sibling iframe does not re-register servers.
+  private isRefreshPingForThisInstance( event: MessageEvent, instance: AppState | null ): boolean {
+    const pingInstanceId = event.data?.payload?.instanceId;
+
+    if ( pingInstanceId ) {
+      return pingInstanceId === this.instanceId;
+    }
+
+    const contentWindow = instance?.iframe?.contentWindow;
+
+    if ( contentWindow && event.source ) {
+      return event.source === contentWindow;
+    }
+
+    // Cannot match source (V1, or iframe/source missing). Safe only with no sibling.
+    return getInstanceCount() < 2;
+  }
 
   private setupReRegistrationHandler(): void {
     window.addEventListener('message', (event) => {
       if (event.data?.type === MessageEventType.SDK_ANGIE_REFRESH_PING) {
-        const iframeOrigin = getInstanceById( this.instanceId )?.iframeUrlObject?.origin;
+        const instance = getInstanceById( this.instanceId );
+        const iframeOrigin = instance?.iframeUrlObject?.origin;
         if ( iframeOrigin && event.origin !== iframeOrigin ) {
           this.logger.log(`Ignoring refresh ping from unexpected origin. Event origin: ${event.origin}, iframe origin: ${iframeOrigin}`);
           return;
         }
 
-        const pingInstanceId = event.data?.payload?.instanceId;
-        // Embedded Angie does not send instanceId yet; absent id keeps legacy behavior.
-        if (pingInstanceId && pingInstanceId !== this.instanceId) {
-          this.logger.log(`Ignoring refresh ping for different instance. Ping instanceId: ${pingInstanceId}, this instanceId: ${this.instanceId}`);
+        if ( ! this.isRefreshPingForThisInstance( event, instance ) ) {
+          this.logger.log(`Ignoring refresh ping from another instance's iframe. This instanceId: ${this.instanceId}`);
           return;
         }
 

--- a/src/instance-registry.ts
+++ b/src/instance-registry.ts
@@ -35,6 +35,8 @@ export const createAngieInstance = ( args: CreateAngieInstanceArgs ): AppState =
 
 export const getFirstInstance = (): AppState | null => instances[ 0 ] ?? null;
 
+export const getInstanceCount = (): number => instances.length;
+
 const getFirstIframeInstance = (): AppState | null => {
 	const registered = instances.find( ( instance ) => instance.iframe !== null );
 


### PR DESCRIPTION
## Why
When more than one Angie iframe is on the page, Embedded Angie still sends refresh pings without `instanceId`. Every SDK instance treated that as “mine”, reset its registration queue, and tried to `connect()` again. That causes duplicate MCP connects and noisy failures on multi-widget hosts.

## What
Match an id-less ping to this instance’s iframe (`event.source`). If that cannot be checked, accept the ping only when a single instance is registered.

## Test plan
- [ ] Unit tests for sibling iframe / own iframe / unverifiable + siblings / lone instance
- [ ] Multi-instance page: refresh one widget and confirm siblings do not re-register servers

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Refresh pings lacking an `instanceId` were indiscriminately triggering MCP resets across all active widget instances. This change ensures pings are scoped to the specific instance that sent them.

## 2. What Changed (Where)
- `src/angie-mcp-sdk.ts`: Added `isRefreshPingForThisInstance` and integrated it into the re-registration handler.
- `src/instance-registry.ts`: Added `getInstanceCount` to support fallback logic.
- `src/angie-mcp-sdk.test.ts`: Added test cases for id-less pings, sibling windows, and single-instance scenarios.

## 3. How It Works
The SDK now validates refresh pings using a tiered priority:
1. Matches `instanceId` if provided in the payload.
2. Compares `event.source` against the instance's `contentWindow` for id-less pings.
3. Falls back to allowing the ping only if `getInstanceCount() < 2` to maintain legacy compatibility.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
