### PR TITLE
feat: forward an Angie App id to the embedded app

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.7.2",
+      "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.4",
+  "version": "1.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.7.4",
+      "version": "1.7.6",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.4",
+  "version": "1.7.6",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -65,6 +65,10 @@ export type WidgetConfig = {
   topBar?: FeatureToggle;
 };
 
+export type AngieMcpSdkConstructorOptions = {
+  appId?: string;
+};
+
 export type AngieMcpSdkOptions = {
   origin?: string;
   uiTheme?: string;
@@ -85,6 +89,7 @@ const DEFAULT_OPTIONS: Required<Omit<AngieMcpSdkOptions, 'widgetConfig'>> = {
 };
 
 export class AngieMcpSdk {
+  private appId?: string;
   private angieDetector: AngieDetector;
   private clientManager: ClientManager;
   private logger: Logger;
@@ -94,7 +99,8 @@ export class AngieMcpSdk {
   private sidebarV2BootPromise: Promise<void> | null = null;
   private promptHashListenerAttached = false;
 
-  constructor() {
+  constructor( options?: AngieMcpSdkConstructorOptions ) {
+    this.appId = options?.appId?.trim() || undefined;
     this.instanceId = generateInstanceId();
     this.logger = createChildLogger({ instanceId: this.instanceId });
     this.logger.log('Constructor called - initializing SDK');
@@ -115,6 +121,7 @@ export class AngieMcpSdk {
     const config = { ...DEFAULT_OPTIONS, ...rest };
     appState.containerId = config.containerId;
     appState.instanceId = this.instanceId;
+    appState.appId = this.appId;
     initAngieSidebar( { skipDefaultCss: config.skipDefaultCss } );
     const opened = await openIframe( config );
 
@@ -137,7 +144,7 @@ export class AngieMcpSdk {
       this.instanceId = options.host.instanceId;
     }
 
-    this.sidebarV2BootPromise = bootSidebar( { ...options, sdkInstanceId: this.instanceId } );
+    this.sidebarV2BootPromise = bootSidebar( { ...options, sdkInstanceId: this.instanceId, appId: this.appId } );
     this.setupPromptHashDetection();
     return this.sidebarV2BootPromise;
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export type AppState = {
 	iframeUrlObject: URL | null;
 	containerId: string;
 	instanceId: string;
+	appId?: string;
 	layout: LoadSidebarV2Layout | '';
 	iframeElementId: string;
 };
@@ -20,6 +21,7 @@ export const createDefaultAppState = (): AppState => ( {
 	iframeUrlObject: null,
 	containerId: DEFAULT_CONTAINER_ID,
 	instanceId: '',
+	appId: undefined,
 	layout: '',
 	iframeElementId: DEFAULT_IFRAME_ELEMENT_ID,
 } );

--- a/src/iframe.test.ts
+++ b/src/iframe.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals
 import {
 	disableNavigationPrevention,
 	isValidPath,
+	openIframe,
 	registerIframeHostHandler,
 	resetIframeHostHandlersForTests,
 } from './iframe';
@@ -15,6 +16,24 @@ jest.mock( './logger', () => ( {
 		warn: jest.fn(),
 		error: jest.fn(),
 	} ) ),
+} ) );
+
+jest.mock( './openSaaSPage', () => ( {
+	openSaaSPage: jest.fn( () => Promise.resolve( {
+		iframe: document.createElement( 'iframe' ),
+		iframeUrlObject: new URL( 'https://angie.elementor.com/angie/embedded' ),
+	} ) ),
+} ) );
+
+jest.mock( './sdk', () => ( {
+	flushPendingSdkMessages: jest.fn(),
+	registerSdkInstance: jest.fn(),
+	startSdkMessageRouting: jest.fn(),
+} ) );
+
+jest.mock( './oauth', () => ( {
+	listenToOAuthFromIframe: jest.fn(),
+	setupOidcLoginFlowHandler: jest.fn(),
 } ) );
 
 describe( 'disableNavigationPrevention', () => {
@@ -191,6 +210,54 @@ describe( 'iframe host message routing', () => {
 			origin,
 		);
 		expect( sidebarWindow.postMessage ).not.toHaveBeenCalled();
+	} );
+} );
+
+describe( 'openIframe appId', () => {
+	let mockOpenSaaSPage: jest.Mock;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		resetInstancesForTests();
+		resetIframeHostHandlersForTests();
+		// jsdom reports availWidth 0, which openIframe treats as mobile and skips.
+		Object.defineProperty( window.screen, 'availWidth', { value: 1280, configurable: true } );
+		document.body.innerHTML = '<div id="angie-sidebar-container"></div>';
+		mockOpenSaaSPage = require( './openSaaSPage' ).openSaaSPage as jest.Mock;
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		resetIframeHostHandlersForTests();
+	} );
+
+	it( 'should forward the instance appId to the iframe url builder', async () => {
+		const instance = createAngieInstance( {
+			containerId: 'angie-sidebar-container',
+			instanceId: 'demo-sidebar',
+			appId: 'NG-XRLGFZE',
+			layout: 'sidebar',
+		} );
+
+		await openIframe( { uiTheme: 'light', isRTL: false }, instance );
+
+		expect( mockOpenSaaSPage ).toHaveBeenCalledWith(
+			expect.objectContaining( { appId: 'NG-XRLGFZE' } ),
+		);
+	} );
+
+	it( 'should forward no appId when the instance has none', async () => {
+		const instance = createAngieInstance( {
+			containerId: 'angie-sidebar-container',
+			instanceId: 'demo-sidebar',
+			layout: 'sidebar',
+		} );
+
+		await openIframe( { uiTheme: 'light', isRTL: false }, instance );
+
+		expect( mockOpenSaaSPage ).toHaveBeenCalledWith(
+			expect.objectContaining( { appId: undefined } ),
+		);
 	} );
 } );
 

