### PR TITLE
Add demo: CSS editing with an MCP App review card

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -124,6 +124,10 @@
         <strong>loadSidebarV2 — right click floating</strong>
         <span>Right-click a text area to rewrite it with a host MCP server.</span>
       </a>
+      <a class="card" href="./load-sidebar-v2-css-mcp-app/">
+        <strong>loadSidebarV2 — CSS with MCP App preview</strong>
+        <span>Angie proposes CSS in a review card; the user applies it with one click.</span>
+      </a>
       <a class="card" href="./load-sidebar-v2-multi-instance/">
         <strong>loadSidebarV2 — multi instances</strong>
         <span>A sidebar and two floating chats on one page, each with its own iframe and widget config.</span>

--- a/demo/load-sidebar-v2-css-mcp-app/ajv-formats-shim.js
+++ b/demo/load-sidebar-v2-css-mcp-app/ajv-formats-shim.js
@@ -1,0 +1,1 @@
+export default function addFormats() {}

--- a/demo/load-sidebar-v2-css-mcp-app/ajv-shim.js
+++ b/demo/load-sidebar-v2-css-mcp-app/ajv-shim.js
@@ -1,0 +1,15 @@
+export default class Ajv {
+	compile() {
+		const validate = () => true;
+		validate.errors = null;
+		return validate;
+	}
+
+	getSchema() {
+		return undefined;
+	}
+
+	errorsText() {
+		return '';
+	}
+}

