### PR TITLE
[AI-9384] Improve: Trigger demo cannot send or isolate context attachment

### DIFF
--- a/demo/trigger-angie-prompt/ajv-formats-shim.js
+++ b/demo/trigger-angie-prompt/ajv-formats-shim.js
@@ -1,0 +1,1 @@
+export default function addFormats() {}

--- a/demo/trigger-angie-prompt/ajv-shim.js
+++ b/demo/trigger-angie-prompt/ajv-shim.js
@@ -1,0 +1,15 @@
+export default class Ajv {
+	compile() {
+		const validate = () => true;
+		validate.errors = null;
+		return validate;
+	}
+
+	getSchema() {
+		return undefined;
+	}
+
+	errorsText() {
+		return '';
+	}
+}

--- a/demo/trigger-angie-prompt/host.js
+++ b/demo/trigger-angie-prompt/host.js
@@ -1,9 +1,42 @@
 import { AngieMcpSdk, LAYOUT_SIDEBAR } from '../../dist/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
 const DEFAULT_PROMPT = 'Help me improve the headline on this page for conversions.';
+const PAGE_SERVER_NAME = 'demo-page-heading';
 const CONTEXT_ATTACHMENT = {
 	label: 'Selected heading',
 	content: 'Element type: heading (h1). Current text: "Get started today". Section: pricing hero. Goal: more trial sign-ups.',
+};
+
+const createPageHeadingServer = () => {
+	const server = new McpServer(
+		{
+			name: PAGE_SERVER_NAME,
+			version: '1.0.0',
+			title: 'Page heading',
+		},
+		{
+			capabilities: {
+				tools: {},
+			},
+			instructions: 'Use get-selected-heading to read the heading the user is editing.',
+		}
+	);
+
+	server.registerTool(
+		'get-selected-heading',
+		{
+			description: 'Read the selected heading on this demo page: element type, current text, section, and goal.',
+			annotations: {
+				readOnlyHint: true,
+			},
+		},
+		async () => ( {
+			content: [ { type: 'text', text: CONTEXT_ATTACHMENT.content } ],
+		} )
+	);
+
+	return server;
 };
 
 const sdk = new AngieMcpSdk();
@@ -127,6 +160,7 @@ sdk.loadSidebarV2( {
 	widgetConfig: {
 		title: 'Angie',
 		subtitle: 'Prompt trigger demo',
+		featuredMcpServer: PAGE_SERVER_NAME,
 		localServers: { skipLoading: true },
 		suggestions: {
 			items: [
@@ -141,8 +175,18 @@ sdk.loadSidebarV2( {
 			],
 		},
 	},
-} ).then( () => {
-	setStatus( 'Angie sidebar loaded. Use the controls or hash links below.' );
-} ).catch( ( error ) => {
-	setStatus( error instanceof Error ? error.message : 'Failed to load Angie', 'error' );
-} );
+} ).then( () => sdk.waitForReady() )
+	.then( () => sdk.registerServer( {
+		name: PAGE_SERVER_NAME,
+		version: '1.0.0',
+		description: 'Selected heading on this demo page',
+		server: createPageHeadingServer(),
+		capabilities: {
+			tools: {},
+		},
+	} ) )
+	.then( () => {
+		setStatus( 'Angie sidebar loaded. Use the controls or hash links below.' );
+	} ).catch( ( error ) => {
+		setStatus( error instanceof Error ? error.message : 'Failed to load Angie', 'error' );
+	} );

--- a/demo/trigger-angie-prompt/host.js
+++ b/demo/trigger-angie-prompt/host.js
@@ -2,8 +2,8 @@ import { AngieMcpSdk, LAYOUT_SIDEBAR } from '../../dist/index.js';
 
 const DEFAULT_PROMPT = 'Help me improve the headline on this page for conversions.';
 const CONTEXT_ATTACHMENT = {
-	label: 'Current page headline',
-	content: 'Build faster with Angie',
+	label: 'Selected heading',
+	content: 'Element type: heading (h1). Current text: "Get started today". Section: pricing hero. Goal: more trial sign-ups.',
 };
 
 const sdk = new AngieMcpSdk();
