### PR TITLE
Add host callbacks for website and analytics context

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,
 	type ExternalHeadersCallback,
+	type HostContextProvider,
 	type LoadSidebarV2Options,
 } from './load-sidebar-v2/config';
 export { AngieDetector } from './angie-detector';

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -58,7 +58,7 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 | `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
 | `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
-| `callbacks` | `onClose`, `getExternalHeaders` for auth/API headers |
+| `callbacks` | `onClose`, `getExternalHeaders`, `getWebsiteContext`, `getAnalyticsContext` (see [message ownership](#message-ownership)) |
 | `widgetConfig` | Embedded UI copy, feature toggles, MCP focus, close behavior — see [widgetConfig guide](./widget-config.md) |
 
 Embedded config uses `configVersion: 2` (`LOAD_SIDEBAR_V2_CONFIG_VERSION`).
@@ -205,9 +205,23 @@ Full reference: [Hash Parameter Method](../../README.md#hash-parameter-method).
 [`host-api-bridge.ts`](./host-api-bridge.ts) listens for messages from the Angie iframe (origin-checked) and responds on a `MessagePort`:
 
 - `GET_EXTERNAL_HEADERS` — `callbacks.getExternalHeaders()`
-- `angie/context/get-website-context` — host + document metadata
-- `angie/context/get-analytics-context` — screen path + `host.analytics`
+- `angie/context/get-website-context` — `callbacks.getWebsiteContext()`, else host + document metadata
+- `angie/context/get-analytics-context` — `callbacks.getAnalyticsContext()`, else screen path + `host.analytics`
 - Host localStorage get/set (V2 only; V1 uses [`localStorage.ts`](../localStorage.ts)). With `host.instanceId`, keys are scoped per widget (`logicalKey::__angie::<id>`); omit it for legacy unprefixed keys on a single widget.
+
+### Message ownership
+
+The iframe uses the **first** reply on the port. Do not keep a host `window` listener for these
+types — it races the bridge and usually loses the payload the host meant to send.
+
+| Need | Owner |
+|---|---|
+| Static website/analytics fields | `host.website` / `host.analytics` |
+| Per-request context | `callbacks.getWebsiteContext` / `getAnalyticsContext` |
+| Auth headers | `callbacks.getExternalHeaders` |
+| Host localStorage | Bridge (do not add a get/set listener) |
+
+Providers may be async. A throw becomes an error reply.
 
 ## Module map
 

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -78,6 +78,8 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 		iframeOrigin: config.iframe.origin,
 		host: config.host,
 		getExternalHeaders: config.callbacks.getExternalHeaders,
+		getWebsiteContext: config.callbacks.getWebsiteContext,
+		getAnalyticsContext: config.callbacks.getAnalyticsContext,
 		instance,
 	} );
 

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -51,9 +51,16 @@ export type ExternalHeadersCallback = () =>
 	| Record<string, string | undefined>
 	| Promise<Record<string, string | undefined>>;
 
+/** Per-request context when boot-time `host.website` / `host.analytics` is not enough. */
+export type HostContextProvider = () =>
+	| Record<string, unknown>
+	| Promise<Record<string, unknown>>;
+
 export type CallbacksConfig = {
 	onClose?: () => void;
 	getExternalHeaders?: ExternalHeadersCallback;
+	getWebsiteContext?: HostContextProvider;
+	getAnalyticsContext?: HostContextProvider;
 };
 
 export type LoadSidebarV2Options = {

--- a/src/load-sidebar-v2/host-api-bridge.test.ts
+++ b/src/load-sidebar-v2/host-api-bridge.test.ts
@@ -71,6 +71,69 @@ describe( 'load-sidebar-v2/host-api-bridge', () => {
 		} );
 	} );
 
