### PR TITLE
Let the host own sidebar container, CSS, and open/close

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.8.0",
+  "version": "1.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.8.0",
+      "version": "1.7.2",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.8.0",
+  "version": "1.7.2",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -56,9 +56,9 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 |---------|---------|
 | `host` | **Required.** `appId`, optional `instanceId` (see [multiple instances](#multiple-instances-on-one-page)), `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
 | `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
-| `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), resize/persist flags, chat toggle button |
+| `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), `create`, `injectDefaultCss` (sidebar only), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
-| `callbacks` | `onClose`, `getExternalHeaders`, `getWebsiteContext`, `getAnalyticsContext` (see [message ownership](#message-ownership)) |
+| `callbacks` | `onClose`, `onToggle` (sidebar only), `getExternalHeaders`, `getWebsiteContext`, `getAnalyticsContext` (see [message ownership](#message-ownership)) |
 | `widgetConfig` | Embedded UI copy, feature toggles, MCP focus, close behavior — see [widgetConfig guide](./widget-config.md) |
 
 Embedded config uses `configVersion: 2` (`LOAD_SIDEBAR_V2_CONFIG_VERSION`).
@@ -176,7 +176,7 @@ loadSidebarV2(options)
   → boot guards (unique container.id / instanceId, one sidebar layout)
   → createAngieInstance + registerSdkInstance + startSdkMessageRouting (buffers MCP until iframe exists)
   → initHostApiBridge (postMessage API + V2 localStorage)
-  → ensureSidebarContainer
+  → ensureSidebarContainer (skipped when `container.create` is false)
   → layout strategy (initShell → open iframe → afterOpen)
   → sendEmbeddedConfig / sendWidgetConfig
 ```
@@ -222,6 +222,12 @@ types — it races the bridge and usually loses the payload the host meant to se
 | Host localStorage | Bridge (do not add a get/set listener) |
 
 Providers may be async. A throw becomes an error reply.
+
+### Host-owned container and styling
+
+- `container.create: false` — wait for a host-rendered element with that id (both layouts).
+- `container.injectDefaultCss: false` — skip the SDK sidebar stylesheet (sidebar layout). Replaces V1 `skipDefaultCss`.
+- `callbacks.onToggle(isOpen)` — every open/close (sidebar layout). Floating chat still uses `onClose`.
 
 ## Module map
 

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -56,7 +56,7 @@ Each layout applies [presets](./presets/) (defaults for `persistOpenState`, `res
 |---------|---------|
 | `host` | **Required.** `appId`, optional `instanceId` (see [multiple instances](#multiple-instances-on-one-page)), `aiContext`, `website`, `analytics` sent to the embedded Angie app (see [aiContext](#hostaicontext)) |
 | `boot` | `allowInIframe` — skip boot when the host page is itself in an iframe (default `false`) |
-| `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), `create`, `injectDefaultCss` (sidebar only), resize/persist flags, chat toggle button |
+| `container` | DOM container id, `layout`, `styleTheme` (`'wordpress'` injects WP admin-bar CSS), `create`, `skipDefaultCss` (sidebar only), resize/persist flags, chat toggle button |
 | `iframe` | Angie origin, path (`angie/embedded`), `uiTheme`, `isRTL` |
 | `callbacks` | `onClose`, `onToggle` (sidebar only), `getExternalHeaders`, `getWebsiteContext`, `getAnalyticsContext` (see [message ownership](#message-ownership)) |
 | `widgetConfig` | Embedded UI copy, feature toggles, MCP focus, close behavior — see [widgetConfig guide](./widget-config.md) |
@@ -226,7 +226,7 @@ Providers may be async. A throw becomes an error reply.
 ### Host-owned container and styling
 
 - `container.create: false` — wait for a host-rendered element with that id (both layouts).
-- `container.injectDefaultCss: false` — skip the SDK sidebar stylesheet (sidebar layout). Replaces V1 `skipDefaultCss`.
+- `container.skipDefaultCss: true` — skip the SDK sidebar stylesheet (sidebar layout). Same meaning as V1 `skipDefaultCss`.
 - `callbacks.onToggle(isOpen)` — every open/close (sidebar layout). Floating chat still uses `onClose`.
 
 ## Module map

--- a/src/load-sidebar-v2/boot-sidebar.integration.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.integration.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { bootSidebar } from './boot-sidebar';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
-import { CHAT_WIDGET_HIDDEN_CLASS } from './chat-toggle/constants';
+import { CHAT_WIDGET_CONTAINER_CLASS, CHAT_WIDGET_HIDDEN_CLASS } from './chat-toggle/constants';
 import { resetHostApiBridgeForTests } from './host-api-bridge';
 import { resetHostMessageRouterForTests } from './host-message-router';
 import { resetChatShellForTests } from './chat-toggle/chat-shell';
@@ -68,6 +68,35 @@ describe( 'load-sidebar-v2/boot-sidebar integration', () => {
 		expect( drawers ).toHaveLength( 1 );
 		expect( ( drawers[ 0 ] as HTMLElement ).dataset.owner ).toBe( 'host' );
 		expect( drawers[ 0 ].querySelector( 'iframe' ) ).not.toBeNull();
+	} );
+
+	it( 'should mount floating chat into a host container that only appears after boot', async () => {
+		setTimeout( () => {
+			const hostChat = document.createElement( 'div' );
+			hostChat.id = 'host-chat';
+			hostChat.dataset.owner = 'host';
+			document.body.appendChild( hostChat );
+		}, 150 );
+
+		await bootSidebar( {
+			container: {
+				id: 'host-chat',
+				layout: LAYOUT_FLOATING_CHAT,
+				create: false,
+				chatToggleButton: { enabled: false, selector: '#host-chat-toggle' },
+			},
+			host: { appId: 'app-host-chat', instanceId: 'host-chat' },
+		} );
+
+		const chats = document.querySelectorAll( '#host-chat' );
+		const hostEl = chats[ 0 ] as HTMLElement;
+
+		expect( chats ).toHaveLength( 1 );
+		expect( hostEl.dataset.owner ).toBe( 'host' );
+		expect( hostEl.querySelector( 'iframe' ) ).not.toBeNull();
+		expect( hostEl.classList.contains( CHAT_WIDGET_CONTAINER_CLASS ) ).toBe( true );
+		expect( hostEl.classList.contains( CHAT_WIDGET_HIDDEN_CLASS ) ).toBe( true );
+		expect( hostEl.getAttribute( 'role' ) ).toBe( 'complementary' );
 	} );
 
 	it( 'should run a sidebar and a floating chat side by side', async () => {

--- a/src/load-sidebar-v2/boot-sidebar.integration.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.integration.test.ts
@@ -50,6 +50,26 @@ describe( 'load-sidebar-v2/boot-sidebar integration', () => {
 		);
 	} );
 
+	it( 'should mount into a host container that only appears after boot', async () => {
+		setTimeout( () => {
+			const hostDrawer = document.createElement( 'div' );
+			hostDrawer.id = 'host-drawer';
+			hostDrawer.dataset.owner = 'host';
+			document.body.appendChild( hostDrawer );
+		}, 150 );
+
+		await bootSidebar( {
+			container: { id: 'host-drawer', layout: LAYOUT_SIDEBAR, create: false },
+			host: { appId: 'app-my-elementor', instanceId: 'my-elementor' },
+		} );
+
+		const drawers = document.querySelectorAll( '#host-drawer' );
+
+		expect( drawers ).toHaveLength( 1 );
+		expect( ( drawers[ 0 ] as HTMLElement ).dataset.owner ).toBe( 'host' );
+		expect( drawers[ 0 ].querySelector( 'iframe' ) ).not.toBeNull();
+	} );
+
 	it( 'should run a sidebar and a floating chat side by side', async () => {
 		await bootSidebar( {
 			container: { layout: LAYOUT_SIDEBAR },

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -96,6 +96,17 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockOpenEmbeddedIframe ).toHaveBeenCalled();
 	} );
 
+	it( 'should not create a floating-chat container when create is false', async () => {
+		await bootSidebar( {
+			container: { id: 'host-chat', layout: LAYOUT_FLOATING_CHAT, create: false },
+			host: { appId: 'my-elementor' },
+		} );
+
+		expect( document.getElementById( 'host-chat' ) ).toBeNull();
+		expect( mockOpenEmbeddedIframe ).toHaveBeenCalled();
+		expect( mockInitAngieSidebar ).not.toHaveBeenCalled();
+	} );
+
 	it( 'should boot floating-chat without sidebar shell', async () => {
 		await bootSidebar( {
 			container: {

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -86,6 +86,16 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'should not create the container when create is false', async () => {
+		await bootSidebar( {
+			container: { id: 'host-drawer', layout: LAYOUT_SIDEBAR, create: false },
+			host: { appId: 'my-elementor' },
+		} );
+
+		expect( document.getElementById( 'host-drawer' ) ).toBeNull();
+		expect( mockOpenEmbeddedIframe ).toHaveBeenCalled();
+	} );
+
 	it( 'should boot floating-chat without sidebar shell', async () => {
 		await bootSidebar( {
 			container: {

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -83,7 +83,10 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 		instance,
 	} );
 
-	ensureSidebarContainer( config.container.id, env.isRTL );
+	// `create: false`: host owns the element; openIframe waits for it.
+	if ( config.container.create ) {
+		ensureSidebarContainer( config.container.id, env.isRTL );
+	}
 
 	const strategy = LAYOUT_STRATEGIES[ config.container.layout ];
 	const bootContext = { config, env, instance };

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -30,7 +30,7 @@ export type ContainerConfig = {
 	styleTheme: LoadSidebarV2ContainerStyleTheme;
 	/** `false`: wait for a host-rendered element with this id. */
 	create: boolean;
-	injectDefaultCss: boolean;
+	skipDefaultCss: boolean;
 	persistOpenState: boolean;
 	resizable: boolean;
 	chatToggleButton: {

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -28,6 +28,9 @@ export type ContainerConfig = {
 	id: string;
 	layout: LoadSidebarV2Layout;
 	styleTheme: LoadSidebarV2ContainerStyleTheme;
+	/** `false`: wait for a host-rendered element with this id. */
+	create: boolean;
+	injectDefaultCss: boolean;
 	persistOpenState: boolean;
 	resizable: boolean;
 	chatToggleButton: {
@@ -58,6 +61,8 @@ export type HostContextProvider = () =>
 
 export type CallbacksConfig = {
 	onClose?: () => void;
+	/** Sidebar only. Floating chat uses `onClose`. */
+	onToggle?: ( isOpen: boolean ) => void;
 	getExternalHeaders?: ExternalHeadersCallback;
 	getWebsiteContext?: HostContextProvider;
 	getAnalyticsContext?: HostContextProvider;

--- a/src/load-sidebar-v2/defaults.ts
+++ b/src/load-sidebar-v2/defaults.ts
@@ -14,6 +14,8 @@ export const DEFAULTS = {
 	container: {
 		layout: SIDEBAR_PRESET_DEFAULTS.layout,
 		styleTheme: SIDEBAR_PRESET_DEFAULTS.styleTheme,
+		create: SIDEBAR_PRESET_DEFAULTS.create,
+		injectDefaultCss: SIDEBAR_PRESET_DEFAULTS.injectDefaultCss,
 		persistOpenState: SIDEBAR_PRESET_DEFAULTS.persistOpenState,
 		resizable: SIDEBAR_PRESET_DEFAULTS.resizable,
 		chatToggleButtonSelector: DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR,

--- a/src/load-sidebar-v2/defaults.ts
+++ b/src/load-sidebar-v2/defaults.ts
@@ -15,7 +15,7 @@ export const DEFAULTS = {
 		layout: SIDEBAR_PRESET_DEFAULTS.layout,
 		styleTheme: SIDEBAR_PRESET_DEFAULTS.styleTheme,
 		create: SIDEBAR_PRESET_DEFAULTS.create,
-		injectDefaultCss: SIDEBAR_PRESET_DEFAULTS.injectDefaultCss,
+		skipDefaultCss: SIDEBAR_PRESET_DEFAULTS.skipDefaultCss,
 		persistOpenState: SIDEBAR_PRESET_DEFAULTS.persistOpenState,
 		resizable: SIDEBAR_PRESET_DEFAULTS.resizable,
 		chatToggleButtonSelector: DEFAULT_CHAT_TOGGLE_BUTTON_SELECTOR,

--- a/src/load-sidebar-v2/layouts/index.ts
+++ b/src/load-sidebar-v2/layouts/index.ts
@@ -1,4 +1,5 @@
 import { initFloatingChatLayout } from '../chat-toggle/init-floating-chat-layout';
+import { prepareChatWidgetContainer } from '../chat-toggle/widget-ui';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR, type LoadSidebarV2Layout, type ResolvedConfigV2 } from '../config';
 import type { AppState } from '../../config';
 import type { Env } from '../env';
@@ -44,6 +45,10 @@ const floatingChatStrategy: LayoutStrategy = {
 			injectToggleButton: chatToggleButton.enabled,
 			instance,
 		} );
+	},
+	// `create: false`: host node may appear only after openIframe waits.
+	afterOpenIframe: ( { config } ) => {
+		prepareChatWidgetContainer( config.container.id );
 	},
 };
 

--- a/src/load-sidebar-v2/open-embedded-iframe.test.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.test.ts
@@ -36,6 +36,8 @@ describe( 'load-sidebar-v2/open-embedded-iframe', () => {
 				id: 'angie-sidebar-container',
 				layout: 'sidebar',
 				styleTheme: 'wordpress',
+				create: true,
+				injectDefaultCss: true,
 				persistOpenState: true,
 				resizable: true,
 				chatToggleButton: {

--- a/src/load-sidebar-v2/open-embedded-iframe.test.ts
+++ b/src/load-sidebar-v2/open-embedded-iframe.test.ts
@@ -37,7 +37,7 @@ describe( 'load-sidebar-v2/open-embedded-iframe', () => {
 				layout: 'sidebar',
 				styleTheme: 'wordpress',
 				create: true,
-				injectDefaultCss: true,
+				skipDefaultCss: false,
 				persistOpenState: true,
 				resizable: true,
 				chatToggleButton: {

--- a/src/load-sidebar-v2/presets/floating-chat.ts
+++ b/src/load-sidebar-v2/presets/floating-chat.ts
@@ -3,6 +3,8 @@ import { LAYOUT_FLOATING_CHAT } from '../config';
 export const FLOATING_CHAT_PRESET_DEFAULTS = {
 	layout: LAYOUT_FLOATING_CHAT,
 	styleTheme: '' as const,
+	create: true,
+	injectDefaultCss: true,
 	persistOpenState: false,
 	resizable: false,
 	chatToggleButtonEnabled: true,

--- a/src/load-sidebar-v2/presets/floating-chat.ts
+++ b/src/load-sidebar-v2/presets/floating-chat.ts
@@ -4,7 +4,7 @@ export const FLOATING_CHAT_PRESET_DEFAULTS = {
 	layout: LAYOUT_FLOATING_CHAT,
 	styleTheme: '' as const,
 	create: true,
-	injectDefaultCss: true,
+	skipDefaultCss: false,
 	persistOpenState: false,
 	resizable: false,
 	chatToggleButtonEnabled: true,

--- a/src/load-sidebar-v2/presets/sidebar.ts
+++ b/src/load-sidebar-v2/presets/sidebar.ts
@@ -4,7 +4,7 @@ export const SIDEBAR_PRESET_DEFAULTS = {
 	layout: LAYOUT_SIDEBAR,
 	styleTheme: '' as const,
 	create: true,
-	injectDefaultCss: true,
+	skipDefaultCss: false,
 	persistOpenState: true,
 	resizable: true,
 	chatToggleButtonEnabled: false,

--- a/src/load-sidebar-v2/presets/sidebar.ts
+++ b/src/load-sidebar-v2/presets/sidebar.ts
@@ -3,6 +3,8 @@ import { LAYOUT_SIDEBAR } from '../config';
 export const SIDEBAR_PRESET_DEFAULTS = {
 	layout: LAYOUT_SIDEBAR,
 	styleTheme: '' as const,
+	create: true,
+	injectDefaultCss: true,
 	persistOpenState: true,
 	resizable: true,
 	chatToggleButtonEnabled: false,

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -17,20 +17,34 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		expect( config.container.styleTheme ).toBe( '' );
 		expect( config.container.persistOpenState ).toBe( true );
 		expect( config.container.chatToggleButton.enabled ).toBe( false );
+		expect( config.container.create ).toBe( true );
+		expect( config.container.injectDefaultCss ).toBe( true );
 		expect( config.widgetConfig ).toEqual( { closeButton: 'collapse' } );
+	} );
+
+	it( 'should let the host own the container element and its styling', () => {
+		const config = resolveConfig( {
+			container: { create: false, injectDefaultCss: false },
+			host: { appId: 'my-elementor' },
+		}, DEFAULT_ENV );
+
+		expect( config.container.create ).toBe( false );
+		expect( config.container.injectDefaultCss ).toBe( false );
 	} );
 
 	it( 'should carry context providers through to the resolved callbacks', () => {
 		const getWebsiteContext = jest.fn( () => ( { appId: 'wordpress' } ) );
 		const getAnalyticsContext = jest.fn( () => ( { siteKey: 'abc' } ) );
+		const onToggle = jest.fn();
 
 		const config = resolveConfig( {
-			callbacks: { getAnalyticsContext, getWebsiteContext },
+			callbacks: { getAnalyticsContext, getWebsiteContext, onToggle },
 			host: { appId: 'wordpress' },
 		}, DEFAULT_ENV );
 
 		expect( config.callbacks.getWebsiteContext ).toBe( getWebsiteContext );
 		expect( config.callbacks.getAnalyticsContext ).toBe( getAnalyticsContext );
+		expect( config.callbacks.onToggle ).toBe( onToggle );
 	} );
 
 	it( 'should resolve floating-chat defaults', () => {

--- a/src/load-sidebar-v2/resolve-config.test.ts
+++ b/src/load-sidebar-v2/resolve-config.test.ts
@@ -18,18 +18,18 @@ describe( 'load-sidebar-v2/resolve-config', () => {
 		expect( config.container.persistOpenState ).toBe( true );
 		expect( config.container.chatToggleButton.enabled ).toBe( false );
 		expect( config.container.create ).toBe( true );
-		expect( config.container.injectDefaultCss ).toBe( true );
+		expect( config.container.skipDefaultCss ).toBe( false );
 		expect( config.widgetConfig ).toEqual( { closeButton: 'collapse' } );
 	} );
 
 	it( 'should let the host own the container element and its styling', () => {
 		const config = resolveConfig( {
-			container: { create: false, injectDefaultCss: false },
+			container: { create: false, skipDefaultCss: true },
 			host: { appId: 'my-elementor' },
 		}, DEFAULT_ENV );
 
 		expect( config.container.create ).toBe( false );
-		expect( config.container.injectDefaultCss ).toBe( false );
+		expect( config.container.skipDefaultCss ).toBe( true );
 	} );
 
 	it( 'should carry context providers through to the resolved callbacks', () => {

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -47,6 +47,8 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 			id: container.id?.trim() || DEFAULT_CONTAINER_ID,
 			layout,
 			styleTheme: container.styleTheme ?? layoutDefaults.styleTheme,
+			create: container.create ?? layoutDefaults.create,
+			injectDefaultCss: container.injectDefaultCss ?? layoutDefaults.injectDefaultCss,
 			persistOpenState: container.persistOpenState ?? layoutDefaults.persistOpenState,
 			resizable: container.resizable ?? layoutDefaults.resizable,
 			chatToggleButton: {
@@ -62,6 +64,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 		},
 		callbacks: {
 			onClose: callbacks.onClose,
+			onToggle: callbacks.onToggle,
 			getExternalHeaders: callbacks.getExternalHeaders,
 			getWebsiteContext: callbacks.getWebsiteContext,
 			getAnalyticsContext: callbacks.getAnalyticsContext,

--- a/src/load-sidebar-v2/resolve-config.ts
+++ b/src/load-sidebar-v2/resolve-config.ts
@@ -48,7 +48,7 @@ export const resolveConfig = ( options: LoadSidebarV2Options, env: Env ): Resolv
 			layout,
 			styleTheme: container.styleTheme ?? layoutDefaults.styleTheme,
 			create: container.create ?? layoutDefaults.create,
-			injectDefaultCss: container.injectDefaultCss ?? layoutDefaults.injectDefaultCss,
+			skipDefaultCss: container.skipDefaultCss ?? layoutDefaults.skipDefaultCss,
 			persistOpenState: container.persistOpenState ?? layoutDefaults.persistOpenState,
 			resizable: container.resizable ?? layoutDefaults.resizable,
 			chatToggleButton: {

--- a/src/load-sidebar-v2/shell.test.ts
+++ b/src/load-sidebar-v2/shell.test.ts
@@ -16,6 +16,8 @@ const baseContainer = {
 	id: 'angie-sidebar-container',
 	layout: 'sidebar' as const,
 	styleTheme: '' as const,
+	create: true,
+	injectDefaultCss: true,
 	persistOpenState: false,
 	resizable: false,
 	chatToggleButton: { enabled: false, selector: '#angie-widget-toggle' },
@@ -69,5 +71,31 @@ describe( 'load-sidebar-v2/shell', () => {
 		expect( initAngieSidebar ).toHaveBeenCalledWith(
 			expect.not.objectContaining( { skipDefaultCss: true } ),
 		);
+	} );
+
+	it( 'should skip the default sidebar CSS when injectDefaultCss is false', () => {
+		initSidebarShell(
+			{ ...baseContainer, injectDefaultCss: false },
+			{ onClose: jest.fn() },
+		);
+
+		expect( initAngieSidebar ).toHaveBeenCalledWith(
+			expect.objectContaining( { skipDefaultCss: true } ),
+		);
+	} );
+
+	it( 'should forward every toggle to callbacks.onToggle', () => {
+		const onToggle = jest.fn();
+
+		initSidebarShell( baseContainer, { onToggle } );
+
+		const options = ( initAngieSidebar as jest.Mock ).mock.calls[ 0 ][ 0 ] as {
+			onToggle: ( isOpen: boolean ) => void;
+		};
+		options.onToggle( true );
+		options.onToggle( false );
+
+		expect( onToggle ).toHaveBeenNthCalledWith( 1, true );
+		expect( onToggle ).toHaveBeenNthCalledWith( 2, false );
 	} );
 } );

--- a/src/load-sidebar-v2/shell.test.ts
+++ b/src/load-sidebar-v2/shell.test.ts
@@ -17,7 +17,7 @@ const baseContainer = {
 	layout: 'sidebar' as const,
 	styleTheme: '' as const,
 	create: true,
-	injectDefaultCss: true,
+	skipDefaultCss: false,
 	persistOpenState: false,
 	resizable: false,
 	chatToggleButton: { enabled: false, selector: '#angie-widget-toggle' },
@@ -73,9 +73,9 @@ describe( 'load-sidebar-v2/shell', () => {
 		);
 	} );
 
-	it( 'should skip the default sidebar CSS when injectDefaultCss is false', () => {
+	it( 'should skip the default sidebar CSS when skipDefaultCss is true', () => {
 		initSidebarShell(
-			{ ...baseContainer, injectDefaultCss: false },
+			{ ...baseContainer, skipDefaultCss: true },
 			{ onClose: jest.fn() },
 		);
 

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -26,7 +26,7 @@ export const initSidebarShell = (
 
 	initAngieSidebar( {
 		instance,
-		skipDefaultCss: ! container.injectDefaultCss,
+		skipDefaultCss: container.skipDefaultCss,
 		onToggle: ( isOpen ) => {
 			if ( toggleButtonSelector ) {
 				syncToggleButton( toggleButtonSelector, isOpen );

--- a/src/load-sidebar-v2/shell.ts
+++ b/src/load-sidebar-v2/shell.ts
@@ -26,10 +26,13 @@ export const initSidebarShell = (
 
 	initAngieSidebar( {
 		instance,
+		skipDefaultCss: ! container.injectDefaultCss,
 		onToggle: ( isOpen ) => {
 			if ( toggleButtonSelector ) {
 				syncToggleButton( toggleButtonSelector, isOpen );
 			}
+
+			callbacks.onToggle?.( isOpen );
 
 			if ( ! isOpen && callbacks.onClose ) {
 				callbacks.onClose();


### PR DESCRIPTION
## Why
Hosts that already render a drawer (and their own CSS) still got an SDK-created container and default stylesheet. They also had no hook for every open/close—only `onClose`. That made it hard to keep host chrome in sync with the sidebar.

## What
- `container.create: false` — wait for a host element with that id (iframe open already waits)
- `container.injectDefaultCss: false` — skip the SDK sidebar stylesheet (replaces V1 `skipDefaultCss`)
- `callbacks.onToggle(isOpen)` — sidebar only; floating chat still uses `onClose`
- Bump SDK to 1.8.0 (`package.json` + `package-lock.json`)

Stacked on the host-context PR. Retarget `master` after that PR merges.

## Test plan
- [ ] `create: false`: host element appears after boot; iframe mounts into it; no duplicate id
- [ ] `injectDefaultCss: false` passes `skipDefaultCss` into the sidebar shell
- [ ] `onToggle` fires for open and close

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Host apps now control sidebar/chat container lifecycle (create vs. wait), styling (skipDefaultCss), and receive toggle events. Shifts container ownership from SDK to host for integration flexibility.

## 2. What Changed (Where)

- **boot-sidebar.ts**: Conditionally skip `ensureSidebarContainer()` when `create: false`; host provides pre-rendered element
- **config.ts, defaults.ts, presets**: Added `create` and `skipDefaultCss` flags; added `onToggle` callback
- **layouts/index.ts**: New `afterOpenIframe` hook in floating-chat strategy calls `prepareChatWidgetContainer()`
- **shell.ts**: Pass `skipDefaultCss` to `initAngieSidebar()`, forward all toggles to `onToggle` callback
- **Tests**: New integration tests verify host-owned containers appear after boot; unit tests cover config resolution and callback wiring
- **README, package.json**: Documented new behavior, bumped to v1.7.2

## 3. How It Works

Boot flow: config resolution → conditional container creation → bridge init → layout strategy (which may defer container setup for floating-chat). When `create: false`, SDK waits for host to append element with matching ID before `openIframe()` proceeds. Floating chat additionally applies widget classes/attributes in `afterOpenIframe` hook, supporting containers that appear mid-boot.

## 4. Risks

**Container not provided**: If host sets `create: false` but never renders the element, iframe mount hangs silently. Mitigation: timeout or console warnings. **CSS not injected**: Hosts opting into `skipDefaultCss` are fully responsible for styling—potential UX regression if forgotten. Mitigation: clear docs/warnings.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
