### PR TITLE
[AI-9420] Feature: Allow configuring sign-in screen copy via widgetConfig

### DIFF
--- a/demo/load-sidebar-v2-widget-config/host.js
+++ b/demo/load-sidebar-v2-widget-config/host.js
@@ -101,6 +101,11 @@ const buildSandboxWidgetConfig = () => ( {
 	quotaBanner: { enabled: true },
 	userProfileMenu: { enabled: true },
 	topBar: { enabled: false },
+	signInScreen: {
+		title: 'Sign in to continue',
+		subtitle: 'Log in to your demo store account to keep chatting.',
+		buttonText: 'Log in',
+	},
 } );
 
 const PRESETS = {

--- a/demo/load-sidebar-v2-widget-config/index.html
+++ b/demo/load-sidebar-v2-widget-config/index.html
@@ -105,6 +105,10 @@
               <dd>Empty-state heading and supporting line</dd>
             </div>
             <div>
+              <dt><code>signInScreen</code></dt>
+              <dd>Signed-out screen copy — <code>title</code>, <code>subtitle</code>, <code>buttonText</code></dd>
+            </div>
+            <div>
               <dt><code>suggestions.items</code></dt>
               <dd>Starter chips — <code>label</code> shown, <code>value</code> sent as prompt</dd>
             </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.7.4",
+      "version": "1.7.5",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/angie-mcp-sdk.ts
+++ b/src/angie-mcp-sdk.ts
@@ -47,6 +47,12 @@ export type GenerationTypesConfig = {
   artifacts?: FeatureToggle;
 };
 
+export type SignInScreenConfig = {
+  title?: string;
+  subtitle?: string;
+  buttonText?: string;
+};
+
 export type WidgetConfig = {
   title?: string;
   subtitle?: string;
@@ -68,6 +74,7 @@ export type WidgetConfig = {
   models?: ModelsConfig;
   generationTypes?: GenerationTypesConfig;
   topBar?: FeatureToggle;
+  signInScreen?: SignInScreenConfig;
 };
 
 export type AngieMcpSdkOptions = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type GenerationTypesConfig, type ModeSwitcherConfig, type ModelsConfig, type WidgetConfig } from './angie-mcp-sdk';
+export { AngieMcpSdk, DEFAULT_CONTAINER_ID, type AngieMcpSdkOptions, type GenerationTypesConfig, type ModeSwitcherConfig, type ModelsConfig, type SignInScreenConfig, type WidgetConfig } from './angie-mcp-sdk';
 export {
 	LAYOUT_FLOATING_CHAT,
 	LAYOUT_SIDEBAR,

--- a/src/load-sidebar-v2/widget-config.md
+++ b/src/load-sidebar-v2/widget-config.md
@@ -59,9 +59,32 @@ All fields are optional. Omitted fields use Angie embedded-app defaults.
 |-------|------|---------|
 | `title` | `string` | Main heading in the empty chat state |
 | `subtitle` | `string` | Supporting line under the title |
+| `signInScreen` | `{ title?: string; subtitle?: string; buttonText?: string }` | Copy of the signed-out screen — see [Signed-out screen](#signed-out-screen) |
 | `suggestions` | `{ items: { label: string; value: string }[] }` | Starter prompt chips. `label` is shown in the UI; `value` is the prompt sent when clicked |
 
 `suggestions.items` is the same shape used in production Elementor hosts (`window.angieConfig.prompts` mapped to `suggestions.items`).
+
+### Signed-out screen
+
+Angie shows a signed-out screen when the user has no active session. Use `signInScreen` to replace its copy so it matches your product's wording.
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `signInScreen.title` | `string` | `You're signed out` | Heading on the signed-out screen |
+| `signInScreen.subtitle` | `string` | `Sign in to start creating with Angie` | Supporting line under the heading |
+| `signInScreen.buttonText` | `string` | `Sign in to Angie` | Label of the sign-in button |
+
+```typescript
+widgetConfig: {
+  signInScreen: {
+    title: 'Sign in to continue',
+    subtitle: 'Log in to your store account to get help with orders.',
+    buttonText: 'Log in',
+  },
+}
+```
+
+Each field is independent. Omitted fields keep the Angie default copy.
 
 ### Feature toggles
 


### PR DESCRIPTION
## Problem
Embedding hosts cannot customize the signed-out screen copy Angie shows before login — the heading, supporting text, and sign-in button label are hardcoded.

## Solution
Add `signInScreen` to `WidgetConfig` with optional `title`, `subtitle`, and `buttonText`. Each field is independent; omitted fields keep Angie defaults. Document the field, include it in the widget-config demo (sandbox preset + field list), and bump SDK to 1.7.4.

Jira: https://elementor.atlassian.net/browse/AI-9420

Made with [Cursor](https://cursor.com)
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Allows embedding consumers to customize sign-in screen copy (title, subtitle, button text) via `widgetConfig` instead of hardcoded defaults, enabling better product alignment without SDK changes.

## 2. What Changed (Where)

- `src/angie-mcp-sdk.ts`: Added `SignInScreenConfig` type with three optional string fields; added `signInScreen` property to `WidgetConfig`
- `src/index.ts`: Exported new `SignInScreenConfig` type
- `package.json`: Bumped version 1.7.4 → 1.7.5
- Demo and documentation updated with configuration example and API reference

## 3. How It Works

`WidgetConfig.signInScreen` accepts an object with optional `title`, `subtitle`, and `buttonText` fields. Omitted fields fall back to Angie defaults. The consuming application passes these during widget initialization; the embedded app reads and applies them to the signed-out screen UI.

## 4. Risks

None identified. Purely additive API surface with optional fields and sensible defaults. No breaking changes to existing configurations.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