+	it( 'should prefer context providers over static host fields', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			host: {
+				appId: 'wordpress',
+				website: { name: 'from host.website' },
+				analytics: { siteKey: 'from-host' },
+			},
+			getWebsiteContext: async () => ( { appId: 'wordpress', name: 'from provider' } ),
+			getAnalyticsContext: async () => ( { siteKey: 'from-provider' } ),
+			instance: appState,
+		} );
+
+		const websitePort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_WEBSITE_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ websitePort as unknown as MessagePort ],
+		} ) );
+
+		const analyticsPort = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_ANALYTICS_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ analyticsPort as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( websitePort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { payload: { appId: 'wordpress', name: 'from provider' } },
+		} );
+		expect( analyticsPort.postMessage ).toHaveBeenCalledWith( {
+			status: 'success',
+			payload: { payload: { siteKey: 'from-provider' } },
+		} );
+	} );
+
+	it( 'should report an error when a context provider throws', async () => {
+		initHostApiBridge( {
+			iframeOrigin: IFRAME_ORIGIN,
+			getWebsiteContext: async () => {
+				throw new Error( 'context unavailable' );
+			},
+			instance: appState,
+		} );
+
+		const port = createMockPort();
+		window.dispatchEvent( new MessageEvent( 'message', {
+			data: { type: GET_WEBSITE_CONTEXT_MESSAGE_TYPE },
+			origin: IFRAME_ORIGIN,
+			ports: [ port as unknown as MessagePort ],
+		} ) );
+
+		await flushAsync();
+
+		expect( port.postMessage ).toHaveBeenCalledWith( {
+			status: 'error',
+			payload: { message: 'context unavailable' },
+		} );
+	} );
+
 	it( 'should respond with empty headers when no callback is provided', async () => {
 		initHostApiBridge( { iframeOrigin: IFRAME_ORIGIN, instance: appState } );
 

--- a/src/load-sidebar-v2/host-api-bridge.ts
+++ b/src/load-sidebar-v2/host-api-bridge.ts
@@ -1,7 +1,7 @@
 import { sendErrorMessage, sendSuccessMessage } from '../utils';
 import { HostLocalStorageEventType } from '../types';
 import type { AppState } from '../config';
-import type { ExternalHeadersCallback, HostConfig } from './config';
+import type { ExternalHeadersCallback, HostConfig, HostContextProvider } from './config';
 
 export const GET_EXTERNAL_HEADERS_MESSAGE_TYPE = 'GET_EXTERNAL_HEADERS';
 
@@ -13,6 +13,8 @@ type InitHostApiBridgeArgs = {
 	iframeOrigin: string;
 	host?: HostConfig;
 	getExternalHeaders?: ExternalHeadersCallback;
+	getWebsiteContext?: HostContextProvider;
+	getAnalyticsContext?: HostContextProvider;
 	instance: AppState;
 };
 
@@ -65,6 +67,26 @@ export const buildAnalyticsContextResponse = ( host?: HostConfig ) => ( {
 		...host?.analytics,
 	},
 } );
+
+// First reply on the port wins. Do not add a host listener for these types.
+const respondWithContext = async (
+	port: MessagePort,
+	provider: HostContextProvider | undefined,
+	buildFallback: () => { payload: Record<string, unknown> },
+): Promise<void> => {
+	if ( ! provider ) {
+		sendSuccessMessage( port, buildFallback() );
+		return;
+	}
+
+	try {
+		sendSuccessMessage( port, { payload: await provider() } );
+	} catch ( error ) {
+		sendErrorMessage( port, {
+			message: error instanceof Error ? error.message : String( error ),
+		} );
+	}
+};
 
 const handleGetExternalHeaders = async (
 	port: MessagePort,
@@ -142,7 +164,11 @@ const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
 			if ( ! port ) {
 				return;
 			}
-			sendSuccessMessage( port, buildWebsiteContextResponse( bridgeConfig.host ) );
+			await respondWithContext(
+				port,
+				bridgeConfig.getWebsiteContext,
+				() => buildWebsiteContextResponse( bridgeConfig.host ),
+			);
 			break;
 		}
 
@@ -150,7 +176,11 @@ const handleHostApiMessage = async ( event: MessageEvent ): Promise<void> => {
 			if ( ! port ) {
 				return;
 			}
-			sendSuccessMessage( port, buildAnalyticsContextResponse( bridgeConfig.host ) );
+			await respondWithContext(
+				port,
+				bridgeConfig.getAnalyticsContext,
+				() => buildAnalyticsContextResponse( bridgeConfig.host ),
+			);
 			break;
 		}
 

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -20,6 +20,19 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		expect( config.widgetConfig ).toEqual( { closeButton: 'collapse' } );
 	} );
 
