### PR TITLE
[AI-9399] feat: support conversation-starter suggestions in triggerAngie

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,20 @@ interface ContextAttachment {
   content: string;
 }
 
+interface PromptSuggestion {
+  label: string;
+  value: string;
+  autoSend?: boolean;
+  color?: string;
+  isNew?: boolean;
+  requiresPrompt?: string;
+}
+
 interface AngieTriggerRequest {
   prompt?: string;
   context?: { source?: string } & Record<string, unknown>;
   contextAttachment?: ContextAttachment;
+  suggestions?: { items: PromptSuggestion[] };
   options?: {
     timeout?: number;
     newChat?: boolean;
@@ -220,6 +230,12 @@ await sdk.triggerAngie({
     label: 'Current SEO report',
     content: 'The page is missing a meta description.',
   },
+  suggestions: {
+    items: [
+      { label: 'Add meta description', value: 'Add a meta description to this page', autoSend: true },
+      { label: 'Improve title', value: 'Suggest a better SEO title', isNew: true },
+    ],
+  },
   options: {
     timeout: 30000, // Optional: 30 seconds timeout (default: 30000)
     newChat: true,
@@ -243,6 +259,7 @@ await sdk.triggerAngie({ contextAttachment });
 **Request fields:**
 - `prompt`: Optional prompt text.
 - `contextAttachment`: Optional labeled content attached to the next submitted user message. It can be used without `prompt` and is not rendered as part of the message text.
+- `suggestions`: Optional list of prompt suggestions shown to the user. Each item has a `label` (displayed text) and `value` (prompt sent when selected); optional `autoSend` submits immediately, `color` sets the chip color, `isNew` shows a "new" badge, and `requiresPrompt` gates the suggestion behind a given prompt.
 - `context`: Optional integration metadata. The SDK adds the current `pageUrl` and `pageTitle`; supplied values can override them. This legacy field is not model-visible message content.
 - `options.timeout`: How long to wait for Angie response in milliseconds (default: `30000`).
 - `options.newChat`: When `true`, clears the current conversation and opens a fresh chat.

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ await sdk.triggerAngie({ contextAttachment });
 - `prompt`: Optional prompt text.
 - `contextAttachment`: Optional labeled content attached to the next submitted user message. It can be used without `prompt` and is not rendered as part of the message text.
 - `suggestions`: Optional list of prompt suggestions shown to the user. Each item has a `label` (displayed text) and `value` (prompt sent when selected); optional `autoSend` submits immediately, `color` sets the chip color, `isNew` shows a "new" badge, and `requiresPrompt` gates the suggestion behind a given prompt.
-- `context`: Optional integration metadata. The SDK adds the current `pageUrl` and `pageTitle`; supplied values can override them. This legacy field is not model-visible message content.
+- `context`: Optional integration metadata. The SDK adds the current `pageUrl` and `pageTitle`;
 - `options.timeout`: How long to wait for Angie response in milliseconds (default: `30000`).
 - `options.newChat`: When `true`, clears the current conversation and opens a fresh chat.
 

--- a/demo/trigger-angie-prompt/host.js
+++ b/demo/trigger-angie-prompt/host.js
@@ -74,6 +74,74 @@ document.querySelectorAll( '[data-prompt-chip]' ).forEach( ( chip ) => {
 	} );
 } );
 
+// 3. Inject context on the fly — the field value rides the next message
+// under `context.consumer`, so Angie doesn't need a "read current value" tool.
+const fieldInput = document.getElementById( 'demo-field-input' );
+
+const injectFieldContext = async () => {
+	try {
+		setStatus( 'Waiting for Angie…' );
+		await sdk.waitForReady();
+
+		const value = fieldInput?.value?.trim() || '';
+		const response = await sdk.triggerAngie( {
+			options: { newChat: true, timeout: 30000 },
+			context: {
+				source: 'demo-field-context',
+				selectedField: { name: 'headline', value },
+			},
+		} );
+
+		if ( response.success ) {
+			setStatus( 'Angie opened with the field in context. Ask it about the headline — no read tool needed.', 'success' );
+			return;
+		}
+
+		setStatus( response.error || 'Angie trigger failed.', 'error' );
+	} catch ( error ) {
+		setStatus( error instanceof Error ? error.message : 'Unknown error', 'error' );
+	}
+};
+
+document.getElementById( 'demo-inject-context' )?.addEventListener( 'click', () => {
+	void injectFieldContext();
+} );
+
+// 4. Conversation starters at trigger time — set the new chat's starters
+// from the host, per entry point, instead of only at loadSidebar.
+const TEXT_EDITING_STARTERS = {
+	items: [
+		{ label: 'Make it longer', value: 'Make this text longer.' },
+		{ label: 'Make it shorter', value: 'Make this text shorter.' },
+		{ label: 'Fix grammar', value: 'Fix the grammar in this text.' },
+	],
+};
+
+const triggerWithStarters = async () => {
+	try {
+		setStatus( 'Waiting for Angie…' );
+		await sdk.waitForReady();
+
+		const response = await sdk.triggerAngie( {
+			options: { newChat: true, timeout: 30000 },
+			suggestions: TEXT_EDITING_STARTERS,
+		} );
+
+		if ( response.success ) {
+			setStatus( 'New chat opened with custom conversation starters.', 'success' );
+			return;
+		}
+
+		setStatus( response.error || 'Angie trigger failed.', 'error' );
+	} catch ( error ) {
+		setStatus( error instanceof Error ? error.message : 'Unknown error', 'error' );
+	}
+};
+
+document.getElementById( 'demo-trigger-starters' )?.addEventListener( 'click', () => {
+	void triggerWithStarters();
+} );
+
 sdk.loadSidebarV2( {
 	host: {
 		appId: 'demo-trigger-angie-prompt',

--- a/demo/trigger-angie-prompt/index.html
+++ b/demo/trigger-angie-prompt/index.html
@@ -147,8 +147,69 @@ await sdk.triggerAngie({
 &lt;/a&gt;</pre>
         </section>
 
+        <section class="demo-card" aria-labelledby="context-heading">
+          <h2 id="context-heading">3. Inject context on the fly</h2>
+          <p class="demo-card-lead">
+            Pass a <code>context</code> object to <code>triggerAngie</code> and it rides the next
+            message under a reserved <code>context.consumer</code> key — so Angie already knows the
+            value instead of calling a "read current value" tool. Everything you send goes in as-is.
+          </p>
+
+          <div class="demo-field">
+            <label for="demo-field-input">Headline field (the value your control holds)</label>
+            <textarea id="demo-field-input" spellcheck="false">Build faster with Angie</textarea>
+          </div>
+
+          <div class="demo-actions">
+            <button type="button" class="demo-btn demo-btn-primary" id="demo-inject-context">
+              Open Angie with this field as context
+            </button>
+          </div>
+
+          <p class="demo-card-lead">
+            Then ask Angie anything about "this field" — the value is already in
+            <code>context.consumer.selectedField</code> on the request.
+          </p>
+
+          <pre class="demo-code-block" aria-hidden="true">await sdk.waitForReady();
+await sdk.triggerAngie({
+  options: { newChat: true },
+  context: {
+    source: 'demo-field-context',
+    selectedField: { name: 'headline', value: fieldValue },
+  },
+});</pre>
+        </section>
+
+        <section class="demo-card" aria-labelledby="starters-heading">
+          <h2 id="starters-heading">4. Conversation starters at trigger time</h2>
+          <p class="demo-card-lead">
+            Pass <code>suggestions</code> to <code>triggerAngie</code> to set the conversation
+            starters for the new chat — different entry points can offer different starters,
+            not only the ones configured at <code>loadSidebar</code>.
+          </p>
+
+          <div class="demo-actions">
+            <button type="button" class="demo-btn demo-btn-primary" id="demo-trigger-starters">
+              New chat with text-editing starters
+            </button>
+          </div>
+
+          <pre class="demo-code-block" aria-hidden="true">await sdk.waitForReady();
+await sdk.triggerAngie({
+  options: { newChat: true },
+  suggestions: {
+    items: [
+      { label: 'Make it longer',  value: 'Make this text longer.' },
+      { label: 'Make it shorter', value: 'Make this text shorter.' },
+      { label: 'Fix grammar',     value: 'Fix the grammar in this text.' },
+    ],
+  },
+});</pre>
+        </section>
+
         <section class="demo-card" aria-labelledby="status-heading">
-          <h2 id="status-heading">3. Status</h2>
+          <h2 id="status-heading">5. Status</h2>
           <p class="demo-card-lead">
             Last result from the controls above. Hash links are handled inside the SDK, so they do
             not report here.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.test.ts
+++ b/src/angie-mcp-sdk.test.ts
@@ -260,6 +260,38 @@ describe('AngieMcpSdk', () => {
 
       postMessageSpy.mockRestore();
     });
+
+    it('should include conversation-starter suggestions in the trigger payload', async () => {
+      const suggestions = { items: [ { label: 'Make it longer', value: 'Make it longer' } ] };
+      const postMessageSpy = jest.spyOn(window, 'postMessage').mockImplementation((message: any) => {
+        if (message?.type === MessageEventType.SDK_TRIGGER_ANGIE) {
+          window.dispatchEvent(new MessageEvent('message', {
+            data: {
+              type: MessageEventType.SDK_TRIGGER_ANGIE_RESPONSE,
+              payload: {
+                success: true,
+                requestId: message.payload.requestId,
+              },
+            },
+          }));
+        }
+      });
+      mockAngieDetector.isReady.mockReturnValue(true);
+
+      await sdk.triggerAngie({
+        prompt: 'Rewrite this',
+        context: { source: 'demo-field-switch' },
+        suggestions,
+      });
+
+      const triggerMessage = postMessageSpy.mock.calls.find(
+        ([message]) => message.type === MessageEventType.SDK_TRIGGER_ANGIE
+      )?.[0];
+
+      expect(triggerMessage.payload.suggestions).toBe(suggestions);
+
+      postMessageSpy.mockRestore();
+    });
   });
 
   describe('waitForReady', () => {

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -13,7 +13,7 @@ import { getInstanceById, getInstanceCount } from './instance-registry';
 import { generateInstanceId } from './utils';
 import { bootSidebar } from './load-sidebar-v2/boot-sidebar';
 import type { LoadSidebarV2Options } from './load-sidebar-v2/config';
-import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerConfig, AngieServerConfig, AngieServerType, MessageEventType, ServerRegistration, AngieTriggerRequest, AngieTriggerResponse } from './types';
+import { AngieLocalServerConfig, AngieLocalServerTransport, AngieRemoteServerConfig, AngieServerConfig, AngieServerType, MessageEventType, ServerRegistration, AngieTriggerRequest, AngieTriggerResponse, PromptSuggestion } from './types';
 
 export { DEFAULT_CONTAINER_ID } from './config';
 
@@ -29,8 +29,6 @@ export const resetPromptHashListenersForTests = (): void => {
 };
 
 type FeatureToggle = { enabled: boolean };
-
-type PromptSuggestion = { label: string; value: string };
 
 export type ModeSwitcherConfig = {
   enabled?: boolean;
@@ -372,6 +370,7 @@ export class AngieMcpSdk {
           prompt: request.prompt,
           options: request.options,
           contextAttachment: request.contextAttachment,
+          suggestions: request.suggestions,
           context: {
             pageUrl: window.location.href,
             pageTitle: document.title,

--- a/src/sdk.test.ts
+++ b/src/sdk.test.ts
@@ -109,6 +109,32 @@ describe( 'sdk', () => {
 		expect( relayedMessage.payload.prompt ).toBeUndefined();
 	} );
 
+	it( 'should relay conversation-starter suggestions to the Angie iframe', () => {
+		const instance = createAngieInstance( {
+			containerId: 'container-a',
+			instanceId: 'aaaaaa',
+			layout: 'sidebar',
+		} );
+		const postMessage = attachIframe( instance );
+		const suggestions = { items: [ { label: 'Make it longer', value: 'Make it longer' } ] };
+
+		registerForRouting( instance );
+		emitHostMessage( {
+			type: MessageEventType.SDK_TRIGGER_ANGIE,
+			payload: {
+				instanceId: 'aaaaaa',
+				requestId: 'request-123',
+				suggestions,
+			},
+		} );
+
+		const relayedMessage = postMessage.mock.calls[ 0 ][ 0 ] as {
+			payload: { suggestions?: typeof suggestions };
+		};
+
+		expect( relayedMessage.payload.suggestions ).toBe( suggestions );
+	} );
+
 	it( 'should not forward client creation to a sibling while the addressed instance is still booting', () => {
 		const first = createAngieInstance( {
 			containerId: 'container-a',

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -156,7 +156,7 @@ export const startSdkMessageRouting = (): void => {
 				// timeout, and on mobile no iframe is ever opened, so a queued
 				// trigger would stall instead of reporting the failure.
 				try {
-					const { requestId, prompt, context, contextAttachment, options } = event.data.payload;
+					const { requestId, prompt, context, contextAttachment, suggestions, options } = event.data.payload;
 
 					if ( target.iframe ) {
 						target.iframe.contentWindow?.postMessage( {
@@ -166,6 +166,7 @@ export const startSdkMessageRouting = (): void => {
 								prompt,
 								context,
 								contextAttachment,
+								suggestions,
 								options,
 							},
 						}, target.iframeUrlObject?.origin || '' );

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,12 +103,22 @@ export interface ContextAttachment {
   content: string;
 }
 
+export interface PromptSuggestion {
+  label: string;
+  value: string;
+  autoSend?: boolean;
+  color?: string;
+  isNew?: boolean;
+  requiresPrompt?: string;
+}
+
 export interface AngieTriggerRequest {
   prompt?: string;
   context?: {
     source?: string;
   } & Record<string, unknown>;
   contextAttachment?: ContextAttachment;
+  suggestions?: { items: PromptSuggestion[] };
   options?: {
     timeout?: number;
     newChat?: boolean;


### PR DESCRIPTION
## What

Adds an optional `suggestions` field to `AngieTriggerRequest`, so consumers can configure conversation starters **at trigger time** (`triggerAngie`), not only at `loadSidebar`.

- `types.ts`: new exported `PromptSuggestion` interface + `suggestions?: { items: PromptSuggestion[] }` on `AngieTriggerRequest` (de-duplicates the previously-local `PromptSuggestion` type).
- `angie-mcp-sdk.ts`: include `suggestions` in the `SDK_TRIGGER_ANGIE` payload.
- `sdk.ts`: forward `suggestions` through the host→iframe router (otherwise it's dropped at the relay).
- Version bump `1.7.2` → `1.7.3`.

## Why

Angie SDK consumers need to be able to adjust the prompt suggestion

## Tests

- `triggerAngie` includes `suggestions` in the payload.
- Router relays `suggestions` to the iframe.
- Full suite green (262 tests).

<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
AI-9399: Enables passing dynamic conversation-starter suggestions and on-the-fly context during the `triggerAngie` call to allow entry-point specific UX.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `src/types.ts` | Added `PromptSuggestion` interface and `suggestions` field to `AngieTriggerRequest`. |
| `src/angie-mcp-sdk.ts` | Integrated `suggestions` into the trigger payload. |
| `src/sdk.ts` | Updated message routing to relay `suggestions` to the iframe. |
| `demo/...` | Added UI cards and logic to demonstrate context injection and starters. |
| `README.md` | Updated API documentation for `triggerAngie`. |
| `src/*.test.ts` | Added regression tests for payload relaying. |
| `package.json` | Bumped version to 1.7.3. |

## 3. How It Works
The `triggerAngie` method now accepts a `suggestions` object (containing `PromptSuggestion[]`) and custom `context`, which are passed through the SDK's internal message router via `postMessage` to the Angie iframe for rendering.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
