### PR TITLE
[AI-9466] Add CI workflows for PR review and merge notifications

### DIFF
--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -17,7 +17,7 @@ runs:
       shell: bash
       env:
         WORKFLOW: ${{ inputs.workflow }}
-        PR_INPUT: ${{ github.event.pull_request.html_url || github.event.issue.pull_request.html_url || github.event.issue.html_url || github.event.inputs.pr_input }}
+        PR_INPUT: ${{ github.event.pull_request.html_url || format('https://github.com/{0}/pull/{1}', github.repository, github.event.issue.number) || github.event.inputs.pr_input }}
         REPOSITORY: ${{ github.repository }}
         EVENT_NAME: ${{ github.event_name }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/actions/dispatch-angie-dev-tools/action.yaml
+++ b/.github/actions/dispatch-angie-dev-tools/action.yaml
@@ -5,6 +5,10 @@ inputs:
   workflow:
     description: 'Workflow filename in elementor/angie-dev-tools'
     required: true
+  extra-fields:
+    description: 'Additional gh workflow run -f key=value pairs, one per line'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -13,10 +17,11 @@ runs:
       shell: bash
       env:
         WORKFLOW: ${{ inputs.workflow }}
-        PR_INPUT: ${{ github.event.pull_request.html_url || github.event.inputs.pr_input }}
+        PR_INPUT: ${{ github.event.pull_request.html_url || github.event.issue.pull_request.html_url || github.event.issue.html_url || github.event.inputs.pr_input }}
         REPOSITORY: ${{ github.repository }}
         EVENT_NAME: ${{ github.event_name }}
         PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+        EXTRA_FIELDS: ${{ inputs.extra-fields }}
       run: |
         if [ -z "$GH_TOKEN" ]; then
           echo "ANGIE_DEV_TOOLS_BOT_TOKEN is required to dispatch private angie-dev-tools workflows." >&2
@@ -27,10 +32,27 @@ runs:
           exit 1
         fi
 
-        if [ "$EVENT_NAME" = "pull_request" ]; then
+        if [ "$EVENT_NAME" = "pull_request" ] || [ "$EVENT_NAME" = "pull_request_review" ]; then
           if [ "$PR_HEAD_REPO" != "$REPOSITORY" ]; then
             echo "Skipping fork PR dispatch."
             exit 0
+          fi
+        elif [ "$EVENT_NAME" = "issue_comment" ]; then
+          if [[ "$PR_INPUT" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)/?$ ]]; then
+            URL_REPO="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+            PR_NUM="${BASH_REMATCH[3]}"
+            if [ "$URL_REPO" != "$REPOSITORY" ]; then
+              echo "Refusing to dispatch a PR from another repository: $URL_REPO" >&2
+              exit 1
+            fi
+            HEAD_REPO="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUM}" --jq .head.repo.full_name)"
+            if [ "$HEAD_REPO" != "$REPOSITORY" ]; then
+              echo "Skipping fork PR dispatch."
+              exit 0
+            fi
+          else
+            echo "issue_comment requires a full PR URL." >&2
+            exit 1
           fi
         elif [[ "$PR_INPUT" =~ ^https://github\.com/([^/]+)/([^/]+)/pull/([0-9]+)/?$ ]]; then
           URL_REPO="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
@@ -53,6 +75,13 @@ runs:
           -f "pr_input=${PR_INPUT}"
           -f "target_repository=${REPOSITORY}"
         )
+
+        if [ -n "$EXTRA_FIELDS" ]; then
+          while IFS= read -r line || [ -n "$line" ]; do
+            [ -z "$line" ] && continue
+            ARGS+=(-f "$line")
+          done <<< "$EXTRA_FIELDS"
+        fi
 
         RUN_URL="$(gh workflow run "$WORKFLOW" \
           --repo elementor/angie-dev-tools \

--- a/.github/workflows/pr-ci-slack-approval-emoji.yml
+++ b/.github/workflows/pr-ci-slack-approval-emoji.yml
@@ -1,0 +1,42 @@
+name: PR Slack Approval Emoji
+
+on:
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: |
+      (
+        github.event_name == 'pull_request_review' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.review.user.type != 'Bot'
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        github.event.comment.user.type != 'Bot' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)
+      )
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+      - uses: ./.github/actions/dispatch-angie-dev-tools
+        env:
+          GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
+        with:
+          workflow: pr-ci-slack-approval-emoji.yml
+          extra-fields: |
+            source_event=${{ github.event_name }}
+            review_state=${{ github.event.review.state }}
+            event_user=${{ github.event.review.user.login || github.event.comment.user.login }}
+            event_user_type=${{ github.event.review.user.type || github.event.comment.user.type }}

--- a/.github/workflows/pr-ci-slack-approval-emoji.yml
+++ b/.github/workflows/pr-ci-slack-approval-emoji.yml
@@ -15,7 +15,8 @@ jobs:
       (
         github.event_name == 'pull_request_review' &&
         github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.review.user.type != 'Bot'
+        github.event.review.user.type != 'Bot' &&
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.review.author_association)
       ) ||
       (
         github.event_name == 'issue_comment' &&

--- a/.github/workflows/pr-ci-slack-merged-emoji.yml
+++ b/.github/workflows/pr-ci-slack-merged-emoji.yml
@@ -1,0 +1,29 @@
+name: PR Slack Merged Emoji
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    if: |
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+      - uses: ./.github/actions/dispatch-angie-dev-tools
+        env:
+          GH_TOKEN: ${{ secrets.ANGIE_DEV_TOOLS_BOT_TOKEN }}
+        with:
+          workflow: pr-ci-slack-merged-emoji.yml
+          extra-fields: |
+            source_event=${{ github.event_name }}


### PR DESCRIPTION
## Summary

Adds GitHub Actions workflows that post Slack updates when pull requests are reviewed, commented on, or merged.

## Changes

- Add `pr-ci-slack-approval-emoji` workflow for review and comment events
- Add `pr-ci-slack-merged-emoji` workflow for merged PRs
- Extend the shared dispatch action to support review/comment events and optional extra fields

Follows the same pattern as the existing ready-for-review workflow. Fork PRs are skipped.
<!--start_gitstream_placeholder-->
### ✨ PR Description
## 1. Problem & Context

Adds CI workflows to dispatch Slack emoji notifications on PR reviews and merges. Extends the dispatch action to handle multiple event triggers (pull_request_review, issue_comment) and pass custom fields to downstream workflows.

## 2. What Changed (Where)

- `.github/actions/dispatch-angie-dev-tools/action.yaml`: Added `extra-fields` input, expanded `PR_INPUT` resolution logic, added `issue_comment` event handling with fork detection, and loop to append extra fields to workflow dispatch args.
- `.github/workflows/pr-ci-slack-approval-emoji.yml`: New workflow triggering on PR reviews/comments with author association checks.
- `.github/workflows/pr-ci-slack-merged-emoji.yml`: New workflow triggering on merged PRs with author association validation.

## 3. How It Works

Dispatch action now resolves PR context from three sources (pull_request URL, issue number, or manual input) and validates ownership. For `issue_comment` events, it parses the PR URL and queries GitHub API to check if the branch repo matches the target. Both new workflows conditionally dispatch to `angie-dev-tools` with event metadata (source event, review state, user info) passed via `extra-fields`, enabling downstream emoji reactions keyed to event type and user role.

## 4. Risks

Fork PR rejection in `issue_comment` flow relies on URL regex parsing—malformed URLs exit with error rather than gracefully skipping. Extra fields loop doesn't validate field format; invalid `key=value` pairs will be passed to `gh workflow run` and fail at dispatch time rather than validation time.

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