+	it( 'should carry context providers through to the resolved callbacks', () => {
+		const getWebsiteContext = jest.fn( () => ( { appId: 'wordpress' } ) );
+		const getAnalyticsContext = jest.fn( () => ( { siteKey: 'abc' } ) );
+
+		const config = resolveConfig( {
+			callbacks: { getAnalyticsContext, getWebsiteContext },
+			host: { appId: 'wordpress' },
+		}, DEFAULT_ENV );
+
+		expect( config.callbacks.getWebsiteContext ).toBe( getWebsiteContext );
+		expect( config.callbacks.getAnalyticsContext ).toBe( getAnalyticsContext );
+	} );
+
 	it( 'should resolve floating-chat defaults', () => {
 		const config = resolveConfig(
 			{ container: { layout: LAYOUT_FLOATING_CHAT }, host: { appId: 'editor-lite' } },

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -63,6 +63,8 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		callbacks: {
 			onClose: callbacks.onClose,
 			getExternalHeaders: callbacks.getExternalHeaders,
+			getWebsiteContext: callbacks.getWebsiteContext,
+			getAnalyticsContext: callbacks.getAnalyticsContext,
 		},
 		widgetConfig: resolveWidgetConfig( layout, options.widgetConfig ),
 	};


### PR DESCRIPTION
## Why
Hosts that need fresh website or analytics data on each iframe request were adding their own `window` listeners. The iframe uses the first reply on the MessagePort, so those listeners race the SDK bridge and often win with empty or stale payloads.

## What
`callbacks.getWebsiteContext` / `getAnalyticsContext` (sync or async) become the single owner of those replies. If omitted, behavior stays as today (`host.website` / `host.analytics`). A thrown provider returns an error on the port. Export `HostContextProvider`.

## Test plan
- [ ] Bridge tests: provider payload wins over static host fields; throw → error reply
- [ ] Resolve-config carries the callbacks through
- [ ] Confirm a host does not also listen for the same message types

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Enables dynamic, per-request website and analytics context via host callbacks, overriding static boot-time configuration for cases where context changes after initialization.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `src/index.ts` | Exported `HostContextProvider` type. |
| `src/load-sidebar-v2/boot-sidebar.ts` | Passed new callbacks to `initHostApiBridge`. |
| `src/load-sidebar-v2/config.ts` | Defined `HostContextProvider` and added fields to `CallbacksConfig`. |
| `src/load-sidebar-v2/host-api-bridge.ts` | Implemented `respondWithContext` to handle async provider resolution. |
| `src/load-sidebar-v2/resolve-config.ts` | Integrated new callbacks into the config resolution flow. |
| `src/load-sidebar-v2/README.md` | Updated documentation for callbacks and message ownership. |
| `src/load-sidebar-v2/*.test.ts` | Added coverage for provider preference and error handling. |

## 3. How It Works
The `host-api-bridge.ts` now uses `respondWithContext` when receiving `GET_WEBSITE_CONTEXT` or `GET_ANALYTICS_CONTEXT` messages; it prioritizes the `HostContextProvider` callback if defined, falling back to static host config otherwise. Errors thrown within these async providers are caught and returned as error messages via the `MessagePort`.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
