### PR TITLE
[AI-9464] Feature: Bump SDK to 1.7.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@elementor/angie-sdk",
-      "version": "1.7.2",
+      "version": "1.7.4",
       "license": "MIT",
       "dependencies": {
         "@elementor/angie-logger": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@elementor/angie-sdk",
-  "version": "1.7.3",
+  "version": "1.7.4",
   "description": "TypeScript SDK for Angie AI assistant",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
## Problem
npm `@elementor/angie-sdk@1.7.3` was published 2026-09-01 and does not include `widgetConfig.generationTypes` from #100. A new version is required before elementor-ai can consume it.

## Solution
Bump package version to 1.7.4 so a release / publish workflow can ship the merged API.

## Video proof demo
#skip_video
Version bump only.

Jira: https://elementor.atlassian.net/browse/AI-9464
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Patch version bump for SDK release pipeline.

## 2. What Changed (Where)

- `package.json`: Version incremented from 1.7.3 → 1.7.4

## 3. How It Works

Standard semver patch release—no code changes, dependency tree or API surface modifications.

## 4. Risks

None—version-only bump is safe. Verify dist artifacts and changelog align before publishing.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