--- a/demo/load-sidebar-v2-css-mcp-app/host.js
+++ b/demo/load-sidebar-v2-css-mcp-app/host.js
@@ -1,0 +1,292 @@
+import { AngieMcpSdk, LAYOUT_SIDEBAR, McpAppDisplayMode, getAngieIframe } from '../../dist/index.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+const ANGIE_ORIGIN = 'https://angie.elementor.com';
+
+const CONTEXT_SERVER_NAME = 'demo-css-editor';
+const PREVIEW_URI = 'ui://demo-css-editor/preview.html';
+const PREVIEW_MIME_TYPE = 'text/html;profile=mcp-app';
+const HEADING_SELECTOR = '#demo-heading';
+
+const sdk = new AngieMcpSdk();
+
+const styleEl = document.getElementById( 'angie-custom-css' );
+const codeEl = document.getElementById( 'css-code' );
+const headingEl = document.querySelector( HEADING_SELECTOR );
+const aiButton = document.getElementById( 'css-ai-button' );
+
+const getAppliedCss = () => styleEl.textContent.trim();
+
+const getHeadingText = () => headingEl?.textContent?.trim() ?? '';
+
+let appliedVersion = 1;
+
+const applyCss = ( css ) => {
+	styleEl.textContent = css;
+	codeEl.textContent = css;
+	appliedVersion += 1;
+	sendCssContext();
+
+	return css;
+};
+
+// The proposal never touches the page. It waits here until the preview card applies it.
+const proposals = new Map();
+let nextProposalId = 1;
+
+let previewHtmlPromise;
+
+const loadPreviewHtml = () => {
+	if ( ! previewHtmlPromise ) {
+		previewHtmlPromise = fetch( new URL( './preview-app.html', import.meta.url ) )
+			.then( ( response ) => {
+				if ( ! response.ok ) {
+					throw new Error( `Failed to load preview app: ${ response.status }` );
+				}
+
+				return response.text();
+			} )
+			.catch( ( error ) => {
+				previewHtmlPromise = undefined;
+				throw error;
+			} );
+	}
+
+	return previewHtmlPromise;
+};
+
+const createCssServer = () => {
+	const server = new McpServer(
+		{
+			name: CONTEXT_SERVER_NAME,
+			version: '1.0.0',
+			title: 'Heading CSS',
+		},
+		{
+			capabilities: {
+				tools: {},
+				resources: {},
+			},
+			instructions: [
+				'This server styles a single heading on the host page.',
+				'The CSS that is currently applied arrives as page context or as an attachment on the user message — there is no tool for reading it.',
+				'Call propose-css with the full replacement stylesheet. That renders a preview card in the chat where the user reviews the code.',
+				'Do not call apply-css yourself. The user applies the CSS from the preview card.',
+			].join( ' ' ),
+		}
+	);
+
+	server.registerTool(
+		'propose-css',
+		{
+			description: 'Show the user a preview card with proposed CSS for the heading. This does not change the page — the user applies it from the card. Pass the full replacement stylesheet, not a patch.',
+			inputSchema: {
+				css: z.string().describe( `The full replacement stylesheet. Target ${ HEADING_SELECTOR }.` ),
+				summary: z.string().optional().describe( 'A short title for the change, e.g. "Purple gradient heading"' ),
+			},
+			annotations: {
+				readOnlyHint: true,
+			},
+			_meta: {
+				ui: {
+					resourceUri: PREVIEW_URI,
+					displayMode: McpAppDisplayMode.Inline,
+				},
+			},
+		},
+		async ( { css, summary } ) => {
+			const proposalId = String( nextProposalId++ );
+
+			proposals.set( proposalId, css );
+
+			return {
+				content: [ {
+					type: 'text',
+					text: `Proposed CSS is waiting for the user in preview card ${ proposalId }. Do not apply it yourself.`,
+				} ],
+				structuredContent: {
+					proposalId,
+					css,
+					summary: summary ?? 'Heading style',
+					appliedCss: getAppliedCss(),
+					version: appliedVersion,
+				},
+			};
+		}
+	);
+
+	server.registerTool(
+		'apply-css',
+		{
+			description: 'Apply CSS to the heading on the page. The preview card calls this when the user approves a proposal.',
+			inputSchema: {
+				css: z.string().optional().describe( 'The full stylesheet to apply. Omit when passing proposalId.' ),
+				proposalId: z.string().optional().describe( 'The proposalId from propose-css, applied instead of css.' ),
+			},
+		},
+		async ( { css, proposalId } ) => {
+			const resolved = css ?? ( proposalId ? proposals.get( proposalId ) : undefined );
+
+			if ( ! resolved ) {
+				return {
+					content: [ { type: 'text', text: 'Pass either css or a known proposalId' } ],
+					isError: true,
+				};
+			}
+
+			applyCss( resolved );
+
+			if ( proposalId ) {
+				proposals.delete( proposalId );
+			}
+
+			return {
+				content: [ { type: 'text', text: `Applied CSS to ${ HEADING_SELECTOR }` } ],
+				structuredContent: {
+					applied: true,
+					version: appliedVersion,
+					appliedCss: resolved,
+				},
+			};
+		}
+	);
+
+	server.registerResource(
+		'css-preview-app',
+		PREVIEW_URI,
+		{
+			title: 'CSS preview card',
+			description: 'MCP App that shows proposed CSS with an apply button',
+			mimeType: PREVIEW_MIME_TYPE,
+		},
+		async () => ( {
+			contents: [ {
+				uri: PREVIEW_URI,
+				mimeType: PREVIEW_MIME_TYPE,
+				text: await loadPreviewHtml(),
+			} ],
+		} )
+	);
+
+	return server;
+};
+
+const buildAiContext = () => ( {
+	whatUserSees: {
+		screen: 'CSS MCP app demo',
+		selector: HEADING_SELECTOR,
+		headingText: getHeadingText(),
+		appliedCss: getAppliedCss(),
+	},
+	whatUserCanDo: [
+		'Ask for a new heading style, review the proposed CSS in the preview card, and apply it',
+	],
+} );
+
+// read-css is deliberately absent: Angie learns the current CSS from page context and
+// from the attachment the AI button sends, so the context has to be pushed on every change.
+function sendCssContext() {
+	const iframe = getAngieIframe();
+	const contentWindow = iframe?.contentWindow;
+
+	if ( ! iframe || ! contentWindow ) {
+		return;
+	}
+
+	let origin;
+
+	try {
+		origin = new URL( iframe.src ).origin;
+	} catch {
+		return;
+	}
+
+	contentWindow.postMessage(
+		{
+			type: 'sdk-embedded-config',
+			payload: {
+				configVersion: 2,
+				aiContext: buildAiContext(),
+			},
+		},
+		origin
+	);
+}
+
+const askAngieAboutCss = async () => {
+	aiButton.disabled = true;
+
+	try {
+		await sdk.waitForReady();
+		window.toggleAngieSidebar?.( true );
+
+		await sdk.triggerAngie( {
+			// Angie holds this until the user sends the message, then attaches it as a
+			// context-attachment part. Nothing renders in the composer before that.
+			contextAttachment: {
+				label: 'Applied CSS',
+				content: getAppliedCss(),
+			},
+			context: { source: 'demo-css-panel', selector: HEADING_SELECTOR },
+			options: { newChat: true, timeout: 30000 },
+		} );
+	} catch ( error ) {
+		console.error( 'Could not open Angie with the CSS attached', error );
+	} finally {
+		aiButton.disabled = false;
+	}
+};
+
+aiButton.addEventListener( 'click', askAngieAboutCss );
+
+codeEl.textContent = getAppliedCss();
+
+await sdk.loadSidebarV2( {
+	host: {
+		appId: 'demo-css-mcp-app',
+		aiContext: buildAiContext(),
+	},
+	container: {
+		layout: LAYOUT_SIDEBAR,
+		chatToggleButton: {
+			enabled: true,
+			selector: '#demo-sidebar-toggle',
+		},
+	},
+	iframe: {
+		origin: ANGIE_ORIGIN,
+		path: 'angie/embedded',
+		uiTheme: 'light',
+	},
+	widgetConfig: {
+		title: 'Style this heading',
+		subtitle: 'Angie proposes CSS. You approve it in the preview card.',
+		suggestions: {
+			items: [
+				{ label: 'Purple gradient', value: 'Give the heading a purple gradient text fill' },
+				{ label: 'Soft shadow', value: 'Add a soft text shadow and tighten the letter spacing' },
+			],
+		},
+		featuredMcpServer: CONTEXT_SERVER_NAME,
+		localServers: { skipLoading: true },
+		planning: { enabled: false },
+		promptLibrary: { enabled: false },
+		fileUpload: { enabled: false },
+		commands: { enabled: false },
+		topBar: { enabled: false },
+		modeSwitcher: { enabled: false },
+	},
+} );
+
+await sdk.waitForReady();
+await sdk.registerServer( {
+	name: CONTEXT_SERVER_NAME,
+	version: '1.0.0',
+	description: 'Propose CSS for the page heading and apply it once the user approves',
+	server: createCssServer(),
+	capabilities: {
+		tools: {},
+		resources: {},
+	},
+} );