--- a/src/iframe.ts
+++ b/src/iframe.ts
@@ -273,6 +273,7 @@ export const openIframe = async (
 		sdkVersion: ANGIE_SDK_VERSION,
 		iframeElementId: instance.iframeElementId,
 		instanceId: instance.instanceId,
+		appId: instance.appId,
 	} );
 
 	instance.iframe = iframe;

--- a/src/instance-registry.ts
+++ b/src/instance-registry.ts
@@ -6,7 +6,7 @@ import {
 } from './config';
 import { LAYOUT_SIDEBAR, type LoadSidebarV2Layout } from './load-sidebar-v2/config';
 
-export type CreateAngieInstanceArgs = Pick<AppState, 'containerId' | 'instanceId'> & {
+export type CreateAngieInstanceArgs = Pick<AppState, 'containerId' | 'instanceId' | 'appId'> & {
 	layout: LoadSidebarV2Layout;
 };
 

--- a/src/load-sidebar-v2/README.md
+++ b/src/load-sidebar-v2/README.md
@@ -31,6 +31,16 @@ await sdk.loadSidebarV2({
 });
 ```
 
+**Angie App registry id** (optional). Not the same thing as `host.appId`: this is the `NG-...`
+id of a registered Angie App. Declare it on the constructor and it reaches the embedded app as
+the `appId` query parameter on the iframe URL.
+
+```typescript
+const sdk = new AngieMcpSdk( { appId: 'NG-XRLGFZE' } );
+```
+
+It belongs to the `AngieMcpSdk` object, so each instance on a page carries its own.
+
 Local demos:
 
 - [`demo/load-sidebar-v2-sidebar/`](../../demo/load-sidebar-v2-sidebar/) — minimal sidebar
@@ -219,6 +229,7 @@ types — it races the bridge and usually loses the payload the host meant to se
 | Static website/analytics fields | `host.website` / `host.analytics` |
 | Per-request context | `callbacks.getWebsiteContext` / `getAnalyticsContext` |
 | Auth headers | `callbacks.getExternalHeaders` |
+| Angie App registry id (`NG-...`) | `new AngieMcpSdk({ appId })` → iframe URL `?appId=` → in-memory in iframe (not `host.appId`) |
 | Host localStorage | Bridge (do not add a get/set listener) |
 
 Providers may be async. A throw becomes an error reply.

--- a/src/load-sidebar-v2/boot-sidebar.test.ts
+++ b/src/load-sidebar-v2/boot-sidebar.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import { LAYOUT_FLOATING_CHAT, LAYOUT_SIDEBAR } from './config';
 import { bootSidebar } from './boot-sidebar';
-import { getFirstInstance, resetInstancesForTests } from '../instance-registry';
+import { getFirstInstance, getInstanceById, resetInstancesForTests } from '../instance-registry';
 
 jest.mock( '../sidebar', () => ( {
 	ANGIE_SIDEBAR_STATE_CLOSED: 'closed',
@@ -84,6 +84,55 @@ describe( 'load-sidebar-v2/boot-sidebar', () => {
 		);
 		expect( mockLoadState ).toHaveBeenCalledWith( 'open' );
 		expect( mockInitializeResize ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should carry the sdk appId on the instance so the iframe url can use it', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR },
+			host: { appId: 'editor-lite' },
+			appId: 'NG-XRLGFZE',
+		} );
+
+		expect( getFirstInstance()?.appId ).toBe( 'NG-XRLGFZE' );
+	} );
+
+	it( 'should leave the instance appId unset when the sdk has none', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR },
+			host: { appId: 'editor-lite' },
+		} );
+
+		expect( getFirstInstance()?.appId ).toBeUndefined();
+	} );
+
+	it( 'should give each instance its own appId', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR },
+			host: { appId: 'app-a', instanceId: 'first' },
+			appId: 'NG-XRLGFXYZ',
+		} );
+		await bootSidebar( {
+			container: { id: 'second-container', layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-b', instanceId: 'second' },
+			appId: 'NG-XRLGFZRX',
+		} );
+
+		expect( getInstanceById( 'first' )?.appId ).toBe( 'NG-XRLGFXYZ' );
+		expect( getInstanceById( 'second' )?.appId ).toBe( 'NG-XRLGFZRX' );
+	} );
+
+	it( 'should not leak an appId to a sibling instance that declares none', async () => {
+		await bootSidebar( {
+			container: { layout: LAYOUT_SIDEBAR },
+			host: { appId: 'app-a', instanceId: 'first' },
+			appId: 'NG-XRLGFXYZ',
+		} );
+		await bootSidebar( {
+			container: { id: 'second-container', layout: LAYOUT_FLOATING_CHAT },
+			host: { appId: 'app-b', instanceId: 'second' },
+		} );
+
+		expect( getInstanceById( 'second' )?.appId ).toBeUndefined();
 	} );
 
 	it( 'should not create the container when create is false', async () => {

--- a/src/load-sidebar-v2/boot-sidebar.ts
+++ b/src/load-sidebar-v2/boot-sidebar.ts
@@ -68,6 +68,7 @@ export const bootSidebar = async ( options: LoadSidebarV2Options ): Promise<void
 	const instance = createAngieInstance( {
 		containerId: config.container.id,
 		instanceId,
+		appId: options.appId,
 		layout: config.container.layout,
 	} );
 

--- a/src/load-sidebar-v2/config.ts
+++ b/src/load-sidebar-v2/config.ts
@@ -76,6 +76,7 @@ export type LoadSidebarV2Options = {
 	callbacks?: CallbacksConfig;
 	widgetConfig?: WidgetConfig;
 	sdkInstanceId?: string;
+	appId?: string;
 };
 
 export type ResolvedConfigV2 = {

--- a/src/openSaaSPage.test.ts
+++ b/src/openSaaSPage.test.ts
@@ -166,6 +166,44 @@ describe('openSaaSPage', () => {
       expect(resolved).toBe(true);
     });
 
+    it('should append appId to the iframe URL when provided', async () => {
+      const messagePromise = openSaaSPage({
+        ...defaultProps,
+        appId: 'NG-XRLGFZE',
+      });
+
+      const messageListener = mockWindow.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === 'message'
+      )?.[1];
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        data: { type: HostEventType.ANGIE_READY },
+      });
+
+      const result = await messagePromise;
+      const appendSpy = result.iframeUrlObject.searchParams.append as jest.MockedFunction<any>;
+      const appIdCall = appendSpy.mock.calls.find((call: any[]) => call[0] === 'appId');
+
+      expect(appIdCall?.[1]).toBe('NG-XRLGFZE');
+    });
+
+    it('should not add an appId param when none is provided', async () => {
+      const messagePromise = openSaaSPage(defaultProps);
+
+      const messageListener = mockWindow.addEventListener.mock.calls.find(
+        (call: any[]) => call[0] === 'message'
+      )?.[1];
+      messageListener({
+        origin: 'https://angie.elementor.com',
+        data: { type: HostEventType.ANGIE_READY },
+      });
+
+      const result = await messagePromise;
+      const appendSpy = result.iframeUrlObject.searchParams.append as jest.MockedFunction<any>;
+
+      expect(appendSpy.mock.calls.find((call: any[]) => call[0] === 'appId')).toBeUndefined();
+    });
+
     it('should apply CSS styles correctly', async () => {
       const cssProps = {
         width: '400px',

--- a/src/openSaaSPage.ts
+++ b/src/openSaaSPage.ts
@@ -16,6 +16,7 @@ type OpenSaaSPageInput = {
 	sdkVersion: string;
 	iframeElementId?: string;
 	instanceId?: string;
+	appId?: string;
 };
 
 type OpenSaaSPageOutput = {
@@ -43,6 +44,10 @@ export const openSaaSPage = async ( props: OpenSaaSPageInput ): Promise<OpenSaaS
 
 		if ( props.isRTL ) {
 			iframeUrlObject.searchParams.append( 'isRTL', props.isRTL ? 'true' : 'false' );
+		}
+
+		if ( props.appId ) {
+			iframeUrlObject.searchParams.append( 'appId', props.appId );
 		}
 
 		// pass testing error messages to iframe


### PR DESCRIPTION
## What

A host embedding Angie can now declare which registered Angie App the sidebar belongs to. The id is declared once on the SDK object and travels to the embedded app as the `appId` query parameter on the iframe URL.

```js
const sdk = new AngieMcpSdk( { appId: 'NG-ab35bf57' } );
await sdk.loadSidebarV2( { container: { layout: 'sidebar' } } );
```

This is not the same thing as `host.appId`, which will be deprecated. This is the `NG-...` id of an app registered in Angie (mixed letters and numbers after the prefix, e.g. `NG-ab35bf57`).

## Why

Without it the embedded app has no way to know it is running as a specific Angie App, so it cannot pick up that app's own configuration.

## Notes

The id lives on the `AngieMcpSdk` instance, so multiple Angie instances on one page each carry their own and never inherit a sibling's. Covered by unit tests in `boot-sidebar.test.ts`, `iframe.test.ts` and `openSaaSPage.test.ts`, including the case where no id is declared and no query parameter is added. Documented in `src/load-sidebar-v2/README.md`. Patch version bump to 1.7.7.

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context
Allows passing a specific Angie App registry ID (`NG-...`) from the SDK constructor to the embedded app to identify the registered application via the iframe URL.

## 2. What Changed (Where)

| File | Change |
| :--- | :--- |
| `src/angie-mcp-sdk.ts` | Added `appId` to constructor options and internal state. |
| `src/config.ts` | Added `appId` to `AppState` type and default state. |
| `src/iframe.ts` | Forwards `appId` from instance to the iframe builder. |
| `src/instance-registry.ts` | Added `appId` to `CreateAngieInstanceArgs`. |
| `src/load-sidebar-v2/*` | Updated boot logic and configs to support `appId` propagation. |
| `src/openSaaSPage.ts` | Appends `appId` as a query parameter to the iframe URL. |
| `package.json` | Bumped version to `1.7.7`. |
| `src/*.test.ts` | Added unit tests for `appId` forwarding and isolation. |

## 3. How It Works
The `appId` is provided during `AngieMcpSdk` instantiation, stored in the `AppState` for the specific instance, and eventually appended as a search parameter to the iframe URL in `openSaaSPage`.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