@@ -36,7 +36,6 @@ const triggerWithPrompt = async ( { newChat = false, prompt = getPrompt() } = {}
 
 		const response = await sdk.triggerAngie( {
 			prompt,
-			contextAttachment: CONTEXT_ATTACHMENT,
 			options: {
 				newChat,
 				timeout: 30000,
@@ -54,12 +53,45 @@ const triggerWithPrompt = async ( { newChat = false, prompt = getPrompt() } = {}
 	}
 };
 
+const triggerWithContextAttachment = async () => {
+	try {
+		setStatus( 'Waiting for Angie…' );
+		await sdk.waitForReady();
+
+		const prompt = getPrompt();
+		const response = await sdk.triggerAngie( {
+			prompt,
+			contextAttachment: CONTEXT_ATTACHMENT,
+			options: {
+				newChat: true,
+				timeout: 30000,
+			},
+		} );
+
+		if ( response.success ) {
+			setStatus(
+				`Prompt and context attachment sent. Prompt: "${ prompt }". Label: "${ CONTEXT_ATTACHMENT.label }". Content: "${ CONTEXT_ATTACHMENT.content }". Request ID: ${ response.requestId }`,
+				'success'
+			);
+			return;
+		}
+
+		setStatus( response.error || 'Context attachment trigger failed.', 'error' );
+	} catch ( error ) {
+		setStatus( error instanceof Error ? error.message : 'Unknown error', 'error' );
+	}
+};
+
 document.getElementById( 'demo-trigger-fill' )?.addEventListener( 'click', () => {
 	void triggerWithPrompt();
 } );
 
 document.getElementById( 'demo-trigger-new-chat' )?.addEventListener( 'click', () => {
 	void triggerWithPrompt( { newChat: true } );
+} );
+
+document.getElementById( 'demo-trigger-context-attachment' )?.addEventListener( 'click', () => {
+	void triggerWithContextAttachment();
 } );
 
 document.querySelectorAll( '[data-prompt-chip]' ).forEach( ( chip ) => {
@@ -95,6 +127,7 @@ sdk.loadSidebarV2( {
 	widgetConfig: {
 		title: 'Angie',
 		subtitle: 'Prompt trigger demo',
+		localServers: { skipLoading: true },
 		suggestions: {
 			items: [
 				{

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -71,6 +71,9 @@
             <button type="button" class="demo-btn demo-btn-secondary" id="demo-trigger-new-chat">
               New chat + prompt
             </button>
+            <button type="button" class="demo-btn demo-btn-secondary" id="demo-trigger-context-attachment">
+              Prompt + hidden context
+            </button>
           </div>
 
           <pre class="demo-code-block" aria-hidden="true">await sdk.waitForReady();

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -8,8 +8,15 @@
   <script type="importmap">
   {
     "imports": {
+      "@modelcontextprotocol/sdk/server/mcp.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js",
       "@modelcontextprotocol/sdk/types.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
-      "zod/v4": "../../node_modules/zod/v4/index.js"
+      "zod": "../../node_modules/zod/index.js",
+      "zod/v3": "../../node_modules/zod/v3/index.js",
+      "zod/v4": "../../node_modules/zod/v4/index.js",
+      "zod/v4-mini": "../../node_modules/zod/v4-mini/index.js",
+      "zod-to-json-schema": "../../node_modules/zod-to-json-schema/dist/esm/index.js",
+      "ajv": "./ajv-shim.js",
+      "ajv-formats": "./ajv-formats-shim.js"
     }
   }
   </script>

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -79,7 +79,7 @@
               New chat + prompt
             </button>
             <button type="button" class="demo-btn demo-btn-secondary" id="demo-trigger-context-attachment">
-              Prompt + context
+              Prompt + context attachment
             </button>
           </div>
 

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -79,7 +79,7 @@
               New chat + prompt
             </button>
             <button type="button" class="demo-btn demo-btn-secondary" id="demo-trigger-context-attachment">
-              Prompt + hidden context
+              Prompt + context
             </button>
           </div>
 


### PR DESCRIPTION
## Problem
The trigger demo always sent a context attachment with every prompt, so you could not try a prompt-only path vs a context-attachment path. Send also stayed disabled because the production iframe waits for a host context server this demo never provides.

## Solution
Skip loading host local servers, register a small demo page-heading server so Send works, and add a dedicated **Prompt + context attachment** action. Regular prompt buttons send the prompt only.

<img width="1172" height="726" alt="image" src="https://github.com/user-attachments/assets/76dd869b-d8d7-419c-8627-0ad4a8fe2b52" />
<img width="1000" height="565" alt="image" src="https://github.com/user-attachments/assets/0918383f-c281-45e2-952c-be16a90fe915" />

## Jira Link
https://elementor.atlassian.net/browse/AI-9384
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Demo was conflating prompt-only and context-attachment flows; needed separate code paths and MCP server registration to isolate concerns and enable selective context sharing.

## 2. What Changed (Where)

- `host.js`: Extracted `createPageHeadingServer()`, added `triggerWithContextAttachment()` handler, wired MCP server registration post-sidebar init
- `index.html`: Expanded importmap (zod, ajv shims, MCP server module), added context attachment button
- New shimmed modules: `ajv-shim.js` and `ajv-formats-shim.js` for dependency resolution

## 3. How It Works

On SDK ready → register MCP server with `get-selected-heading` tool → trigger button dispatches to appropriate flow. Prompt-only skips context; context-attachment flow passes `CONTEXT_ATTACHMENT` object. Server exposes tool to SDK via `registerServer()` call after sidebar load.

## 4. Risks

MCP server registration happens async post-sidebar; button clicks before registration could fail silently if timing races. Mitigation: `waitForReady()` chains ensure server is live before accepting clicks. Shim approach works but masks missing ajv/zod—consider explicit peer dependency warnings if demo fails to load.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