--- a/demo/load-sidebar-v2-css-mcp-app/index.html
+++ b/demo/load-sidebar-v2-css-mcp-app/index.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>loadSidebarV2 — CSS with MCP App preview</title>
+  <script type="importmap">
+  {
+    "imports": {
+      "@modelcontextprotocol/sdk/server/mcp.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/server/mcp.js",
+      "@modelcontextprotocol/sdk/types.js": "../../node_modules/@modelcontextprotocol/sdk/dist/esm/types.js",
+      "zod": "../../node_modules/zod/index.js",
+      "zod/v3": "../../node_modules/zod/v3/index.js",
+      "zod/v4": "../../node_modules/zod/v4/index.js",
+      "zod/v4-mini": "../../node_modules/zod/v4-mini/index.js",
+      "zod-to-json-schema": "../../node_modules/zod-to-json-schema/dist/esm/index.js",
+      "ajv": "./ajv-shim.js",
+      "ajv-formats": "./ajv-formats-shim.js"
+    }
+  }
+  </script>
+
+  <!-- Angie writes into this tag. Everything below is the demo page chrome. -->
+  <style id="angie-custom-css">
+#demo-heading {
+	font-size: 2.5rem;
+	color: #111827;
+}
+  </style>
+
+  <style>
+    body { margin: 0; font-family: system-ui, sans-serif; background: #fff; color: #111827; }
+    .page { padding: 1rem; max-width: 40rem; }
+    .hint { color: #555; }
+    #demo-sidebar-toggle { padding: 0.5rem 1rem; font: inherit; cursor: pointer; }
+    #demo-heading { margin: 2rem 0; }
+    .code-panel { border: 1px solid #e5e7eb; border-radius: 0.5rem; overflow: hidden; }
+    .code-panel-label {
+      display: flex; align-items: center; gap: 0.5rem;
+      padding: 0.5rem 0.75rem; background: #f9fafb; border-bottom: 1px solid #e5e7eb;
+      font-size: 0.8rem; font-weight: 600; color: #374151;
+    }
+    .code-panel-label .chip {
+      padding: 0.05rem 0.35rem; border: 1px solid #d1d5db; border-radius: 0.25rem;
+      font-weight: 500; color: #6b7280;
+    }
+    .code-panel-label .spacer { flex: 1; }
+    #css-ai-button {
+      display: inline-flex; align-items: center; gap: 0.3rem;
+      padding: 0.2rem 0.45rem; border: 1px solid #d8b4fe; border-radius: 0.3rem;
+      background: #faf5ff; color: #7c3aed;
+      font: inherit; font-size: 0.75rem; font-weight: 600; cursor: pointer;
+    }
+    #css-ai-button:hover { background: #f3e8ff; }
+    #css-ai-button:disabled { opacity: 0.5; cursor: default; }
+    .code-panel pre { margin: 0; padding: 0.75rem; overflow-x: auto; }
+    .code-panel code { font: 0.8rem/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; color: #111827; tab-size: 2; }
+  </style>
+</head>
+<body>
+  <main class="page">
+  <p><a href="../">← All demos</a></p>
+  <p>Angie writes the CSS for the heading below, but nothing is applied until you approve it.</p>
+  <p class="hint">
+    Ask for a style change in the sidebar. Angie calls <code>propose-css</code>, which renders an MCP App
+    preview card inside the chat. The CSS only reaches this page when you click <strong>Apply to page</strong>
+    in that card — the button calls the <code>apply-css</code> tool directly.
+  </p>
+
+  <p><button type="button" id="demo-sidebar-toggle">Open Angie</button></p>
+
+  <h1 id="demo-heading">Summer sale is live</h1>
+
+  <div class="code-panel">
+    <div class="code-panel-label">
+      Applied CSS <span class="chip">CSS</span>
+      <span class="spacer"></span>
+      <button type="button" id="css-ai-button" title="Edit this CSS with Angie">
+        <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+          <path d="M12 2l1.9 5.6L19.5 9.5 13.9 11.4 12 17l-1.9-5.6L4.5 9.5l5.6-1.9L12 2z" />
+          <path d="M18.5 14.5l.9 2.6 2.6.9-2.6.9-.9 2.6-.9-2.6-2.6-.9 2.6-.9.9-2.6z" />
+        </svg>
+        Edit with Angie
+      </button>
+    </div>
+    <pre><code id="css-code"></code></pre>
+  </div>
+  </main>
+
+  <div id="angie-sidebar-container" aria-hidden="true"></div>
+  <script type="module" src="./host.js"></script>
+</body>
+</html>

--- a/demo/load-sidebar-v2-css-mcp-app/preview-app.html
+++ b/demo/load-sidebar-v2-css-mcp-app/preview-app.html
@@ -1,0 +1,460 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<title>CSS preview</title>
+<style>
+	:root {
+		--card-bg: var( --color-background-primary, #ffffff );
+		--card-bg-soft: var( --color-background-secondary, #f9fafb );
+		--card-border: var( --color-border-primary, #e5e7eb );
+		--text: var( --color-text-primary, #111827 );
+		--text-soft: var( --color-text-secondary, #6b7280 );
+		--btn-bg: var( --color-background-inverse, #111827 );
+		--btn-text: var( --color-text-inverse, #ffffff );
+		--danger: var( --color-text-danger, #b91c1c );
+		--success: var( --color-text-success, #15803d );
+		--mono: var( --font-mono, ui-monospace, SFMono-Regular, Menlo, monospace );
+		--sans: var( --font-sans, system-ui, -apple-system, sans-serif );
+	}
+
+	* { box-sizing: border-box; }
+
+	html, body { margin: 0; padding: 0; background: transparent; }
+
+	body {
+		font-family: var( --sans );
+		color: var( --text );
+		font-size: 13px;
+	}
+
+	.card {
+		background: var( --card-bg );
+		border: 1px solid var( --card-border );
+		border-radius: 12px;
+		overflow: hidden;
+	}
+
+	.card-head {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 12px 14px;
+	}
+
+	.glyph {
+		font-family: var( --mono );
+		font-size: 12px;
+		color: var( --text-soft );
+	}
+
+	.title {
+		font-weight: 600;
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		white-space: nowrap;
+	}
+
+	.chip {
+		flex: none;
+		padding: 1px 6px;
+		border: 1px solid var( --card-border );
+		border-radius: 5px;
+		font-size: 11px;
+		color: var( --text-soft );
+		background: var( --card-bg-soft );
+	}
+
+	.code-wrap {
+		position: relative;
+		margin: 0 14px;
+		border: 1px solid var( --card-border );
+		border-radius: 8px;
+		background: var( --card-bg-soft );
+	}
+
+	pre {
+		margin: 0;
+		padding: 12px 40px 12px 12px;
+		max-height: 260px;
+		overflow: auto;
+		font: 12px/1.55 var( --mono );
+		white-space: pre;
+		tab-size: 2;
+	}
+
+	.tok-sel { color: #b45309; }
+	.tok-prop { color: #1d4ed8; }
+	.tok-val { color: #047857; }
+	.tok-comment { color: var( --text-soft ); font-style: italic; }
+
+	.copy {
+		position: absolute;
+		top: 6px;
+		right: 6px;
+		padding: 4px 7px;
+		border: 1px solid var( --card-border );
+		border-radius: 6px;
+		background: var( --card-bg );
+		color: var( --text-soft );
+		font: 11px/1 var( --sans );
+		cursor: pointer;
+	}
+
+	.copy:hover { color: var( --text ); }
+
+	.card-foot {
+		display: flex;
+		align-items: center;
+		gap: 10px;
+		margin-top: 12px;
+		padding: 10px 14px;
+		border-top: 1px solid var( --card-border );
+	}
+
+	.meta {
+		flex: 1;
+		min-width: 0;
+		font-size: 11px;
+		color: var( --text-soft );
+	}
+
+	.meta.is-error { color: var( --danger ); }
+	.meta.is-applied { color: var( --success ); }
+
+	button {
+		font-family: var( --sans );
+		cursor: pointer;
+	}
+
+	.btn-ghost {
+		padding: 6px 10px;
+		border: 0;
+		border-radius: 8px;
+		background: transparent;
+		color: var( --text-soft );
+		font-size: 12px;
+	}
+
+	.btn-ghost:hover { color: var( --text ); }
+
+	.btn-primary {
+		padding: 7px 13px;
+		border: 0;
+		border-radius: 8px;
+		background: var( --btn-bg );
+		color: var( --btn-text );
+		font-size: 12px;
+		font-weight: 500;
+	}
+
+	.btn-primary:disabled {
+		opacity: 0.45;
+		cursor: default;
+	}
+
+	[hidden] { display: none !important; }
+</style>
+</head>
+<body>
+	<div class="card">
+		<div class="card-head">
+			<span class="glyph">&lt;/&gt;</span>
+			<span class="title" id="title">Loading proposal…</span>
+			<span class="chip">CSS</span>
+		</div>
+
+		<div class="code-wrap">
+			<button class="copy" id="copy" type="button">Copy</button>
+			<pre><code id="code"></code></pre>
+		</div>
+
+		<div class="card-foot">
+			<span class="meta" id="meta">Waiting for the tool result…</span>
+			<button class="btn-ghost" id="discard" type="button" hidden>Discard</button>
+			<button class="btn-primary" id="apply" type="button" hidden>Apply to page</button>
+		</div>
+	</div>
+
+<script>
+( () => {
+	'use strict';
+
+	const PROTOCOL_VERSION = '2026-01-26';
+
+	const el = ( id ) => document.getElementById( id );
+	const titleEl = el( 'title' );
+	const codeEl = el( 'code' );
+	const metaEl = el( 'meta' );
+	const applyBtn = el( 'apply' );
+	const discardBtn = el( 'discard' );
+	const copyBtn = el( 'copy' );
+
+	/* ---------- JSON-RPC over postMessage ----------
+	   The host loads this document via iframe srcdoc, so our origin is `null` and the
+	   CSP blocks external scripts. That rules out bundling @modelcontextprotocol/ext-apps,
+	   so we speak the MCP Apps wire protocol directly. The host validates event.source
+	   and expects `null` as our origin, so '*' is the correct target origin here. */
+
+	const pending = new Map();
+	let nextId = 1;
+
+	const request = ( method, params ) => {
+		const id = nextId++;
+
+		return new Promise( ( resolve, reject ) => {
+			pending.set( id, { resolve, reject } );
+			parent.postMessage( { jsonrpc: '2.0', id, method, params: params || {} }, '*' );
+		} );
+	};
+
+	const notify = ( method, params ) => {
+		parent.postMessage( { jsonrpc: '2.0', method, params: params || {} }, '*' );
+	};
+
+	const respond = ( id, result ) => {
+		parent.postMessage( { jsonrpc: '2.0', id, result: result || {} }, '*' );
+	};
+
+	window.addEventListener( 'message', ( event ) => {
+		const msg = event.data;
+
+		if ( ! msg || msg.jsonrpc !== '2.0' ) {
+			return;
+		}
+
+		const isResponse = 'result' in msg || 'error' in msg;
+
+		if ( isResponse && pending.has( msg.id ) ) {
+			const entry = pending.get( msg.id );
+			pending.delete( msg.id );
+
+			if ( msg.error ) {
+				entry.reject( new Error( msg.error.message || 'Request failed' ) );
+			} else {
+				entry.resolve( msg.result );
+			}
+
+			return;
+		}
+
+		if ( ! msg.method ) {
+			return;
+		}
+
+		// Host -> app requests (ping, ui/resource-teardown) need an answer or the host waits.
+		if ( msg.id !== undefined && msg.id !== null ) {
+			respond( msg.id, {} );
+			return;
+		}
+
+		if ( msg.method === 'ui/notifications/tool-result' ) {
+			renderProposal( msg.params );
+		}
+	} );
+
+	/* ---------- Sizing ----------
+	   The host starts the iframe at 50px and resizes only when we report a height. */
+
+	let lastHeight = 0;
+
+	const reportHeight = () => {
+		const height = Math.ceil( document.documentElement.scrollHeight );
+
+		if ( height > 0 && height !== lastHeight ) {
+			lastHeight = height;
+			notify( 'ui/notifications/size-changed', { height } );
+		}
+	};
+
+	if ( window.ResizeObserver ) {
+		new ResizeObserver( reportHeight ).observe( document.documentElement );
+	}
+
+	/* ---------- Rendering ---------- */
+
+	const escapeHtml = ( value ) => value
+		.replace( /&/g, '&amp;' )
+		.replace( /</g, '&lt;' )
+		.replace( />/g, '&gt;' );
+
+	// Enough highlighting to make a stylesheet readable, line by line.
+	const highlight = ( css ) => css.split( '\n' ).map( ( line ) => {
+		const safe = escapeHtml( line );
+		const trimmed = safe.trim();
+
+		if ( ! trimmed ) {
+			return safe;
+		}
+
+		if ( trimmed.startsWith( '/*' ) || trimmed.startsWith( '*' ) ) {
+			return '<span class="tok-comment">' + safe + '</span>';
+		}
+
+		const colon = safe.indexOf( ':' );
+
+		if ( colon !== -1 && ! trimmed.endsWith( '{' ) ) {
+			return '<span class="tok-prop">' + safe.slice( 0, colon ) + '</span>:' +
+				'<span class="tok-val">' + safe.slice( colon + 1 ) + '</span>';
+		}
+
+		if ( trimmed.endsWith( '{' ) || trimmed.startsWith( '@' ) ) {
+			return '<span class="tok-sel">' + safe + '</span>';
+		}
+
+		return safe;
+	} ).join( '\n' );
+
+	let proposal = null;
+	let settled = false;
+
+	const setMeta = ( text, state ) => {
+		metaEl.textContent = text;
+		metaEl.className = 'meta' + ( state ? ' is-' + state : '' );
+	};
+
+	const readProposal = ( toolResult ) => {
+		if ( toolResult && toolResult.structuredContent && toolResult.structuredContent.css ) {
+			return toolResult.structuredContent;
+		}
+
+		// Fallback for hosts that forward content blocks only.
+		const block = ( toolResult && toolResult.content || [] ).find( ( item ) => item.type === 'text' );
+
+		try {
+			const parsed = JSON.parse( block && block.text );
+			return parsed && parsed.css ? parsed : null;
+		} catch {
+			return null;
+		}
+	};
+
+	function renderProposal( toolResult ) {
+		proposal = readProposal( toolResult );
+
+		if ( ! proposal ) {
+			titleEl.textContent = 'No CSS in this proposal';
+			setMeta( 'The tool result did not include any CSS.', 'error' );
+			reportHeight();
+			return;
+		}
+
+		titleEl.textContent = proposal.summary || 'Heading style';
+		codeEl.innerHTML = highlight( proposal.css );
+		setMeta( 'v' + ( proposal.version || 1 ) + ' · Proposed just now' );
+		applyBtn.hidden = false;
+		discardBtn.hidden = false;
+		reportHeight();
+	}
+
+	/* ---------- Actions ---------- */
+
+	applyBtn.addEventListener( 'click', async () => {
+		if ( settled || ! proposal ) {
+			return;
+		}
+
+		applyBtn.disabled = true;
+		discardBtn.disabled = true;
+		setMeta( 'Applying…' );
+
+		try {
+			// Angie proxies tools/call straight to the MCP server that served this app.
+			const result = await request( 'tools/call', {
+				name: 'apply-css',
+				arguments: { css: proposal.css, proposalId: proposal.proposalId },
+			} );
+
+			if ( result && result.isError ) {
+				throw new Error( 'The apply-css tool reported an error' );
+			}
+
+			settled = true;
+			applyBtn.textContent = 'Applied';
+			discardBtn.hidden = true;
+			setMeta( 'v' + ( ( proposal.version || 1 ) + 1 ) + ' · Applied just now', 'applied' );
+			reportHeight();
+
+			// Plain text, never the $$MCP_SIGNAL$$ prefix — signals ask the host to reload the page.
+			request( 'ui/message', {
+				role: 'user',
+				content: [ { type: 'text', text: 'I applied the proposed CSS to the page.' } ],
+			} ).catch( () => {} );
+		} catch ( error ) {
+			applyBtn.disabled = false;
+			discardBtn.disabled = false;
+			setMeta( error.message || 'Could not apply the CSS', 'error' );
+			reportHeight();
+		}
+	} );
+
+	discardBtn.addEventListener( 'click', () => {
+		if ( settled ) {
+			return;
+		}
+
+		settled = true;
+		applyBtn.hidden = true;
+		discardBtn.hidden = true;
+		setMeta( 'Discarded · nothing was applied' );
+		reportHeight();
+	} );
+
+	copyBtn.addEventListener( 'click', async () => {
+		if ( ! proposal ) {
+			return;
+		}
+
+		try {
+			await navigator.clipboard.writeText( proposal.css );
+		} catch {
+			// Clipboard access is often denied in a null-origin sandbox.
+			const scratch = document.createElement( 'textarea' );
+			scratch.value = proposal.css;
+			document.body.appendChild( scratch );
+			scratch.select();
+			document.execCommand( 'copy' );
+			scratch.remove();
+		}
+
+		copyBtn.textContent = 'Copied';
+		setTimeout( () => {
+			copyBtn.textContent = 'Copy';
+		}, 1200 );
+	} );
+
+	/* ---------- Handshake ---------- */
+
+	const applyHostStyles = ( hostContext ) => {
+		const variables = hostContext && hostContext.styles && hostContext.styles.variables;
+
+		if ( ! variables ) {
+			return;
+		}
+
+		Object.keys( variables ).forEach( ( key ) => {
+			if ( variables[ key ] ) {
+				document.documentElement.style.setProperty( key, variables[ key ] );
+			}
+		} );
+	};
+
+	request( 'ui/initialize', {
+		appInfo: { name: 'CSS preview', version: '1.0.0' },
+		appCapabilities: {},
+		protocolVersion: PROTOCOL_VERSION,
+	} ).then( ( result ) => {
+		// Whatever version the host negotiated is the version we use. Never assert equality.
+		applyHostStyles( result && result.hostContext );
+		notify( 'ui/notifications/initialized', {} );
+		reportHeight();
+	} ).catch( ( error ) => {
+		setMeta( error.message || 'Could not reach the Angie host', 'error' );
+		reportHeight();
+	} );
+} )();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds `demo/load-sidebar-v2-css-mcp-app` — the first **MCP App** example in this repo: a tool result that renders as interactive UI inside the chat instead of plain text.

The page has a heading and the CSS that styles it. You ask Angie for a style change, and instead of the page changing under you, the proposed CSS shows up as a card in the chat with an **Apply to page** button. Nothing is applied until you click it.

https://www.loom.com/share/6d13f383e752472fa715356e8dcfe80d

How it works:

- `propose-css` declares `_meta.ui.resourceUri` (`ui://demo-css-editor/preview.html`) and just stores the proposal — it never touches the page.
- The server serves that URI with `registerResource`, and Angie renders the HTML in a sandboxed iframe, passing the proposal in via `ui/notifications/tool-result`.
- The card's Apply button calls the `apply-css` tool over `tools/call`, which injects the CSS and updates the on-page code block.

There's no read tool: the **Edit with Angie** button next to the CSS block opens the sidebar with the current stylesheet as a `contextAttachment`.

