### PR TITLE
Dispatch Slack ready-for-review for CONTRIBUTOR teammates

### DIFF
--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -2,7 +2,7 @@ name: PR Slack Ready for Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [ready_for_review]
 
 permissions:
   contents: read
@@ -13,7 +13,6 @@ jobs:
     # that association instead of MEMBER (see PR #98). Forks are still skipped.
     if: |
       github.event.pull_request.head.repo.full_name == github.repository &&
-      github.event.pull_request.draft == false &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -3,31 +3,25 @@ name: PR Slack Ready for Review
 on:
   pull_request:
     types: [opened, ready_for_review]
-  workflow_dispatch:
-    inputs:
-      pr_input:
-        description: 'PR number or URL (e.g., "123" or "https://github.com/owner/repo/pull/123")'
-        required: true
-        type: string
 
 permissions:
   contents: read
 
 jobs:
   dispatch:
+    # CONTRIBUTOR is included because teammates on this public repo often have
+    # that association instead of MEMBER (see PR #98). Forks are still skipped.
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.draft == false
-      )
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}

--- a/.github/workflows/pr-ci-slack-ready.yml
+++ b/.github/workflows/pr-ci-slack-ready.yml
@@ -2,7 +2,13 @@ name: PR Slack Ready for Review
 
 on:
   pull_request:
-    types: [ready_for_review]
+    types: [opened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_input:
+        description: 'PR number or URL (e.g., "123" or "https://github.com/owner/repo/pull/123")'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -10,15 +16,18 @@ permissions:
 jobs:
   dispatch:
     if: |
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.draft == false
+      )
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-          ref: ${{ github.event.pull_request.base.sha }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - uses: ./.github/actions/dispatch-angie-dev-tools
         env:
           GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Slack “ready for review” notifications were skipping for internal PRs whose authors GitHub marks as `CONTRIBUTOR` on this public repo (for example [PR #98](https://github.com/elementor/angie-sdk/pull/98) / [run 34019829971](https://github.com/elementor/angie-sdk/actions/runs/34019829971)).

**Needs human sign-off:** this PR adds `CONTRIBUTOR` to the author-association allowlist. That is a trust-boundary change. Fork PRs are still excluded via the same-repo `head.repo` check. `OWNER` / `MEMBER` / `COLLABORATOR` are unchanged.

The workflow trigger is **only** `ready_for_review` (same as master). It does **not** run on `opened`, and there is no `workflow_dispatch` bypass.

The job still dispatches `pr-ci-slack-ready.yml` on private **elementor/angie-dev-tools**, which keeps its own internal allowlist.

## Test plan
- [x] Slack `dispatch` succeeded on this PR’s ready-for-review event ([run 34020040463](https://github.com/elementor/angie-sdk/actions/runs/34020040463); author is `MEMBER`).
- [ ] Human: confirm `CONTRIBUTOR` on the allowlist is intended.
- [ ] After merge, a same-repo draft marked ready by a `CONTRIBUTOR` teammate should notify Slack instead of skip.
- [ ] Fork PRs should still skip.
- [ ] Opening a non-draft PR should **not** notify (no `opened` trigger).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a08e9a2-77c2-4205-a27e-9aa108bea1ea?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a08e9a2-77c2-4205-a27e-9aa108bea1ea&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Public repo contributors often have CONTRIBUTOR association instead of MEMBER (issue #98), blocking legitimate ready-for-review Slack notifications. This expands the allowlist to include them while maintaining fork protection.

## 2. What Changed (Where)

`.github/workflows/pr-ci-slack-ready.yml`: Added CONTRIBUTOR to author_association allowlist and clarified reasoning in comments.

## 3. How It Works

The `if` condition now checks four association types (OWNER, MEMBER, COLLABORATOR, CONTRIBUTOR) via `contains()`. Forks still filtered by repo ownership check, preventing abuse.

## 4. Risks

None — additive change with existing fork guard and no new permissions granted.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
